### PR TITLE
Add default implementations of API functions to dispatch chains

### DIFF
--- a/src/loader/runtime_interface.cpp
+++ b/src/loader/runtime_interface.cpp
@@ -277,7 +277,7 @@ XrResult RuntimeInterface::CreateInstance(const XrInstanceCreateInfo* info, XrIn
         res = rt_xrCreateInstance(info, instance);
         if (XR_SUCCESS == res) {
             create_succeeded = true;
-            XrGeneratedDispatchTable* dispatch_table = new XrGeneratedDispatchTable;
+            XrGeneratedDispatchTable* dispatch_table = new XrGeneratedDispatchTable();
             GeneratedXrPopulateDispatchTable(dispatch_table, *instance, _get_instant_proc_addr);
             std::unique_lock<std::mutex> mlock(_dispatch_table_mutex);
             _dispatch_table_map[*instance] = dispatch_table;

--- a/src/scripts/loader_source_generator.py
+++ b/src/scripts/loader_source_generator.py
@@ -328,7 +328,7 @@ class LoaderSourceOutputGenerator(AutomaticSourceOutputGenerator):
         result_to_str += self.writeIndent(indent)
         result_to_str += 'XrResult result = GeneratedXrUtilitiesResultToString(value, %s);\n' % buffer_param_name
         result_to_str += self.writeIndent(indent)
-        result_to_str += 'if (XR_SUCCESS != result) {\n'
+        result_to_str += 'if (XR_SUCCEEDED(result)) {\n'
         result_to_str += self.writeIndent(indent + 1)
         result_to_str += 'return result;\n'
         result_to_str += self.writeIndent(indent)
@@ -352,7 +352,7 @@ class LoaderSourceOutputGenerator(AutomaticSourceOutputGenerator):
         struct_to_str += self.writeIndent(indent)
         struct_to_str += 'XrResult result = GeneratedXrUtilitiesStructureTypeToString(value, %s);\n' % buffer_param_name
         struct_to_str += self.writeIndent(indent)
-        struct_to_str += 'if (XR_SUCCESS != result) {\n'
+        struct_to_str += 'if (XR_SUCCEEDED(result)) {\n'
         struct_to_str += self.writeIndent(indent + 1)
         struct_to_str += 'return result;\n'
         struct_to_str += self.writeIndent(indent)
@@ -968,12 +968,8 @@ class LoaderSourceOutputGenerator(AutomaticSourceOutputGenerator):
 
                 if cur_cmd.name in NO_TRAMPOLINE_OR_TERMINATOR:
                     export_funcs += '    table->%s = nullptr;\n' % base_name
-                elif ((cur_cmd.name in MANUAL_LOADER_INSTANCE_FUNCS or cur_cmd.name in MANUAL_LOADER_INSTANCE_TERMINATOR_FUNCS) and
-                      not cur_cmd.name in NO_TRAMPOLINE_OR_TERMINATOR):
-                    export_funcs += '    table->%s = LoaderXrTerm%s;\n' % (
-                        base_name, base_name)
                 else:
-                    export_funcs += '    RuntimeInterface::GetInstanceProcAddr(instance, "%s", reinterpret_cast<PFN_xrVoidFunction*>(&table->%s));\n' % (
+                    export_funcs += '    LoaderXrTermGetInstanceProcAddr(instance, "%s", reinterpret_cast<PFN_xrVoidFunction*>(&table->%s));\n' % (
                         cur_cmd.name, base_name)
 
                 if cur_cmd.protect_value:


### PR DESCRIPTION
The loader defines default implementations and/or terminator functions for a handful of API calls.  Two of these,  `xrResultToString` and `xrStructureTypeToString`, were not being linked into the dispatch call chains. If a runtime which didn't provide these fxns was loaded, those call chains ended with a null fxn pointer, with the expected non-optimal result.

This PR fixes the python script that generates the loader file responsible for the error.  It also refactors `LoaderInstance::CreateInstance()` to remove some unnecessary std containers that were confusing, which eventually became a pretty large re-org of that fxn. Many characters were saved in the making of this PR :)

This addresses gitlab issue: https://gitlab.khronos.org/openxr/openxr/issues/975

