### PR TITLE
loader: Default to static loader only on windows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,7 +22,12 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 # All options defined here
 option(BUILD_LOADER "Build loader" ON)
-option(DYNAMIC_LOADER "Build the loader as a .dll library" OFF)
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    option(DYNAMIC_LOADER "Build the loader as a .dll library" OFF)
+else()
+    option(DYNAMIC_LOADER "Build the loader as a .dll library" ON)
+endif()
+
 option(BUILD_API_LAYERS "Build API layers" ON)
 option(BUILD_TESTS "Build tests" ON)
 


### PR DESCRIPTION
On Linux we want to follow the Vulkan model of a system wide dynamic loader.
Appplications are still free to link to a static copy of the loader if they wish.