### PR TITLE
Fix list test output;

### DIFF
--- a/src/tests/list/list.cpp
+++ b/src/tests/list/list.cpp
@@ -95,7 +95,7 @@ int main() {
     printf("Evaluating system\n");
     printf("\t           name: '%s'\n", systemProperties.systemName);
     printf("\t       vendorId: 0x%" PRIx32 "\n", systemProperties.vendorId);
-    printf("\\t      systemId: 0x%" PRIx64 "\n", systemProperties.systemId);
+    printf("\t       systemId: 0x%" PRIx64 "\n", systemProperties.systemId);
     printf("\t     systemName: %s\n", systemProperties.systemName);
 
     // The program struct will do cleanup for us.


### PR DESCRIPTION
The list test was printing a literal `\t` instead of a tab for the `systemId` line.