### PR TITLE
hello_xr: Fix a warning

### DIFF
--- a/src/tests/hello_xr/graphicsplugin_vulkan.cpp
+++ b/src/tests/hello_xr/graphicsplugin_vulkan.cpp
@@ -850,7 +850,7 @@ struct SwapchainImageContext {
             bases[i] = reinterpret_cast<XrSwapchainImageBaseHeader*>(&swapchainImages[i]);
         }
 
-        return std::move(bases);
+        return bases;
     }
 
     uint32_t ImageIndex(const XrSwapchainImageBaseHeader* swapchainImageHeader) {


### PR DESCRIPTION
My version of GCC locally pointed out that moving a return value is actually a pessimization for some reason.