### PR TITLE
Update BUILDING.md with some linux pre-requisites

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -46,12 +46,20 @@ Open the build\win32\OPENXR.sln in the Visual Studio to build the samples.
 
 ## Linux
 
-The following packages are required, at minimum.
+The following set of packages provides all required libs for building for xlib or xcb with OpenGL and Vulkan support.
+ - build-essential
  - cmake (of _somewhat_ recent vintage, 3.10+ known working)
- - libx11-dev
- - libxxf86vm-dev
+ - libgl1-mesa-dev
+ - libvulkan-dev
+ - libx11-xcb-dev
+ - libxcb-dri2-0-dev
+ - libxcb-glx0-dev
+ - libxcb-icccm4-dev
+ - libxcb-keysyms1-dev
+ - libxcb-randr0-dev
  - libxrandr-dev
- - freeglut3-dev (or another way to support -lGL in ld)
+ - libxxf86vm-dev
+ - mesa-common-dev
 
 ### Linux Debug
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -45,6 +45,14 @@ cmake -G "Visual Studio [Version Number]" ..\..
 Open the build\win32\OPENXR.sln in the Visual Studio to build the samples.
 
 ## Linux
+
+The following packages are required, at minimum.
+ - cmake (of _somewhat_ recent vintage, 3.10+ known working)
+ - libx11-dev
+ - libxxf86vm-dev
+ - libxrandr-dev
+ - freeglut3-dev (or another way to support -lGL in ld)
+
 ### Linux Debug
 
 ```


### PR DESCRIPTION
Just stood up a vanilla Ubuntu 19.04, these are the minimal packages I had to install to get the build working.

@rpavlik, maybe you know more about xxf86vm? Installing it alone didn't satisfy cmake's findpackage, but then installing xrandr resolved the findpackage for xrandr and xxf86vm. So, maybe xxf86vm isn't really needed?  I'm assuming no harm in listing it.