### PR TITLE
Revert "loader: purge std::map bracket operations that might do inadvertent insertions"

### DIFF
--- a/src/api_layers/api_dump.cpp
+++ b/src/api_layers/api_dump.cpp
@@ -573,17 +573,8 @@ XrResult ApiDumpLayerXrDestroyInstance(XrInstance instance) {
     ApiDumpLayerRecordContent(contents);
 
     std::unique_lock<std::mutex> mlock(g_instance_dispatch_mutex);
-    XrGeneratedDispatchTable *next_dispatch = nullptr;
-    auto map_iter = g_instance_dispatch_map.find(instance);
-    if (map_iter != g_instance_dispatch_map.end()) {
-        next_dispatch = map_iter->second;
-    }
+    XrGeneratedDispatchTable *next_dispatch = g_instance_dispatch_map[instance];
     mlock.unlock();
-
-    if (nullptr == next_dispatch) {
-        return XR_ERROR_HANDLE_INVALID;
-    }
-
     next_dispatch->DestroyInstance(instance);
     ApiDumpCleanUpMapsForTable(next_dispatch);
 

--- a/src/loader/loader_core.cpp
+++ b/src/loader/loader_core.cpp
@@ -251,7 +251,7 @@ LOADER_EXPORT XRAPI_ATTR XrResult XRAPI_CALL xrCreateInstance(const XrInstanceCr
             }
         }
 
-        if (XR_FAILED(result)) {
+        if (XR_SUCCESS != result) {
             if (runtime_loaded) {
                 RuntimeInterface::UnloadRuntime("xrCreateInstance");
             }
@@ -264,13 +264,12 @@ LOADER_EXPORT XRAPI_ATTR XrResult XRAPI_CALL xrCreateInstance(const XrInstanceCr
         XrInstance created_instance = XR_NULL_HANDLE;
         result = LoaderInstance::CreateInstance(api_layer_interfaces, info, &created_instance);
 
-        if (XR_SUCCEEDED(result)) {
+        if (XR_SUCCESS == result) {
             *instance = created_instance;
 
-            LoaderInstance *loader_instance = nullptr;
+            LoaderInstance *loader_instance;
             {
                 std::unique_lock<std::mutex> lock(g_instance_mutex);
-                // Unguarded RHS bracket operator ok here - we know it was just successfully found or inserted above
                 loader_instance = g_instance_map[created_instance];
             }
 
@@ -455,14 +454,10 @@ XRAPI_ATTR XrResult XRAPI_CALL xrCreateDebugUtilsMessengerEXT(XrInstance instanc
     try {
         LoaderLogger::LogVerboseMessage("xrCreateDebugUtilsMessengerEXT", "Entering loader trampoline");
 
-        LoaderInstance *loader_instance = nullptr;
+        LoaderInstance *loader_instance;
         {
             std::unique_lock<std::mutex> lock(g_instance_mutex);
-            auto map_iter = g_instance_map.find(instance);
-            if (map_iter == g_instance_map.end()) {
-                return XR_ERROR_VALIDATION_FAILURE;
-            }
-            loader_instance = map_iter->second;
+            loader_instance = g_instance_map[instance];
         }
 
         if (!loader_instance->ExtensionIsEnabled(XR_EXT_DEBUG_UTILS_EXTENSION_NAME)) {
@@ -512,14 +507,10 @@ XRAPI_ATTR XrResult XRAPI_CALL xrDestroyDebugUtilsMessengerEXT(XrDebugUtilsMesse
             return XR_ERROR_DEBUG_UTILS_MESSENGER_INVALID_EXT;
         }
 
-        LoaderInstance *loader_instance = nullptr;
+        LoaderInstance *loader_instance;
         {
             std::unique_lock<std::mutex> lock(g_debugutilsmessengerext_mutex);
-            auto map_iter = g_debugutilsmessengerext_map.find(messenger);
-            if (map_iter == g_debugutilsmessengerext_map.end()) {
-                return XR_ERROR_VALIDATION_FAILURE;
-            }
-            loader_instance = map_iter->second;
+            loader_instance = g_debugutilsmessengerext_map[messenger];
         }
 
         if (!loader_instance->ExtensionIsEnabled(XR_EXT_DEBUG_UTILS_EXTENSION_NAME)) {
@@ -664,14 +655,10 @@ XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermSetDebugUtilsObjectNameEXT(XrInstance
 
 XRAPI_ATTR XrResult XRAPI_CALL xrSessionBeginDebugUtilsLabelRegionEXT(XrSession session, const XrDebugUtilsLabelEXT *labelInfo) {
     try {
-        LoaderInstance *loader_instance = nullptr;
+        LoaderInstance *loader_instance;
         {
             std::unique_lock<std::mutex> lock(g_session_mutex);
-            auto map_iter = g_session_map.find(session);
-            if (map_iter == g_session_map.end()) {
-                return XR_ERROR_VALIDATION_FAILURE;
-            }
-            loader_instance = map_iter->second;
+            loader_instance = g_session_map[session];
         }
 
         std::vector<XrLoaderLogObjectInfo> loader_objects;
@@ -712,14 +699,10 @@ XRAPI_ATTR XrResult XRAPI_CALL xrSessionBeginDebugUtilsLabelRegionEXT(XrSession 
 
 XRAPI_ATTR XrResult XRAPI_CALL xrSessionEndDebugUtilsLabelRegionEXT(XrSession session) {
     try {
-        LoaderInstance *loader_instance = nullptr;
+        LoaderInstance *loader_instance;
         {
             std::unique_lock<std::mutex> lock(g_session_mutex);
-            auto map_iter = g_session_map.find(session);
-            if (map_iter == g_session_map.end()) {
-                return XR_ERROR_VALIDATION_FAILURE;
-            }
-            loader_instance = map_iter->second;
+            loader_instance = g_session_map[session];
         }
 
         if (nullptr == loader_instance) {
@@ -750,14 +733,10 @@ XRAPI_ATTR XrResult XRAPI_CALL xrSessionEndDebugUtilsLabelRegionEXT(XrSession se
 
 XRAPI_ATTR XrResult XRAPI_CALL xrSessionInsertDebugUtilsLabelEXT(XrSession session, const XrDebugUtilsLabelEXT *labelInfo) {
     try {
-        LoaderInstance *loader_instance = nullptr;
+        LoaderInstance *loader_instance;
         {
             std::unique_lock<std::mutex> lock(g_session_mutex);
-            auto map_iter = g_session_map.find(session);
-            if (map_iter == g_session_map.end()) {
-                return XR_ERROR_VALIDATION_FAILURE;
-            }
-            loader_instance = map_iter->second;
+            loader_instance = g_session_map[session];
         }
 
         XrLoaderLogObjectInfo object_info = {};

--- a/src/loader/runtime_interface.cpp
+++ b/src/loader/runtime_interface.cpp
@@ -193,19 +193,14 @@ XrResult RuntimeInterface::GetInstanceProcAddr(XrInstance instance, const char* 
 const XrGeneratedDispatchTable* RuntimeInterface::GetDispatchTable(XrInstance instance) {
     XrGeneratedDispatchTable* table = nullptr;
     std::unique_lock<std::mutex> mlock(_single_runtime_interface->_dispatch_table_mutex);
-    if (0 != _single_runtime_interface->_dispatch_table_map.count(instance)) {
-        table = _single_runtime_interface->_dispatch_table_map[instance];
-    }
+    table = _single_runtime_interface->_dispatch_table_map[instance];
     return table;
 }
 
 const XrGeneratedDispatchTable* RuntimeInterface::GetDebugUtilsMessengerDispatchTable(XrDebugUtilsMessengerEXT messenger) {
     try {
         std::unique_lock<std::mutex> mlock(_single_runtime_interface->_messenger_to_instance_mutex);
-        XrInstance runtime_instance = nullptr;
-        if (0 != _single_runtime_interface->_messenger_to_instance_map.count(messenger)) {
-            runtime_instance = _single_runtime_interface->_messenger_to_instance_map[messenger];
-        }
+        XrInstance runtime_instance = _single_runtime_interface->_messenger_to_instance_map[messenger];
         mlock.unlock();
         return GetDispatchTable(runtime_instance);
     } catch (...) {
@@ -311,12 +306,8 @@ XrResult RuntimeInterface::DestroyInstance(XrInstance instance) {
         if (XR_NULL_HANDLE != instance) {
             // Destroy the dispatch table for this instance first
             std::unique_lock<std::mutex> mlock(_dispatch_table_mutex);
-            XrGeneratedDispatchTable* table = nullptr;
-            auto map_iter = _dispatch_table_map.find(instance);
-            if (map_iter != _dispatch_table_map.end()) {
-                table = map_iter->second;
-                _dispatch_table_map.erase(map_iter);
-            }
+            XrGeneratedDispatchTable* table = _dispatch_table_map[instance];
+            _dispatch_table_map.erase(instance);
             mlock.unlock();
 
             if (nullptr != table) {

--- a/src/scripts/api_dump_generator.py
+++ b/src/scripts/api_dump_generator.py
@@ -1149,10 +1149,8 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
                     base_handle_name = undecorate(handle_param.type)
                     first_handle_name = self.getFirstHandleName(handle_param)
                     generated_commands += '        std::unique_lock<std::mutex> mlock(g_%s_dispatch_mutex);\n' % base_handle_name
-                    generated_commands += '        auto map_iter = g_%s_dispatch_map.find(%s);\n' % (base_handle_name, first_handle_name)
-                    generated_commands += '        mlock.unlock();\n\n'
-                    generated_commands += '        if (map_iter == g_%s_dispatch_map.end()) return XR_ERROR_VALIDATION_FAILURE;\n' % base_handle_name
-                    generated_commands += '        XrGeneratedDispatchTable *gen_dispatch_table = map_iter->second;\n'
+                    generated_commands += '        XrGeneratedDispatchTable *gen_dispatch_table = g_%s_dispatch_map[%s];\n' % (base_handle_name, first_handle_name)
+                    generated_commands += '        mlock.unlock();\n'
                 else:
                     generated_commands += self.printCodeGenErrorMessage(
                         'Command %s does not have an OpenXR Object handle as the first parameter.' % cur_cmd.name)
@@ -1174,7 +1172,7 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
                         param, False, can_expand, 2)
 
                 # Now record the information
-                generated_commands += '        ApiDumpLayerRecordContent(contents);\n\n'
+                generated_commands += '        ApiDumpLayerRecordContent(contents);\n'
 
                 # Call down, looking for the returned result if required.
                 generated_commands += '        '
@@ -1297,12 +1295,8 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
         generated_commands += '        }\n\n'
         generated_commands += '        // We have not found it, so pass it down to the next layer/runtime\n'
         generated_commands += '        std::unique_lock<std::mutex> mlock(g_instance_dispatch_mutex);\n'
-        generated_commands += '        auto map_iter = g_instance_dispatch_map.find(instance);\n'
+        generated_commands += '        XrGeneratedDispatchTable *gen_dispatch_table = g_instance_dispatch_map[instance];\n'
         generated_commands += '        mlock.unlock();\n\n'
-        generated_commands += '        if (map_iter == g_instance_dispatch_map.end()) {\n'
-        generated_commands += '            return XR_ERROR_HANDLE_INVALID;\n'
-        generated_commands += '        }\n\n'
-        generated_commands += '        XrGeneratedDispatchTable *gen_dispatch_table = map_iter->second;\n'
         generated_commands += '        if (nullptr == gen_dispatch_table) {\n'
         generated_commands += '            return XR_ERROR_HANDLE_INVALID;\n'
         generated_commands += '        }\n\n'

--- a/src/scripts/loader_source_generator.py
+++ b/src/scripts/loader_source_generator.py
@@ -526,11 +526,8 @@ class LoaderSourceOutputGenerator(AutomaticSourceOutputGenerator):
                                     tramp_variable_defines += '        }\n'
                             secondary_mutex_name = 'g_%s_mutex' % base_handle_name
                             tramp_variable_defines += '        std::unique_lock<std::mutex> secondary_lock(%s);\n' % secondary_mutex_name
-                            tramp_variable_defines += '        auto map_iter = g_%s_map.find(%s);\n' % (base_handle_name, first_handle_name)
-                            tramp_variable_defines += '        LoaderInstance *loader_instance = nullptr;\n'
-                            tramp_variable_defines += '        if (map_iter != g_%s_map.end()) {\n' % base_handle_name
-                            tramp_variable_defines += '            loader_instance = map_iter->second;\n'
-                            tramp_variable_defines += '        }\n'
+                            tramp_variable_defines += '        LoaderInstance *loader_instance = g_%s_map[%s];\n' % (
+                                base_handle_name, first_handle_name)
                             if cur_cmd.is_destroy_disconnect:
                                 tramp_variable_defines += '        // Destroy the mapping entry for this item if it was valid.\n'
                                 tramp_variable_defines += '        if (nullptr != loader_instance) {\n'
@@ -541,13 +538,9 @@ class LoaderSourceOutputGenerator(AutomaticSourceOutputGenerator):
                             assert((not cur_cmd.is_destroy_disconnect)
                                    or (pointer_count == 0))
                             if pointer_count == 1:
-                                # NOTE - @ 10-June-2019 this stanza is never exercised in loader code-gen. Consider whether necessary. DJH
                                 tramp_variable_defines += '        for (uint32_t i = 1; i < %s; ++i) {\n' % param.pointer_count_var
-                                tramp_variable_defines += '            LoaderInstance *elt_loader_instance = nullptr;\n'
-                                tramp_variable_defines += '            auto map_iter = g_%s_map.find(%s[i]);\n' % (base_handle_name, param.name)
-                                tramp_variable_defines += '            if (map_iter != g_%s_map.end()) {\n' % base_handle_name
-                                tramp_variable_defines += '                elt_loader_instance = map_iter->second;\n'
-                                tramp_variable_defines += '            }\n'
+                                tramp_variable_defines += '            LoaderInstance *elt_loader_instance = g_%s_map[%s[i]];\n' % (
+                                    base_handle_name, param.name)
                                 tramp_variable_defines += '            if (elt_loader_instance == nullptr || elt_loader_instance != loader_instance) {\n'
                                 tramp_variable_defines += '                XrLoaderLogObjectInfo bad_object = {};\n'
                                 tramp_variable_defines += '                bad_object.type = %s;\n' % self.genXrObjectType(
@@ -570,7 +563,7 @@ class LoaderSourceOutputGenerator(AutomaticSourceOutputGenerator):
                                     tramp_variable_defines += '                return XR_ERROR_HANDLE_INVALID;\n'
                                 tramp_variable_defines += '            }\n'
                                 tramp_variable_defines += '        }\n'
-                            tramp_variable_defines += '        secondary_lock.unlock();\n\n'
+                            tramp_variable_defines += '        secondary_lock.unlock();\n'
                             tramp_variable_defines += '        if (nullptr == loader_instance) {\n'
                             tramp_variable_defines += '            XrLoaderLogObjectInfo bad_object = {};\n'
                             tramp_variable_defines += '            bad_object.type = %s;\n' % self.genXrObjectType(


### PR DESCRIPTION
Reverts KhronosGroup/OpenXR-SDK#55

Broke 32-bit builds, noticed when syncing.

```
..\src\loader\runtime_interface.cpp(205): error C2440: 'initializing': cannot convert from 'nullptr' to 'XrInstance'
..\src\loader\runtime_interface.cpp(205): note: A native nullptr can only be converted to bool or, using reinterpret_cast, to an integral type
```