### PR TITLE
make mainfest file more compatible

### DIFF
--- a/src/loader/manifest_file.cpp
+++ b/src/loader/manifest_file.cpp
@@ -24,6 +24,7 @@
 #include <cstring>
 #include <fstream>
 #include <iostream>
+#include <sstream>
 #include <stdexcept>
 
 #include "filesystem_utils.hpp"
@@ -621,7 +622,7 @@ void RuntimeManifestFile::CreateIfValid(std::string filename, std::vector<std::u
                     continue;
                 }
                 std::string original_name = func_it.key().asString();
-                std::string new_name = func_it->asString();
+                std::string new_name = (*func_it).asString();
                 manifest_files.back()->_functions_renamed.insert(std::make_pair(original_name, new_name));
             }
         }
@@ -879,7 +880,7 @@ void ApiLayerManifestFile::CreateIfValid(ManifestFileType type, std::string file
                     continue;
                 }
                 std::string original_name = func_it.key().asString();
-                std::string new_name = func_it->asString();
+                std::string new_name = (*func_it).asString();
                 manifest_files.back()->_functions_renamed.insert(std::make_pair(original_name, new_name));
             }
         }


### PR DESCRIPTION
1. Adding #include\<sstream\> so manifest_file.cpp can work with jsoncpp library without having to almagate the rouces together (calling src/external/jsoncpp/amalgamate.py). This is useful with chroumium where jsoncpp library is used as not almagated.
  
2. Changing Json:::ValueIterator func_it-> to Json:::ValueIterator (*func_it). so it will be compatible to older version of jsoncpp library.(like the one used by chroumium now)