### PR TITLE
Validation layer fixes and refactor

### DIFF
--- a/src/api_layers/core_validation.cpp
+++ b/src/api_layers/core_validation.cpp
@@ -643,10 +643,7 @@ XrResult CoreValidationXrCreateSession(XrInstance instance, const XrSessionCreat
         }
         if (!got_right_graphics_binding_count) {
             std::vector<GenValidUsageXrObjectInfo> objects_info;
-            GenValidUsageXrObjectInfo handle_info = {};
-            handle_info.handle = CONVERT_HANDLE_TO_GENERIC(instance);
-            handle_info.type = XR_OBJECT_TYPE_INSTANCE;
-            objects_info.push_back(handle_info);
+            objects_info.emplace_back(instance, XR_OBJECT_TYPE_INSTANCE);
             std::ostringstream error_stream;
             error_stream << "Invalid number of graphics binding structures provided.  ";
             error_stream << "Expected ";

--- a/src/api_layers/core_validation.cpp
+++ b/src/api_layers/core_validation.cpp
@@ -435,6 +435,11 @@ void CoreValidLogMessage(GenValidUsageXrInstanceInfo *instance_info, const std::
     }
 }
 
+void reportInternalError(std::string const &message) {
+    std::cerr << "INTERNAL VALIDATION LAYER ERROR: " << message << std::endl;
+    throw std::runtime_error("Internal validation layer error: " + message);
+}
+
 // NOTE: Can't validate the following VUIDs since the command never enters a layer:
 // Command: xrEnumerateApiLayerProperties
 //      VUIDs:  "VUID-xrEnumerateApiLayerProperties-propertyCountOutput-parameter"

--- a/src/api_layers/validation_utils.h
+++ b/src/api_layers/validation_utils.h
@@ -1,0 +1,317 @@
+// Copyright (c) 2018-2019 The Khronos Group Inc.
+// Copyright (c) 2018-2019 Valve Corporation
+// Copyright (c) 2018-2019 LunarG, Inc.
+// Copyright (c) 2019, Collabora, Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: Ryan Pavlik <ryan.pavlik@collabora.com>
+//         Mark Young <marky@lunarg.com>
+//
+
+#ifndef VALIDATION_UTILS_H_
+#define VALIDATION_UTILS_H_ 1
+
+#include "api_layer_platform_defines.h"
+
+#include <openxr/openxr.h>
+#include <openxr/openxr_platform.h>
+
+#include <vector>
+#include <unordered_map>
+#include <string>
+#include <mutex>
+#include <memory>
+
+// Handle information for easy conversion
+#if (defined(__LP64__) || defined(_WIN64) || (defined(__x86_64__) && !defined(__ILP32__)) || defined(_M_X64) || defined(__ia64) || \
+     defined(_M_IA64) || defined(__aarch64__) || defined(__powerpc64__))
+#define XR_VALIDATION_GENERIC_HANDLE_TYPE uint64_t
+#define CONVERT_HANDLE_TO_GENERIC(handle) reinterpret_cast<uint64_t>(handle)
+#define CONVERT_GENERIC_TO_HANDLE(type, handle) reinterpret_cast<type>(handle)
+#define CHECK_FOR_NULL_HANDLE(handle) (XR_NULL_HANDLE == reinterpret_cast<void *>(handle))
+#else
+#define XR_VALIDATION_GENERIC_HANDLE_TYPE uint64_t
+#define CONVERT_HANDLE_TO_GENERIC(handle) (handle)
+#define CONVERT_GENERIC_TO_HANDLE(type, handle) (handle)
+#define CHECK_FOR_NULL_HANDLE(handle) (XR_NULL_HANDLE == handle)
+#endif
+// Structure used for storing the instance information we need for validating
+// various aspects of the OpenXR API.
+
+// Debug Utils items
+struct CoreValidationMessengerInfo {
+    XrDebugUtilsMessengerEXT messenger;
+    XrDebugUtilsMessengerCreateInfoEXT *create_info;
+};
+
+struct XrGeneratedDispatchTable;
+
+struct CoreValidationMessengerInfoDeleter {
+    void operator()(CoreValidationMessengerInfo *ptr) const {
+        delete ptr->create_info;
+        delete ptr;
+    }
+};
+
+struct XrDebugUtilsObjectNameInfoEXTDeleter {
+    void operator()(XrDebugUtilsObjectNameInfoEXT *ptr) const {
+        delete ptr->objectName;
+        delete ptr;
+    }
+};
+
+typedef std::unique_ptr<XrDebugUtilsObjectNameInfoEXT, XrDebugUtilsObjectNameInfoEXTDeleter> UniqueXrDebugUtilsObjectNameInfoEXT;
+
+typedef std::unique_ptr<CoreValidationMessengerInfo, CoreValidationMessengerInfoDeleter> UniqueCoreValidationMessengerInfo;
+
+// Define the instance struct used for passing information around.
+// This information includes things like the dispatch table as well as the
+// enabled extensions.
+struct GenValidUsageXrInstanceInfo {
+    GenValidUsageXrInstanceInfo(XrInstance inst, PFN_xrGetInstanceProcAddr next_get_instance_proc_addr);
+    ~GenValidUsageXrInstanceInfo();
+    const XrInstance instance;
+    XrGeneratedDispatchTable *dispatch_table;
+    std::vector<std::string> enabled_extensions;
+    std::vector<UniqueCoreValidationMessengerInfo> debug_messengers;
+    std::vector<UniqueXrDebugUtilsObjectNameInfoEXT> object_names;
+};
+
+// Structure used for storing information for other handles
+struct GenValidUsageXrHandleInfo {
+    GenValidUsageXrInstanceInfo *instance_info;
+    XrObjectType direct_parent_type;
+    XR_VALIDATION_GENERIC_HANDLE_TYPE direct_parent_handle;
+};
+
+// Structure used for storing session label information
+struct GenValidUsageXrInternalSessionLabel {
+    XrDebugUtilsLabelEXT debug_utils_label;
+    std::string label_name;
+    bool is_individual_label;
+};
+
+// Enum used for indicating handle validation status.
+enum ValidateXrHandleResult {
+    VALIDATE_XR_HANDLE_NULL,
+    VALIDATE_XR_HANDLE_INVALID,
+    VALIDATE_XR_HANDLE_SUCCESS,
+};
+
+// Unordered Map associating pointer to a vector of session label information to a session's handle
+extern std::unordered_map<XrSession, std::vector<GenValidUsageXrInternalSessionLabel *> *> g_xr_session_labels;
+
+// This function is used to delete session labels when a session is destroyed
+extern void CoreValidationDeleteSessionLabels(XrSession session);
+
+// Object information used for logging.
+struct GenValidUsageXrObjectInfo {
+    XR_VALIDATION_GENERIC_HANDLE_TYPE handle;
+    XrObjectType type;
+    GenValidUsageXrObjectInfo() = default;
+    template <typename T>
+    GenValidUsageXrObjectInfo(T h, XrObjectType t) : handle(CONVERT_HANDLE_TO_GENERIC(h)), type(t) {}
+};
+
+// Debug message severity levels for logging.
+enum GenValidUsageDebugSeverity {
+    VALID_USAGE_DEBUG_SEVERITY_DEBUG = 0,
+    VALID_USAGE_DEBUG_SEVERITY_INFO = 7,
+    VALID_USAGE_DEBUG_SEVERITY_WARNING = 14,
+    VALID_USAGE_DEBUG_SEVERITY_ERROR = 21,
+};
+
+// in core_validation.cpp
+void EraseAllInstanceTableMapElements(GenValidUsageXrInstanceInfo *search_value);
+
+typedef std::unique_lock<std::mutex> UniqueLock;
+template <typename HandleType, typename InfoType>
+class HandleInfoBase {
+   public:
+    typedef InfoType info_t;
+    typedef HandleType handle_t;
+    typedef std::unordered_map<HandleType, std::unique_ptr<InfoType>> map_t;
+    typedef typename map_t::value_type value_t;
+
+    /// Validate a handle.
+    ///
+    /// Returns an enum indicating null, invalid (not found), or success.
+    ValidateXrHandleResult verifyHandle(HandleType const *handle_to_check);
+
+    /// Lookup a handle.
+    /// Throws if not found.
+    InfoType *get(HandleType handle);
+
+    /// Lookup a handle, returning a pointer (if found) as well as a lock for this object's dispatch mutex.
+    std::pair<UniqueLock, InfoType *> getWithLock(HandleType handle);
+
+    bool empty() const { return info_map_.empty(); }
+
+    /// Insert an info for the supplied handle.
+    /// Throws if it's already there.
+    void insert(HandleType handle, std::unique_ptr<InfoType> &&info);
+
+    /// Remove the info associated with the supplied handle.
+    /// Throws if not found.
+    void erase(HandleType handle);
+
+    /// Get a constant reference to the whole map as well as a lock for this object's dispatch mutex.
+    std::pair<UniqueLock, map_t const &> lockMapConst();
+
+    /// Get a  reference to the whole map as well as a lock for this object's dispatch mutex.
+    std::pair<UniqueLock, map_t &> lockMap();
+
+   protected:
+    map_t info_map_;
+    std::mutex dispatch_mutex_;
+};
+
+/// Subclass used exclusively for instances.
+class InstanceHandleInfo : public HandleInfoBase<XrInstance, GenValidUsageXrInstanceInfo> {
+   public:
+    typedef HandleInfoBase<XrInstance, GenValidUsageXrInstanceInfo> base_t;
+    typedef typename base_t::info_t info_t;
+    typedef typename base_t::handle_t handle_t;
+};
+
+/// Generic handle info for everything-except-instance handles.
+template <typename HandleType>
+class HandleInfo : public HandleInfoBase<HandleType, GenValidUsageXrHandleInfo> {
+   public:
+    typedef HandleInfoBase<HandleType, GenValidUsageXrHandleInfo> base_t;
+    typedef typename base_t::info_t info_t;
+    typedef typename base_t::handle_t handle_t;
+
+    /// Lookup a handle and its instance info
+    /// Throws if not found.
+    std::pair<GenValidUsageXrHandleInfo *, GenValidUsageXrInstanceInfo *> getWithInstanceInfo(HandleType handle);
+
+    /// Removes handles associated  with an instance.
+    void removeHandlesForInstance(GenValidUsageXrInstanceInfo *search_value);
+};
+
+template <typename T, typename Pred>
+inline void map_erase_if(T &container, Pred &&predicate) {
+    for (auto it = container.begin(); it != container.end();) {
+        if (predicate(*it)) {
+            auto here = it;
+            ++it;
+            container.erase(here);
+        } else {
+            ++it;
+        }
+    }
+}
+
+// -- Only implementations of templates follow --//
+
+template <typename HandleType, typename InfoType>
+inline std::pair<UniqueLock, InfoType *> HandleInfoBase<HandleType, InfoType>::getWithLock(HandleType handle) {
+    // Try to find the handle in the appropriate map
+    UniqueLock lock(dispatch_mutex_);
+    auto it = info_map_.find(handle);
+    // If it is not a valid handle, it should return the end of the map.
+    if (info_map_.end() == it) {
+        return {std::move(lock), nullptr};
+    }
+    return {std::move(lock), it->second.get()};
+}
+
+template <typename HT, typename IT>
+inline std::pair<UniqueLock, typename HandleInfoBase<HT, IT>::map_t const &> HandleInfoBase<HT, IT>::lockMapConst() {
+    return {UniqueLock(dispatch_mutex_), info_map_};
+}
+
+template <typename HT, typename IT>
+inline std::pair<UniqueLock, typename HandleInfoBase<HT, IT>::map_t &> HandleInfoBase<HT, IT>::lockMap() {
+    return {UniqueLock(dispatch_mutex_), info_map_};
+}
+
+template <typename HandleType, typename InfoType>
+inline ValidateXrHandleResult HandleInfoBase<HandleType, InfoType>::verifyHandle(HandleType const *handle_to_check) {
+    try {
+        if (nullptr == handle_to_check) {
+            return VALIDATE_XR_HANDLE_INVALID;
+        }
+        // XR_NULL_HANDLE is valid in some cases, so we want to return that we found that value
+        // and let the calling function decide what to do with it.
+        if (*handle_to_check == XR_NULL_HANDLE) {
+            return VALIDATE_XR_HANDLE_NULL;
+        }
+
+        // Try to find the handle in the appropriate map
+        UniqueLock lock(dispatch_mutex_);
+        auto entry_returned = info_map_.find(*handle_to_check);
+        // If it is not a valid handle, it should return the end of the map.
+        if (info_map_.end() == entry_returned) {
+            return VALIDATE_XR_HANDLE_INVALID;
+        }
+        return VALIDATE_XR_HANDLE_SUCCESS;
+    } catch (...) {
+        return VALIDATE_XR_HANDLE_INVALID;
+    }
+}
+
+template <typename HandleType, typename InfoType>
+inline InfoType *HandleInfoBase<HandleType, InfoType>::get(HandleType handle) {
+    // Try to find the handle in the appropriate map
+    UniqueLock lock(dispatch_mutex_);
+    auto entry_returned = info_map_.find(handle);
+    if (entry_returned == info_map_.end()) {
+        throw std::logic_error("Internal layer error: Handle not inserted");
+    }
+    return entry_returned->second.get();
+}
+
+template <typename HandleType, typename InfoType>
+inline void HandleInfoBase<HandleType, InfoType>::insert(HandleType handle, std::unique_ptr<InfoType> &&info) {
+    UniqueLock lock(dispatch_mutex_);
+    auto entry_returned = info_map_.find(handle);
+    if (entry_returned != info_map_.end()) {
+        throw std::logic_error("Internal layer error: Handle already inserted");
+    }
+    info_map_[handle] = std::move(info);
+}
+template <typename HandleType, typename InfoType>
+inline void HandleInfoBase<HandleType, InfoType>::erase(HandleType handle) {
+    UniqueLock lock(dispatch_mutex_);
+    auto entry_returned = info_map_.find(handle);
+    if (entry_returned == info_map_.end()) {
+        throw std::logic_error("Internal layer error: Handle not inserted");
+    }
+    info_map_.erase(handle);
+}
+
+template <typename HandleType>
+inline std::pair<GenValidUsageXrHandleInfo *, GenValidUsageXrInstanceInfo *> HandleInfo<HandleType>::getWithInstanceInfo(
+    HandleType handle) {
+    // Try to find the handle in the appropriate map
+    UniqueLock lock(this->dispatch_mutex_);
+    auto entry_returned = this->info_map_.find(handle);
+    if (entry_returned == this->info_map_.end()) {
+        throw std::logic_error("Handle not registered, internal layer error.");
+    }
+    GenValidUsageXrHandleInfo *info = entry_returned->second.get();
+    GenValidUsageXrInstanceInfo *instance_info = info->instance_info;
+    return {info, instance_info};
+}
+
+template <typename HandleType>
+inline void HandleInfo<HandleType>::removeHandlesForInstance(GenValidUsageXrInstanceInfo *search_value) {
+    typedef typename base_t::value_t value_t;
+    UniqueLock lock(this->dispatch_mutex_);
+    map_erase_if(this->info_map_, [=](value_t const &data) { return data.second && data.second->instance_info == search_value; });
+}
+
+#endif  // VALIDATION_UTILS_H_

--- a/src/scripts/api_dump_generator.py
+++ b/src/scripts/api_dump_generator.py
@@ -145,7 +145,7 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
     def outputApiDumpExterns(self):
         externs = '\n// Externs for API dump\n'
         for handle in self.api_handles:
-            base_handle_name = handle.name[2:].lower()
+            base_handle_name = undecorate(handle.name)
             if handle.protect_value is not None:
                 externs += '#if %s\n' % handle.protect_string
             externs += 'extern std::unordered_map<%s, XrGeneratedDispatchTable*> g_%s_dispatch_map;\n' % (
@@ -200,7 +200,7 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
     def outputApiDumpMapMutexItems(self):
         maps_mutexes = ''
         for handle in self.api_handles:
-            base_handle_name = handle.name[2:].lower()
+            base_handle_name = undecorate(handle.name)
             if handle.protect_value:
                 maps_mutexes += '#if %s\n' % handle.protect_string
             maps_mutexes += 'std::unordered_map<%s, XrGeneratedDispatchTable*> g_%s_dispatch_map;\n' % (
@@ -227,7 +227,7 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
         maps_mutexes += 'void ApiDumpCleanUpMapsForTable(XrGeneratedDispatchTable *table) {\n'
         # Call each handle's erase utility function using the template we defined above.
         for handle in self.api_handles:
-            base_handle_name = handle.name[2:].lower()
+            base_handle_name = undecorate(handle.name)
             if handle.protect_value:
                 maps_mutexes += '#if %s\n' % handle.protect_string
             maps_mutexes += '    eraseAllTableMapElements<std::unordered_map<%s, XrGeneratedDispatchTable*>>' % handle.name
@@ -1145,7 +1145,7 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
                 # Before we can do that, we have to figure out what the dispatch table is
                 if cur_cmd.params[0].is_handle:
                     handle_param = cur_cmd.params[0]
-                    base_handle_name = handle_param.type[2:].lower()
+                    base_handle_name = undecorate(handle_param.type)
                     first_handle_name = self.getFirstHandleName(handle_param)
                     generated_commands += '        std::unique_lock<std::mutex> mlock(g_%s_dispatch_mutex);\n' % base_handle_name
                     generated_commands += '        XrGeneratedDispatchTable *gen_dispatch_table = g_%s_dispatch_map[%s];\n' % (base_handle_name, first_handle_name)
@@ -1193,7 +1193,7 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
                 # for the dispatch table from the unordered_map
                 second_base_handle_name = ''
                 if cur_cmd.params[-1].is_handle and (is_create or is_destroy):
-                    second_base_handle_name = cur_cmd.params[-1].type[2:].lower()
+                    second_base_handle_name = undecorate(cur_cmd.params[-1].type)
                     if is_create:
                         generated_commands += '        if (XR_SUCCESS == result && nullptr != %s) {\n' % cur_cmd.params[-1].name
                         generated_commands += '            auto exists = g_%s_dispatch_map.find(*%s);\n' % (

--- a/src/scripts/automatic_source_generator.py
+++ b/src/scripts/automatic_source_generator.py
@@ -29,6 +29,12 @@ from generator import *
 from collections import namedtuple
 from inspect import currentframe, getframeinfo
 
+def undecorate(name):
+    """Undecorate a name by removing the leading Xr and making it lowercase."""
+    lower = name.lower()
+    assert(lower.startswith('xr'))
+    return lower[2:]
+
 # AutomaticSourceGeneratorOptions - subclass of GeneratorOptions.
 
 

--- a/src/scripts/loader_source_generator.py
+++ b/src/scripts/loader_source_generator.py
@@ -302,7 +302,7 @@ class LoaderSourceOutputGenerator(AutomaticSourceOutputGenerator):
         for handle in self.api_handles:
             if handle.protect_value:
                 map_externs += '#if %s\n' % handle.protect_string
-            base_handle_name = handle.name[2:].lower()
+            base_handle_name = undecorate(handle.name)
             map_externs += 'extern std::unordered_map<%s, class LoaderInstance*> g_%s_map;\n' % (
                 handle.name, base_handle_name)
             map_externs += 'extern std::mutex g_%s_mutex;\n' % base_handle_name
@@ -370,7 +370,7 @@ class LoaderSourceOutputGenerator(AutomaticSourceOutputGenerator):
     def outputLoaderMapDefines(self):
         map_defines = '// Unordered maps to lookup the instance for a given object type\n'
         for handle in self.api_handles:
-            base_handle_name = handle.name[2:].lower()
+            base_handle_name = undecorate(handle.name)
             if handle.protect_value:
                 map_defines += '#if %s\n' % handle.protect_string
             map_defines += 'std::unordered_map<%s, class LoaderInstance*> g_%s_map;\n' % (
@@ -404,7 +404,7 @@ class LoaderSourceOutputGenerator(AutomaticSourceOutputGenerator):
         for handle in self.api_handles:
             if handle.protect_value:
                 map_defines += '#if %s\n' % handle.protect_string
-            base_handle_name = handle.name[2:].lower()
+            base_handle_name = undecorate(handle.name)
             map_defines += '    EraseAllInstanceMapElements<std::unordered_map<%s, class LoaderInstance*>>' % handle.name
             map_defines += '(g_%s_map, g_%s_mutex, instance);\n' % (
                 base_handle_name, base_handle_name)
@@ -497,7 +497,7 @@ class LoaderSourceOutputGenerator(AutomaticSourceOutputGenerator):
                     cmd_tramp_is_handle = param.is_handle
                     if count == 0:
                         if param.is_handle:
-                            base_handle_name = param.type[2:].lower()
+                            base_handle_name = undecorate(param.type)
                             first_handle_name = self.getFirstHandleName(param)
                             if pointer_count == 1 and param.pointer_count_var is not None:
                                 if not param.is_optional:
@@ -597,7 +597,7 @@ class LoaderSourceOutputGenerator(AutomaticSourceOutputGenerator):
 
                     if count == len(cur_cmd.params) - 1:
                         if param.is_handle:
-                            base_handle_name = param.type[2:].lower()
+                            base_handle_name = undecorate(param.type)
                             if cur_cmd.is_create_connect:
                                 func_follow_up += '        if (XR_SUCCESS == result && nullptr != %s) {\n' % param.name
                                 func_follow_up += '            std::unique_lock<std::mutex> %s_lock(g_%s_mutex);\n' % (base_handle_name, base_handle_name)

--- a/src/scripts/validation_layer_generator.py
+++ b/src/scripts/validation_layer_generator.py
@@ -18,11 +18,12 @@
 #
 # Author: Mark Young <marky@lunarg.com>
 
-import os
 import re
 import sys
-from automatic_source_generator import *
-from collections import namedtuple
+
+from automatic_source_generator import (AutomaticSourceGeneratorOptions,
+                                        AutomaticSourceOutputGenerator,
+                                        regSortFeatures, write)
 
 # The following commands should not be generated for the layer
 VALID_USAGE_DONT_GEN = [
@@ -186,7 +187,7 @@ class ValidationSourceOutputGenerator(AutomaticSourceOutputGenerator):
         for cur_state in self.api_states:
             type_name = '%s' % cur_state.type
             cur_list = []
-            if None != active_structures.get(type_name):
+            if active_structures.get(type_name) is not None:
                 cur_list = active_structures.get(type_name)
             cur_list.append(cur_state.variable)
             active_structures[type_name] = cur_list
@@ -240,7 +241,7 @@ class ValidationSourceOutputGenerator(AutomaticSourceOutputGenerator):
             flag_value_validate += '    }\n'
             # If the flag has no values defined for this flag, then anything other than
             # zero generates an error.
-            if flag_tuple.valid_flags == None:
+            if flag_tuple.valid_flags is None:
                 flag_value_validate += '    return VALIDATE_XR_FLAGS_INVALID;\n'
             else:
                 # This flag has values set.  So, check (and remove) each valid value.  Once that's done

--- a/src/scripts/validation_layer_generator.py
+++ b/src/scripts/validation_layer_generator.py
@@ -95,7 +95,7 @@ class ValidationSourceOutputGenerator(AutomaticSourceOutputGenerator):
 
     # Override the base class header warning so the comment indicates this file.
     #   self            the ValidationSourceOutputGenerator object
-    def OutputGeneratedHeaderWarning(self):
+    def outputGeneratedHeaderWarning(self):
         generated_warning = '// *********** THIS FILE IS GENERATED - DO NOT EDIT ***********\n'
         generated_warning += '//     See validation_layer_generator.py for modifications\n'
         generated_warning += '// ************************************************************\n'

--- a/src/scripts/validation_layer_generator.py
+++ b/src/scripts/validation_layer_generator.py
@@ -2556,7 +2556,7 @@ class ValidationSourceOutputGenerator(AutomaticSourceOutputGenerator):
                         next_validate_func += self.writeIndent(3)
                         next_validate_func += '}\n'
 
-                next_validate_func += '            g_%s_info.erase(%s);\n' % (last_lower_type, last_name)
+                next_validate_func += '            %s.erase(%s);\n' % (self.makeInfoName(handle_type=last_handle_tuple), last_name)
                 next_validate_func += '        }\n'
                 if 'xrDestroyInstance' in cur_command.name:
                     next_validate_func += '        GenValidUsageCleanUpMaps(gen_instance_info);\n'
@@ -2648,7 +2648,7 @@ class ValidationSourceOutputGenerator(AutomaticSourceOutputGenerator):
             if handle.name == 'XrInstance':
                 validation_source_funcs += '    EraseAllInstanceTableMapElements(instance_info);\n'
             else:
-                validation_source_funcs += '    g_%s_info.removeHandlesForInstance(instance_info);\n' % base_handle_name
+                validation_source_funcs += '    %s.removeHandlesForInstance(instance_info);\n' % self.makeInfoName(handle_type=handle)
             if handle.protect_value:
                 validation_source_funcs += '#endif // %s\n' % handle.protect_string
         validation_source_funcs += '}\n'

--- a/src/scripts/validation_layer_generator.py
+++ b/src/scripts/validation_layer_generator.py
@@ -2188,6 +2188,21 @@ class ValidationSourceOutputGenerator(AutomaticSourceOutputGenerator):
             obj_type = self.genXrObjectType(handle_param.type)
             pre_validate_func += self.writeIndent(indent)
             pre_validate_func += 'objects_info.emplace_back(%s, %s);\n\n'% (first_handle_name, obj_type)
+
+            # Must verify this param first.
+            # Can skip validating it later.
+
+            pre_validate_func += self.outputParamMemberContents(True, cur_command.name, handle_param, '',
+                                                                'nullptr', # no instance_info yet!
+                                                                command_name_string,
+                                                                True,
+                                                                handle_param,
+                                                                handle_param.name,
+                                                                first_param_handle_tuple,
+                                                                wrote_handle_check_proto,
+                                                                indent)
+            wrote_handle_check_proto = True
+
             lower_handle_name = first_param_handle_tuple.name[2:].lower()
             if first_param_handle_tuple.name == 'XrInstance':
                 pre_validate_func += self.writeIndent(indent)
@@ -2233,6 +2248,9 @@ class ValidationSourceOutputGenerator(AutomaticSourceOutputGenerator):
         # Check for non-optional null pointers
         for count, param in enumerate(cur_command.params):
             is_first = (count == 0)
+            if is_first and first_param_handle_tuple:
+                # This is the first param, which we already validated as being a handle above. Skip this here.
+                continue
             # TODO use_pointer_deref never gets used?
             use_pointer_deref = False
             if len(param.array_count_var) != 0 or len(param.pointer_count_var) != 0:

--- a/src/scripts/validation_layer_generator.py
+++ b/src/scripts/validation_layer_generator.py
@@ -2716,7 +2716,7 @@ class ValidationSourceOutputGenerator(AutomaticSourceOutputGenerator):
                 elif ('xrDestroy' in cur_cmd.name or 'xrDisconnect' in cur_cmd.name) and last_param.is_handle:
                     is_destroy = True
                     has_return = True
-                elif (cur_cmd.return_type != None):
+                elif (cur_cmd.return_type is not None):
                     has_return = True
 
                 validation_source_funcs += self.genValidateInputsFunc(cur_cmd)

--- a/src/scripts/validation_layer_generator.py
+++ b/src/scripts/validation_layer_generator.py
@@ -2290,17 +2290,11 @@ class ValidationSourceOutputGenerator(AutomaticSourceOutputGenerator):
         pre_validate_func += self.writeIndent(indent)
         pre_validate_func += 'std::vector<GenValidUsageXrObjectInfo> objects_info;\n'
         if first_param_handle_tuple != None:
-            pre_validate_func += self.writeIndent(indent)
-            pre_validate_func += 'GenValidUsageXrObjectInfo handle_info = {};\n'
-            pre_validate_func += self.writeIndent(indent)
             handle_param = cur_command.params[0]
             first_handle_name = self.getFirstHandleName(handle_param)
-            pre_validate_func += 'handle_info.handle = CONVERT_HANDLE_TO_GENERIC(%s);\n' % first_handle_name
+            obj_type = self.genXrObjectType(handle_param.type)
             pre_validate_func += self.writeIndent(indent)
-            pre_validate_func += 'handle_info.type = %s;\n' % self.genXrObjectType(
-                handle_param.type)
-            pre_validate_func += self.writeIndent(indent)
-            pre_validate_func += 'objects_info.push_back(handle_info);\n\n'
+            pre_validate_func += 'objects_info.emplace_back(%s, %s);\n\n'% (first_handle_name, obj_type)
             lower_handle_name = first_param_handle_tuple.name[2:].lower()
             if first_param_handle_tuple.name == 'XrInstance':
                 pre_validate_func += self.writeIndent(indent)

--- a/src/scripts/validation_layer_generator.py
+++ b/src/scripts/validation_layer_generator.py
@@ -2464,10 +2464,10 @@ class ValidationSourceOutputGenerator(AutomaticSourceOutputGenerator):
             if handle_tuple.name == 'XrInstance':
                 next_validate_func += '        GenValidUsageXrInstanceInfo *gen_instance_info = g_instance_info.get(%s);\n' % first_handle_name
             else:
-                next_validate_func += '        GenValidUsageXrHandleInfo *gen_%s_info = ' % base_handle_name
-                next_validate_func += 'g_%s_info.get(%s);\n' % (
-                    base_handle_name, first_handle_name)
-                next_validate_func += '        GenValidUsageXrInstanceInfo *gen_instance_info = gen_%s_info->instance_info;\n' % base_handle_name
+                next_validate_func += '        auto info_with_instance = %s.getWithInstanceInfo(%s);\n' % (
+                    self.makeInfoName(handle_type_name=handle_tuple.name), first_handle_name)
+                next_validate_func += '        GenValidUsageXrHandleInfo *gen_%s_info = info_with_instance.first;\n' % base_handle_name
+                next_validate_func += '        GenValidUsageXrInstanceInfo *gen_instance_info = info_with_instance.second;\n'
         else:
             next_validate_func += '#error("Bug")\n'
         # Call down, looking for the returned result if required.

--- a/src/scripts/validation_layer_generator.py
+++ b/src/scripts/validation_layer_generator.py
@@ -163,7 +163,7 @@ class ValidationSourceOutputGenerator(AutomaticSourceOutputGenerator):
             lines.append('%s%s %s;' % (extern_keyword,
                                        info_type, self.makeInfoName(handle)))
             if handle.protect_value:
-                lines.append('#endif // %s" % handle.protect_string')
+                lines.append('#endif // %s' % handle.protect_string)
         return '\n'.join(lines)
 
     # Write out common internal types for validation

--- a/src/scripts/validation_layer_generator.py
+++ b/src/scripts/validation_layer_generator.py
@@ -1317,14 +1317,12 @@ class ValidationSourceOutputGenerator(AutomaticSourceOutputGenerator):
     #   vuid_name           the name of the structure or command to put in the VUID
     #   member_param        the member or parameter generated in automatic_source_generator.py to validate
     #   mem_par_desc_name   Descriptive name of parameter
-    #   output_result_type  Boolean indicating we need to output the handle result type (since it hasn't
-    #                       been defined in the C++ code yet).
     #   return_on_null      Boolean indicating we need to return immediately if we encounter a NULL
     #   instance_info_name  Name of the parameter storing the instance information
     #   element_in_array    This is a single element in an array
     #   indent              the number of "tabs" to space in for the resulting C+ code.
     def writeValidateInlineHandleValidation(self, cmd_name, vuid_name, member_param, mem_par_desc_name,
-                                            output_result_type, return_on_null, instance_info_name,
+                                            return_on_null, instance_info_name,
                                             element_in_array, indent):
         inline_validate_handle = ''
         adjust_to_pointer = ''
@@ -1535,7 +1533,6 @@ class ValidationSourceOutputGenerator(AutomaticSourceOutputGenerator):
                                                                                   struct_command_name,
                                                                                   param_member,
                                                                                   prefixed_param_member_name,
-                                                                                  first_time_handle_check,
                                                                                   is_command,
                                                                                   instance_info_variable,
                                                                                   False,
@@ -1567,7 +1564,6 @@ class ValidationSourceOutputGenerator(AutomaticSourceOutputGenerator):
                                                                                   struct_command_name,
                                                                                   param_member,
                                                                                   prefixed_param_member_name,
-                                                                                  first_time_handle_check,
                                                                                   is_command,
                                                                                   instance_info_variable,
                                                                                   True,

--- a/src/scripts/validation_layer_generator.py
+++ b/src/scripts/validation_layer_generator.py
@@ -2306,6 +2306,7 @@ class ValidationSourceOutputGenerator(AutomaticSourceOutputGenerator):
                 pre_validate_func += self.writeIndent(indent)
                 pre_validate_func += 'mlock.unlock();\n'
             else:
+                pre_validate_func += self.writeIndent(indent)
                 pre_validate_func += 'GenValidUsageXrHandleInfo *gen_%s_info = ' % lower_handle_name
                 pre_validate_func += 'g_%s_info_map[%s];\n' % (
                     lower_handle_name, first_handle_name)

--- a/src/scripts/validation_layer_generator.py
+++ b/src/scripts/validation_layer_generator.py
@@ -2549,28 +2549,6 @@ class ValidationSourceOutputGenerator(AutomaticSourceOutputGenerator):
                 next_validate_func += '        }\n'
                 if 'xrDestroyInstance' in cur_command.name:
                     next_validate_func += '        GenValidUsageCleanUpMaps(gen_instance_info);\n'
-            elif is_sempath_query:
-                assert(False)
-                # xrEnumeratePhysicalDevices is a special case.  It's kind of like a create in that we need to track
-                # these items, but it's also an array of items.
-                next_validate_func += '        if (XR_SUCCESS == result && nullptr != %s && nullptr != %s) {\n' % (cur_command.params[-2].name,
-                                                                                                                   last_name)
-                next_validate_func += '            auto map_with_lock = g_%s_info.lockMap(instance);\n' % last_lower_type
-                next_validate_func += '            auto & map = map_with_lock.second;\n'
-                next_validate_func += '            std::unique_lock<std::mutex> info_lock(g_%s_dispatch_mutex);\n' % last_lower_type
-                next_validate_func += '            for (uint32_t sempath = 0; sempath < *%s; ++sempath) {\n' % cur_command.params[-2].name
-                next_validate_func += '                auto exists = map.find(%s[sempath]);\n' % (
-                    cur_command.params[-1].name)
-                next_validate_func += '                if (exists != map.end()) {\n' % last_lower_type
-                next_validate_func += '                    GenValidUsageXrHandleInfo *handle_info = new GenValidUsageXrHandleInfo();\n'
-                next_validate_func += '                    handle_info->instance_info = gen_instance_info;\n'
-                next_validate_func += '                    handle_info->direct_parent_type = %s;\n' % self.genXrObjectType(
-                    cur_command.params[0].type)
-                next_validate_func += '                    handle_info->direct_parent_handle = CONVERT_HANDLE_TO_GENERIC(%s);\n' % cur_command.params[0].name
-                next_validate_func += '                    map[%s[sempath]] = handle_info;\n' % last_name
-                next_validate_func += '                }\n'
-                next_validate_func += '            }\n'
-                next_validate_func += '        }\n'
 
         # Catch any exceptions that may have occurred.  If any occurred between any of the
         # valid mutex lock/unlock statements, perform the unlock now.  Notice that a create can

--- a/src/scripts/validation_layer_generator.py
+++ b/src/scripts/validation_layer_generator.py
@@ -647,6 +647,10 @@ class ValidationSourceOutputGenerator(AutomaticSourceOutputGenerator):
         validation_header_info += 'struct GenValidUsageXrObjectInfo {\n'
         validation_header_info += '    XR_VALIDATION_GENERIC_HANDLE_TYPE handle;\n'
         validation_header_info += '    XrObjectType type;\n'
+        validation_header_info += '    GenValidUsageXrObjectInfo() = default;\n'
+        validation_header_info += '    template <typename T>\n'
+        validation_header_info += '    GenValidUsageXrObjectInfo(T h, XrObjectType t)\n'
+        validation_header_info += '        : handle(CONVERT_HANDLE_TO_GENERIC(h)), type(t) {}\n'
         validation_header_info += '};\n'
         validation_header_info += '// Debug message severity levels for logging.\n'
         validation_header_info += 'enum GenValidUsageDebugSeverity {\n'
@@ -2355,12 +2359,8 @@ class ValidationSourceOutputGenerator(AutomaticSourceOutputGenerator):
                 use_pointer_deref = True
             if count > 0 and param.is_handle and not param.pointer_count > 0:
                 pre_validate_func += self.writeIndent(indent)
-                pre_validate_func += 'handle_info.handle = CONVERT_HANDLE_TO_GENERIC(%s);\n' % param.name
-                pre_validate_func += self.writeIndent(indent)
-                pre_validate_func += 'handle_info.type = %s;\n' % self.genXrObjectType(
-                    param.type)
-                pre_validate_func += self.writeIndent(indent)
-                pre_validate_func += 'objects_info.push_back(handle_info);\n'
+                pre_validate_func += 'objects_info.emplace_back(%s, %s);\n' % (param.name, self.genXrObjectType(
+                    param.type))
             if not param.no_auto_validity:
                 command_name_string = '"%s"' % cur_command.name
                 pre_validate_func += self.outputParamMemberContents(True, cur_command.name, param, '',

--- a/src/scripts/validation_layer_generator.py
+++ b/src/scripts/validation_layer_generator.py
@@ -2484,6 +2484,8 @@ class ValidationSourceOutputGenerator(AutomaticSourceOutputGenerator):
             last_lower_type = last_handle_tuple.name[2:].lower()
             last_name = cur_command.params[-1].name
             if is_create:
+                assert(last_handle_tuple.name != 'XrInstance')
+
                 next_validate_func += '        if (XR_SUCCESS == result && nullptr != %s) {\n' % last_name
                 next_validate_func += '            auto map_with_lock = g_%s_info.lockMap();\n' % last_lower_type
                 next_validate_func += '            auto & map = map_with_lock.second;\n'
@@ -2557,6 +2559,7 @@ class ValidationSourceOutputGenerator(AutomaticSourceOutputGenerator):
                 if 'xrDestroyInstance' in cur_command.name:
                     next_validate_func += '        GenValidUsageCleanUpMaps(gen_instance_info);\n'
             elif is_sempath_query:
+                assert(False)
                 # xrEnumeratePhysicalDevices is a special case.  It's kind of like a create in that we need to track
                 # these items, but it's also an array of items.
                 next_validate_func += '        if (XR_SUCCESS == result && nullptr != %s && nullptr != %s) {\n' % (cur_command.params[-2].name,

--- a/src/scripts/validation_layer_generator.py
+++ b/src/scripts/validation_layer_generator.py
@@ -2642,8 +2642,7 @@ class ValidationSourceOutputGenerator(AutomaticSourceOutputGenerator):
         validation_source_funcs += '    std::string object_string;\n'
         count = 0
         for object_type in self.api_object_types:
-            object_string = object_type.name.replace("XR_OBJECT_TYPE_", "")
-            object_string = object_string.replace("_", "")
+            object_string = object_type.name.replace("XR_OBJECT_TYPE_", "").replace("_", "")
             if object_string == "UNKNOWN":
                 if count == 0:
                     validation_source_funcs += '    if '

--- a/src/scripts/validation_layer_generator.py
+++ b/src/scripts/validation_layer_generator.py
@@ -2487,41 +2487,32 @@ class ValidationSourceOutputGenerator(AutomaticSourceOutputGenerator):
                 assert(last_handle_tuple.name != 'XrInstance')
 
                 next_validate_func += '        if (XR_SUCCESS == result && nullptr != %s) {\n' % last_name
-                next_validate_func += '            auto map_with_lock = g_%s_info.lockMap();\n' % last_lower_type
-                next_validate_func += '            auto & map = map_with_lock.second;\n'
-                next_validate_func += '            auto exists = map.find(*%s);\n' % last_name
-                next_validate_func += '            if (exists == map.end()) {\n'
-                if last_handle_tuple.name == 'XrInstance':
-                    next_validate_func += '                map[*%s] = gen_instance_info;\n' % last_name
-                else:
-                    next_validate_func += '                std::unique_ptr<GenValidUsageXrHandleInfo> handle_info(new GenValidUsageXrHandleInfo());\n'
-                    next_validate_func += '                handle_info->instance_info = gen_instance_info;\n'
-                    next_validate_func += '                handle_info->direct_parent_type = %s;\n' % self.genXrObjectType(
-                        cur_command.params[0].type)
-                    next_validate_func += '                handle_info->direct_parent_handle = CONVERT_HANDLE_TO_GENERIC(%s);\n' % cur_command.params[
-                        0].name
-                    next_validate_func += '                map[*%s] = std::move(handle_info);\n' % last_name
+                next_validate_func += '            std::unique_ptr<GenValidUsageXrHandleInfo> handle_info(new GenValidUsageXrHandleInfo());\n'
+                next_validate_func += '            handle_info->instance_info = gen_instance_info;\n'
+                next_validate_func += '            handle_info->direct_parent_type = %s;\n' % self.genXrObjectType(
+                    cur_command.params[0].type)
+                next_validate_func += '            handle_info->direct_parent_handle = CONVERT_HANDLE_TO_GENERIC(%s);\n' % cur_command.params[
+                    0].name
+                next_validate_func += '            %s.insert(*%s, std::move(handle_info));\n' % (self.makeInfoName(last_handle_tuple), last_name)
 
                 # If this object contains a state that needs tracking, allocate it
                 valid_type_list = []
                 for cur_state in self.api_states:
                     if last_handle_tuple.name == cur_state.type and cur_state.type not in valid_type_list:
                         valid_type_list.append(cur_state.type)
-                        next_validate_func += self.writeIndent(4)
+                        next_validate_func += self.writeIndent(3)
                         next_validate_func += '// Check to see if this object that has been created has a validation\n'
-                        next_validate_func += self.writeIndent(4)
+                        next_validate_func += self.writeIndent(3)
                         next_validate_func += '// state structure that needs to be created as well.\n'
-                        next_validate_func += self.writeIndent(4)
+                        next_validate_func += self.writeIndent(3)
                         next_validate_func += '%sValidationStates *%s_valid_state = new %sValidationStates;\n' % (
                             cur_state.type, cur_state.type[2:].lower(), cur_state.type)
-                        next_validate_func += self.writeIndent(4)
-                        next_validate_func += '(*%s_valid_state) = {};\n' % cur_state.type[2:].lower(
-                        )
-                        next_validate_func += self.writeIndent(4)
+                        next_validate_func += self.writeIndent(3)
+                        next_validate_func += '(*%s_valid_state) = {};\n' % cur_state.type[2:].lower()
+                        next_validate_func += self.writeIndent(3)
                         next_validate_func += 'g_%s_valid_states[(*%s)] = %s_valid_state;\n' % (
                             cur_state.type[2:].lower(), last_name, cur_state.type[2:].lower())
 
-                next_validate_func += '            }\n'
                 next_validate_func += '        }\n'
             elif is_destroy:
                 if cur_command.params[-1].type == 'XrSession':


### PR DESCRIPTION
I tried to move some things out of the generated code where possible, and reduce duplication (the locking of the maps is automatic and centralized now).

Fixed a few issues:

- Logic regarding whether to insert handle data was flipped, so the maps never got populated.
- We were using a handle to retrieve from info maps before validating that handle, meaning it would crash before it got around to sending the "invalid handle" error.
- The warning heading wasn't ever getting printed right because the case didn't match the parent class, oops.

Also went thru and ran coverage on it, removed a few large chunks of dead code from things I remember being old decisions.

I still get a segfault in a weird place during DestroySpace, but it does at least run fine until that point using a headless app.