### PR TITLE
Timespec fixes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -75,6 +75,8 @@ CHECK_FUNCTION_EXISTS(secure_getenv HAVE_SECURE_GETENV)
 CHECK_FUNCTION_EXISTS(__secure_getenv HAVE___SECURE_GETENV)
 CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/common_cmake_config.h.in ${CMAKE_CURRENT_BINARY_DIR}/common_cmake_config.h)
 
+add_definitions(-DXR_USE_TIMESPEC)
+
 # Set up the OpenXR version variables, used by several targets in this project.
 set(MAJOR "0")
 set(MINOR "0")

--- a/src/scripts/api_dump_generator.py
+++ b/src/scripts/api_dump_generator.py
@@ -449,6 +449,28 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
             write_string += self.writeIndent(indent)
             write_string += 'contents.push_back(std::make_tuple("%s", %s' % (full_type, description)
             write_string += ', oss_%s.str()));\n' % int_short_param_name
+        elif base_type == 'timespec':
+            # Unbeknownst to XR, this is actually a struct.
+            write_string += self.writeIndent(indent)
+            write_string += 'std::ostringstream oss_%s;\n' % int_short_param_name
+            write_string += self.writeIndent(indent)
+            deref = '' + '*' * pointer_count
+
+            # Write whole seconds
+            write_string += 'oss_%s << (' % int_short_param_name
+            write_string += deref
+            write_string += '%s).tv_sec << ".";\n' % full_name
+
+            # Write nanoseconds as a decimal
+            write_string += self.writeIndent(indent)
+            write_string += "oss_%s << std::setw(9) << std::setfill('0') << (" % int_short_param_name
+            write_string += deref
+            write_string += '%s).tv_nsec << "s";\n' % full_name
+
+            write_string += self.writeIndent(indent)
+            write_string += 'contents.push_back(std::make_tuple("%s", %s' % (
+                full_type, description)
+            write_string += ', oss_%s.str()));\n' % int_short_param_name
         else:
             if base_type == 'XrResult':
                 write_string += self.writeIndent(indent)


### PR DESCRIPTION
These changes are required to allow the loader to supply the timespec-related extension functions to an application. It also fixes the bad code generation associated with the api dump layer when trying to deal with a struct timespec.