### PR TITLE
Idiomatic Linux active_runtime.json search logic

### DIFF
--- a/src/common/platform_utils.hpp
+++ b/src/common/platform_utils.hpp
@@ -59,17 +59,6 @@ static inline void PlatformUtilsFreeEnv(char* val) {
     (void)val;
 }
 
-// Prefix for the Linux/Apple global runtime JSON file name
-static const std::string rt_dir_prefix = "/usr/local/share/openxr/";
-static const std::string rt_filename = "/active_runtime.json";
-
-static inline bool PlatformGetGlobalRuntimeFileName(uint16_t major_version, std::string& file_name) {
-    file_name = rt_dir_prefix;
-    file_name += std::to_string(major_version);
-    file_name += rt_filename;
-    return true;
-}
-
 #elif defined(XR_OS_APPLE)
 
 static inline char *PlatformUtilsGetEnv(const char *name) { return getenv(name); }
@@ -94,7 +83,7 @@ static inline void PlatformUtilsFreeEnv(char *val) {
     (void)val;
 }
 
-// Prefix for the Linux/Apple global runtime JSON file name
+// Prefix for the Apple global runtime JSON file name
 static const std::string rt_dir_prefix = "/usr/local/share/openxr/";
 static const std::string rt_filename = "/active_runtime.json";
 

--- a/src/common/platform_utils.hpp
+++ b/src/common/platform_utils.hpp
@@ -126,33 +126,6 @@ static inline void PlatformUtilsFreeEnv(char *val) {
     }
 }
 
-// Prefix for the Windows global runtime JSON file name
-static const std::string rt_file_folder = "\\ProgramData\\Khronos\\OpenXR\\";
-static const std::string rt_file_prefix = "\\openxr_runtime_";
-
-static inline bool PlatformGetGlobalRuntimeFileName(uint16_t major_version, std::string &file_name) {
-    bool ret_value = false;
-    try {
-        char *sys_drive = PlatformUtilsGetSecureEnv("SystemDrive");
-        if (nullptr != sys_drive) {
-            file_name = sys_drive;
-            PlatformUtilsFreeEnv(sys_drive);
-            file_name += rt_file_folder;
-            if (sizeof(void *) == 8) {
-                file_name += "64";
-            } else {
-                file_name += "32";
-            }
-            file_name += rt_file_prefix;
-            file_name += std::to_string(major_version);
-            file_name += ".json";
-            ret_value = true;
-        }
-    } catch (...) {
-    }
-    return ret_value;
-}
-
 #else  // Not Linux or Windows
 
 static inline char *PlatformUtilsGetEnv(const char *name) {

--- a/src/loader/manifest_file.cpp
+++ b/src/loader/manifest_file.cpp
@@ -715,13 +715,15 @@ XrResult RuntimeManifestFile::FindManifestFiles(ManifestFileType type,
             throw std::runtime_error("invalid manifest type");
         }
         std::string filename;
-        const char *override_path = PlatformUtilsGetSecureEnv(OPENXR_RUNTIME_JSON_ENV_VAR);
+        char *override_path = PlatformUtilsGetSecureEnv(OPENXR_RUNTIME_JSON_ENV_VAR);
         if (override_path != nullptr && *override_path != '\0') {
             filename = override_path;
+            PlatformUtilsFreeEnv(override_path);
             std::string info_message = "RuntimeManifestFile::FindManifestFiles - using environment variable override runtime file ";
             info_message += filename;
             LoaderLogger::LogInfoMessage("", info_message);
         } else {
+            PlatformUtilsFreeEnv(override_path);
 #ifdef XR_OS_WINDOWS
             std::vector<std::string> filenames;
             ReadRuntimeDataFilesInRegistry(type, "", "ActiveRuntime", filenames);

--- a/src/loader/manifest_file.cpp
+++ b/src/loader/manifest_file.cpp
@@ -126,7 +126,6 @@ static void AddFilesInPath(ManifestFileType type, const std::string &search_path
             // This works around issue if multiple path separator follow each other directly.
             last_found = found;
             while (found == last_found) {
-                std::ostringstream stringStream2;
                 last_found = found + 1;
                 found = search_path.find_first_of(PATH_SEPARATOR, last_found);
             }


### PR DESCRIPTION
Based on #38. Fixes #28.

This updates the search logic to find the first active_runtime.json in standard config file locations, allowing for more graceful integration with Linux distribution tooling and user/administrator expectations.

I opted not to reuse `ReadDataFilesInSearchPaths` due to its complexity and conflation of config/data search paths.

If this is to be merged, the loader design doc will also need to be updated. I'm not sure where to find the source files for that.