### PR TITLE
Allow certain hardware time to initialize.

### DIFF
--- a/src/tests/hello_xr/openxr_program.cpp
+++ b/src/tests/hello_xr/openxr_program.cpp
@@ -532,6 +532,10 @@ struct OpenXrProgram : IOpenXrProgram {
             XrSessionCreateInfo createInfo{XR_TYPE_SESSION_CREATE_INFO};
             createInfo.next = m_graphicsPlugin->GetGraphicsBinding();
             createInfo.systemId = m_systemId;
+
+            // The hardware may need time to initialize.
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+
             CHECK_XRCMD(xrCreateSession(m_instance, &createInfo, &m_session));
         }
 


### PR DESCRIPTION
Would not work previously using Monado with the Oculus CV1.  There are some magic commands that need to be sent to the CV1 over USB to turn the display on and have X recognize it.  This delay allows the device to startup before hello_xr attempts to access it.  Before this addition, hello_xr would complain that no non-desktop display devices were found, and now it works out of the box with OpenHMD 0.3.0-rc1 and the master branch of Monado.