### PR TITLE
Install missing gitignored files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,30 @@
+*         text=auto
+
+*.txt     text
+*.c       text
+*.cpp     text
+*.h       text
+*.hpp     text
+*.inl     text
+*.adoc    text
+*.in      text
+*.json    text
+
+*.bat     eol=crlf
+*.cmd     eol=crlf
+*.vcproj  eol=crlf
+*.vcxproj eol=crlf
+*.sln     eol=crlf
+
+*.sh      eol=lf
+
+*.png     binary
+
+# Shell scripts that don't end in .sh
+specification/makeAllExts           eol=lf
+specification/makeExt               eol=lf
+specification/makeKHR               eol=lf
+specification/makeKHRAndKHX         eol=lf
+specification/makeReleaseArtifacts  eol=lf
+specification/checkMarkup           eol=lf
+specification/checkSpecLinks        eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+/build
+CMakeLists.txt.user
+*.orig
+.*
+*~
+*.tar.gz
+
+# Cached python scripts in bytecode form
+*.pyc
+applyfixes.sh
+
+# Files related to building examples
+specification/**/*.c
+specification/**/*.cpp
+specification/**/*.o
+specification/examples.mk
+
+# Files related to pytest
+specification/scripts/.cache

--- a/specification/.gitignore
+++ b/specification/.gitignore
@@ -1,0 +1,14 @@
+scripts/__pycache__
+scripts/xrapi.py
+out/*
+generated/*
+sources/chapters/extensions/meta/*
+example-builds/generated/
+man/*
+artifacts/
+temp/
+diffs/
+
+# Artifacts from converting/checking RELAX-NG Compact schema.
+registry/registry.rng
+registry/regenerated.rnc

--- a/src/.clang-format
+++ b/src/.clang-format
@@ -1,0 +1,7 @@
+---
+# Use defaults from the Google style with the following exceptions:
+BasedOnStyle: Google
+IndentWidth: 4
+ColumnLimit: 132
+SortIncludes: false
+...

--- a/src/external/jsoncpp/.clang-format
+++ b/src/external/jsoncpp/.clang-format
@@ -1,0 +1,47 @@
+---
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -2
+ConstructorInitializerIndentWidth: 4
+AlignEscapedNewlinesLeft: false
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakTemplateDeclarations: false
+AlwaysBreakBeforeMultilineStrings: false
+BreakBeforeBinaryOperators: false
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BinPackParameters: false
+ColumnLimit:     80
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+DerivePointerBinding: false
+ExperimentalAutoDetectBinPacking: false
+IndentCaseLabels: false
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 60
+PenaltyBreakString: 1000
+PenaltyBreakFirstLessLess: 120
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerBindsToType: true
+SpacesBeforeTrailingComments: 1
+Cpp11BracedListStyle: false
+Standard:        Cpp03
+IndentWidth:     2
+TabWidth:        8
+UseTab:          Never
+BreakBeforeBraces: Attach
+IndentFunctionDeclarationAfterType: false
+SpacesInParentheses: false
+SpacesInAngles:  false
+SpaceInEmptyParentheses: false
+SpacesInCStyleCastParentheses: false
+SpaceAfterControlStatementKeyword: true
+SpaceBeforeAssignmentOperators: true
+ContinuationIndentWidth: 4
+...
+

--- a/src/external/jsoncpp/.gitattributes
+++ b/src/external/jsoncpp/.gitattributes
@@ -1,0 +1,11 @@
+*           text=auto
+*.h         text
+*.cpp       text
+*.json      text
+*.in        text
+*.sh        eol=lf
+*.bat       eol=crlf
+*.vcproj    eol=crlf
+*.vcxproj   eol=crlf
+*.sln       eol=crlf
+devtools/agent_vm* eol=crlf

--- a/src/external/jsoncpp/.gitignore
+++ b/src/external/jsoncpp/.gitignore
@@ -1,0 +1,52 @@
+/build/
+*.pyc
+*.swp
+*.actual
+*.actual-rewrite
+*.process-output
+*.rewrite
+/bin/
+/buildscons/
+/libs/
+/doc/doxyfile
+/dist/
+#/version
+#/include/json/version.h
+
+# MSVC project files:
+*.sln
+*.vcxproj
+*.filters
+*.user
+*.sdf
+*.opensdf
+*.suo
+
+# MSVC build files:
+*.lib
+*.obj
+*.tlog/
+*.pdb
+
+# CMake-generated files:
+CMakeFiles/
+*.cmake
+pkg-config/jsoncpp.pc
+jsoncpp_lib_static.dir/
+
+# In case someone runs cmake in the root-dir:
+/CMakeCache.txt
+/Makefile
+/include/Makefile
+/src/Makefile
+/src/jsontestrunner/Makefile
+/src/jsontestrunner/jsontestrunner_exe
+/src/lib_json/Makefile
+/src/test_lib_json/Makefile
+/src/test_lib_json/jsoncpp_test
+*.a
+
+# eclipse project files
+.project
+.cproject
+/.settings/

--- a/src/scripts/.gitignore
+++ b/src/scripts/.gitignore
@@ -1,0 +1,4 @@
+*.sln
+*.pyproj
+*.cpp
+*.hpp


### PR DESCRIPTION
Adds some git-ignored files that should be in the repo, but were missed on the initial check-in precisely because they are git-ignored.