### PR TITLE
Support building with embedded python

### DIFF
--- a/specification/scripts/genxr.py
+++ b/specification/scripts/genxr.py
@@ -15,10 +15,13 @@
 # limitations under the License.
 
 import argparse
+import os
 import re
 import sys
 import time
 import xml.etree.ElementTree as etree
+
+sys.path.append(os.path.abspath(os.path.dirname(__file__)))
 
 from cgenerator import CGeneratorOptions, COutputGenerator
 from docgenerator import DocGeneratorOptions, DocOutputGenerator

--- a/src/scripts/src_genxr.py
+++ b/src/scripts/src_genxr.py
@@ -14,7 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import argparse, cProfile, pdb, string, sys, time
+import argparse, cProfile, os, pdb, string, sys, time
+
+base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+sys.path.append(os.path.join(base_dir, 'src', 'scripts'))
+sys.path.append(os.path.join(base_dir, 'specification', 'scripts'))
+
 from reg import *
 from generator import write
 from cgenerator import CGeneratorOptions, COutputGenerator


### PR DESCRIPTION
The CMake logic uses the environment variable `PYTHONPATH` to allow the `src_genxr.py` and `genxr.py` scripts to execute using local modules like `reg`.  

However, vcpkg will use an embedded version of Python if a conventional version is not found on the host system, and the embedded version of Python will not respect the `PYTHONPATH` env variable.  

This PR modifies the scripts to internally modify the `sys.path` array with the required paths, defined here as relative paths to the root of the repository.

This removes the need for defining PYTHONPATH in the CMake files, but PR hasn't done so.  