### PR TITLE
Add install target to cmake files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,3 +40,5 @@ if(BASH_COMMAND)
             USES_TERMINAL)
     endif()
 endif()
+
+install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE" DESTINATION share/doc/openxr)

--- a/include/openxr/CMakeLists.txt
+++ b/include/openxr/CMakeLists.txt
@@ -63,3 +63,12 @@ set_source_files_properties(
     ${CMAKE_CURRENT_BINARY_DIR}/openxr_platform.h
     PROPERTIES GENERATED TRUE
 )
+
+set(INSTALL_HEADERS 
+    ${CMAKE_CURRENT_BINARY_DIR}/openxr_platform_defines.h
+    ${CMAKE_CURRENT_BINARY_DIR}/openxr.h
+    ${CMAKE_CURRENT_BINARY_DIR}/openxr_platform.h)
+
+INSTALL(FILES ${INSTALL_HEADERS} 
+    DESTINATION include/openxr
+)

--- a/src/loader/CMakeLists.txt
+++ b/src/loader/CMakeLists.txt
@@ -162,6 +162,8 @@ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
     endif()
 endif()
 
+install(TARGETS ${LOADER_NAME} DESTINATION lib)
+
 # Custom target for generated helper sources
 add_custom_target(loader_gen_files
     DEPENDS


### PR DESCRIPTION
Addresses #16 

This is a minimal implementation that uses the CMake `INSTALL` directive to install the built binary, generated headers, license file and the generated loader helper files relative to an installation directory.  

Tested with `cmake .. -DCMAKE_INSTALL_PREFIX=F:/openxr_install_test`  

Running the INSTALL target in visual studio resulted in the following files being created in the output folder.

```
./include/openxr
./include/openxr/openxr.h
./include/openxr/openxr_platform.h
./include/openxr/openxr_platform_defines.h
./lib/openxr_loader-0_90.lib
./LICENSE
./src/xr_generated_loader.cpp
./src/xr_generated_loader.hpp
```

Doing this will allow me to create a PR to integrate OpenXR into vcpkg much more easily.  Any suggestions for additional files that should be treated as installable artifacts or better idiomatic cmake usage would be gratefully welcomed. 