### PR TITLE
Simplify loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /build
+/build*
 CMakeLists.txt.user
 *.orig
 .*

--- a/src/api_layers/CMakeLists.txt
+++ b/src/api_layers/CMakeLists.txt
@@ -36,6 +36,8 @@ add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/api_layer_platform_defines
 # Basics for api_dump API Layer
 add_library(XrApiLayer_api_dump SHARED
     api_dump.cpp
+    ${CMAKE_SOURCE_DIR}/src/common/hex_and_handles.cpp
+    ${CMAKE_SOURCE_DIR}/src/common/hex_and_handles.h
     ${CMAKE_BINARY_DIR}/src/xr_generated_dispatch_table.c
     ${CMAKE_BINARY_DIR}/src/api_layers/xr_generated_api_dump.cpp
 )
@@ -62,6 +64,8 @@ endif()
 # Basics for core_validation API Layer
 add_library(XrApiLayer_core_validation SHARED
     core_validation.cpp
+    ${CMAKE_SOURCE_DIR}/src/common/hex_and_handles.cpp
+    ${CMAKE_SOURCE_DIR}/src/common/hex_and_handles.h
     ${CMAKE_BINARY_DIR}/src/xr_generated_dispatch_table.c 
     ${CMAKE_BINARY_DIR}/src/api_layers/xr_generated_core_validation.cpp
 )

--- a/src/api_layers/api_dump.cpp
+++ b/src/api_layers/api_dump.cpp
@@ -17,6 +17,8 @@
 // Author: Mark Young <marky@lunarg.com>
 //
 
+#define XR_UTILS_INCLUDE_IMPLEMENTATION
+
 #include <iostream>
 #include <fstream>
 #include <sstream>
@@ -31,6 +33,7 @@
 #include "xr_generated_dispatch_table.h"
 #include "loader_interfaces.h"
 #include "platform_utils.hpp"
+#include "xr_utils.h"
 
 #if defined(__GNUC__) && __GNUC__ >= 4
 #define LAYER_EXPORT __attribute__((visibility("default")))
@@ -460,9 +463,7 @@ XrResult ApiDumpLayerXrCreateApiLayerInstance(const XrInstanceCreateInfo *info, 
         // Generate output for this command as if it were the standard xrCreateInstance
         std::vector<std::tuple<std::string, std::string, std::string>> contents;
         contents.push_back(std::make_tuple("XrResult", "xrCreateInstance", ""));
-        std::ostringstream oss_info;
-        oss_info << std::hex << reinterpret_cast<const void *>(info);
-        contents.push_back(std::make_tuple("const XrInstanceCreateInfo*", "info", oss_info.str()));
+        contents.push_back(std::make_tuple("const XrInstanceCreateInfo*", "info", PointerToHexString(info)));
         if (nullptr != info) {
             std::string prefix = "info->";
             contents.push_back(std::make_tuple("XrStructureType", "info->type", std::to_string(info->type)));
@@ -527,11 +528,7 @@ XrResult ApiDumpLayerXrCreateApiLayerInstance(const XrInstanceCreateInfo *info, 
             }
         }
 
-        std::ostringstream oss_instance;
-        oss_instance << std::hex << reinterpret_cast<uintptr_t>(instance);
-        std::string hex_instance = "0x";
-        hex_instance += oss_instance.str();
-        contents.push_back(std::make_tuple("XrInstance*", "instance", hex_instance));
+        contents.push_back(std::make_tuple("XrInstance*", "instance", PointerToHexString(instance)));
         ApiDumpLayerRecordContent(contents);
 
         // Copy the contents of the layer info struct, but then move the next info up by
@@ -565,11 +562,7 @@ XrResult ApiDumpLayerXrDestroyInstance(XrInstance instance) {
     // Generate output for this command
     std::vector<std::tuple<std::string, std::string, std::string>> contents;
     contents.push_back(std::make_tuple("XrResult", "xrDestroyInstance", ""));
-    std::ostringstream oss_instance;
-    oss_instance << std::hex << reinterpret_cast<const void *>(instance);
-    std::string hex_instance = "0x";
-    hex_instance += oss_instance.str();
-    contents.push_back(std::make_tuple("XrInstance", "instance", hex_instance));
+    contents.push_back(std::make_tuple("XrInstance", "instance", HandleToHexString(instance)));
     ApiDumpLayerRecordContent(contents);
 
     std::unique_lock<std::mutex> mlock(g_instance_dispatch_mutex);

--- a/src/api_layers/api_dump.cpp
+++ b/src/api_layers/api_dump.cpp
@@ -17,8 +17,6 @@
 // Author: Mark Young <marky@lunarg.com>
 //
 
-#define XR_UTILS_INCLUDE_IMPLEMENTATION
-
 #include <iostream>
 #include <fstream>
 #include <sstream>
@@ -33,7 +31,7 @@
 #include "xr_generated_dispatch_table.h"
 #include "loader_interfaces.h"
 #include "platform_utils.hpp"
-#include "xr_utils.h"
+#include "hex_and_handles.h"
 
 #if defined(__GNUC__) && __GNUC__ >= 4
 #define LAYER_EXPORT __attribute__((visibility("default")))

--- a/src/api_layers/core_validation.cpp
+++ b/src/api_layers/core_validation.cpp
@@ -753,13 +753,10 @@ XrResult CoreValidationXrDestroyDebugUtilsMessengerEXT(XrDebugUtilsMessengerEXT 
             auto info_with_lock = g_debugutilsmessengerext_info.getWithLock(messenger);
             GenValidUsageXrHandleInfo *gen_handle_info = info_with_lock.second;
             if (nullptr != gen_handle_info) {
-                GenValidUsageXrInstanceInfo *gen_instance_info = gen_handle_info->instance_info;
-                for (uint32_t msg_index = 0; msg_index < gen_instance_info->debug_messengers.size(); ++msg_index) {
-                    if (gen_instance_info->debug_messengers[msg_index]->messenger == messenger) {
-                        gen_instance_info->debug_messengers.erase(gen_instance_info->debug_messengers.begin() + msg_index);
-                        break;
-                    }
-                }
+                auto &debug_messengers = gen_handle_info->instance_info->debug_messengers;
+                vector_remove_if_and_erase(
+                    debug_messengers, [=](UniqueCoreValidationMessengerInfo const &msg) { return msg->messenger == messenger; });
+
             } else {
                 return XR_ERROR_DEBUG_UTILS_MESSENGER_INVALID_EXT;
             }

--- a/src/api_layers/core_validation.cpp
+++ b/src/api_layers/core_validation.cpp
@@ -33,7 +33,7 @@
 #include "loader_interfaces.h"
 #include "platform_utils.hpp"
 #include "xr_generated_dispatch_table.h"
-#include "xr_utils.h"
+#include "hex_and_handles.h"
 
 #if defined(__GNUC__) && __GNUC__ >= 4
 #define LAYER_EXPORT __attribute__((visibility("default")))

--- a/src/api_layers/validation_utils.h
+++ b/src/api_layers/validation_utils.h
@@ -24,6 +24,7 @@
 
 #include "api_layer_platform_defines.h"
 #include "xr_utils.h"
+#include "extra_algorithms.h"
 
 #include <openxr/openxr.h>
 #include <openxr/openxr_platform.h>
@@ -193,21 +194,6 @@ class HandleInfo : public HandleInfoBase<HandleType, GenValidUsageXrHandleInfo> 
     /// Removes handles associated  with an instance.
     void removeHandlesForInstance(GenValidUsageXrInstanceInfo *search_value);
 };
-
-/// Like std::remove_if, except it works on associative containers and it actually removes this.
-///
-/// The iterator stuff in here is subtle - .erase() invalidates only that iterator, but it returns a non-invalidated iterator to the
-/// next valid element which we can use instead of incrementing.
-template <typename T, typename Pred>
-inline void map_erase_if(T &container, Pred &&predicate) {
-    for (auto it = container.begin(); it != container.end();) {
-        if (predicate(*it)) {
-            it = container.erase(it);
-        } else {
-            ++it;
-        }
-    }
-}
 
 /// Function to record all the core validation information
 void CoreValidLogMessage(GenValidUsageXrInstanceInfo *instance_info, const std::string &message_id,

--- a/src/api_layers/validation_utils.h
+++ b/src/api_layers/validation_utils.h
@@ -23,7 +23,7 @@
 #define VALIDATION_UTILS_H_ 1
 
 #include "api_layer_platform_defines.h"
-#include "xr_utils.h"
+#include "hex_and_handles.h"
 #include "extra_algorithms.h"
 
 #include <openxr/openxr.h>

--- a/src/api_layers/validation_utils.h
+++ b/src/api_layers/validation_utils.h
@@ -196,14 +196,13 @@ class HandleInfo : public HandleInfoBase<HandleType, GenValidUsageXrHandleInfo> 
 
 /// Like std::remove_if, except it works on associative containers and it actually removes this.
 ///
-/// The iterator stuff in here is subtle - .erase() invalidates only that iterator, so we must advance first.
+/// The iterator stuff in here is subtle - .erase() invalidates only that iterator, but it returns a non-invalidated iterator to the
+/// next valid element which we can use instead of incrementing.
 template <typename T, typename Pred>
 inline void map_erase_if(T &container, Pred &&predicate) {
     for (auto it = container.begin(); it != container.end();) {
         if (predicate(*it)) {
-            auto here = it;
-            ++it;
-            container.erase(here);
+            it = container.erase(it);
         } else {
             ++it;
         }

--- a/src/common/extra_algorithms.h
+++ b/src/common/extra_algorithms.h
@@ -1,0 +1,45 @@
+// Copyright (c) 2017-2019 The Khronos Group Inc.
+// Copyright (c) 2017-2019 Valve Corporation
+// Copyright (c) 2017-2019 LunarG, Inc.
+// Copyright (c) 2019 Collabora, Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: Ryan Pavlik <ryan.pavlik@collabora.com>
+//
+
+/*!
+ * @file
+ *
+ * Additional functions along the lines of the standard library algorithms.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <vector>
+
+/// Like std::remove_if, except it works on associative containers and it actually removes this.
+///
+/// The iterator stuff in here is subtle - .erase() invalidates only that iterator, but it returns a non-invalidated iterator to the
+/// next valid element which we can use instead of incrementing.
+template <typename T, typename Pred>
+static inline void map_erase_if(T &container, Pred &&predicate) {
+    for (auto it = container.begin(); it != container.end();) {
+        if (predicate(*it)) {
+            it = container.erase(it);
+        } else {
+            ++it;
+        }
+    }
+}

--- a/src/common/extra_algorithms.h
+++ b/src/common/extra_algorithms.h
@@ -43,3 +43,15 @@ static inline void map_erase_if(T &container, Pred &&predicate) {
         }
     }
 }
+
+/*!
+ * Moves all elements matching the predicate to the end of the vector then erases them.
+ *
+ * Combines the two parts of the erase-remove idiom to simplify things and avoid accidentally using the wrong erase overload.
+ */
+template <typename T, typename Alloc, typename Pred>
+static inline void vector_remove_if_and_erase(std::vector<T, Alloc> &vec, Pred &&predicate) {
+    auto b = vec.begin();
+    auto e = vec.end();
+    vec.erase(std::remove_if(b, e, std::forward<Pred>(predicate)), e);
+}

--- a/src/common/hex_and_handles.cpp
+++ b/src/common/hex_and_handles.cpp
@@ -1,0 +1,44 @@
+// Copyright (c) 2017-2019 The Khronos Group Inc.
+// Copyright (c) 2017-2019 Valve Corporation
+// Copyright (c) 2017-2019 LunarG, Inc.
+// Copyright (c) 2019 Collabora, Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: Ryan Pavlik <ryan.pavlik@collabora.com>
+//
+
+/*!
+ * @file
+ *
+ * Implementations of the include-requiring hex convesion functions.
+ */
+
+#include "hex_and_handles.h"
+
+#include <sstream>
+#include <iomanip>
+
+std::string Uint64ToHexString(uint64_t val) {
+    std::ostringstream oss;
+    oss << "0x";
+    oss << std::hex << std::setw(16) << std::setfill('0') << val;
+    return oss.str();
+}
+
+std::string Uint32ToHexString(uint32_t val) {
+    std::ostringstream oss;
+    oss << "0x";
+    oss << std::hex << std::setw(8) << std::setfill('0') << val;
+    return oss.str();
+}

--- a/src/common/hex_and_handles.h
+++ b/src/common/hex_and_handles.h
@@ -25,14 +25,7 @@
  *
  * Most are trivial and inlined by default, but a few involve some non-trivial standard headers:
  * the various `...ToHexString`functions.
- * If you want those, you have two ways of using this header:
- *
- * - Out-of-line implementation: Just include this header where you need it, then
- *   in one .cpp file, define XR_UTILS_INCLUDE_IMPLEMENTATION before you include it
- *   to compile the implementation in that file.
- * - Inline implementation: Increases the number of includes, but you don't have to
- *   worry about how many files have defined XR_UTILS_INCLUDE_IMPLEMENTATION.
- *   Define XR_UTILS_INLINE_IMPLEMENTATION in every file before including this.
+ * If you want those, make sure your build includes the corresponding hex_and_handles.cpp file.
  */
 
 #pragma once
@@ -40,10 +33,6 @@
 #include <openxr/openxr.h>
 
 #include <string>
-
-#if defined(XR_UTILS_INLINE_IMPLEMENTATION) && defined(XR_UTILS_INCLUDE_IMPLEMENTATION)
-#error "Cannot define both XR_UTILS_INLINE_IMPLEMENTATION and XR_UTILS_INCLUDE_IMPLEMENTATION"
-#endif
 
 #if XR_PTR_SIZE == 8
 /// Convert a handle into a same-sized integer.
@@ -89,19 +78,13 @@ static inline bool IsIntegerNullHandle(uint64_t handle) { return XR_NULL_HANDLE 
 
 #endif
 
-#ifdef XR_UTILS_INLINE_IMPLEMENTATION
-#define XR_UTILS_STATIC_INLINE static inline
-#else
-#define XR_UTILS_STATIC_INLINE
-#endif
-
 /// Turns a uint64_t into a string formatted as hex.
 ///
 /// The core of the HandleToHexString implementation is in here.
-XR_UTILS_STATIC_INLINE std::string Uint64ToHexString(uint64_t val);
+std::string Uint64ToHexString(uint64_t val);
 
 /// Turns a uint32_t into a string formatted as hex.
-XR_UTILS_STATIC_INLINE std::string Uint32ToHexString(uint32_t val);
+std::string Uint32ToHexString(uint32_t val);
 
 /// Turns an OpenXR handle into a string formatted as hex.
 template <typename T>
@@ -122,25 +105,3 @@ template <typename T>
 static inline std::string PointerToHexString(T const* ptr) {
     return UintptrToHexString(reinterpret_cast<uintptr_t>(ptr));
 }
-
-// Define this only once in your project, in a non-header-file, to include the implementation.
-#if defined(XR_UTILS_INCLUDE_IMPLEMENTATION) || defined(XR_UTILS_INLINE_IMPLEMENTATION)
-
-#include <sstream>
-#include <iomanip>
-
-XR_UTILS_STATIC_INLINE std::string Uint64ToHexString(uint64_t val) {
-    std::ostringstream oss;
-    oss << "0x";
-    oss << std::hex << std::setw(16) << std::setfill('0') << val;
-    return oss.str();
-}
-
-XR_UTILS_STATIC_INLINE std::string Uint32ToHexString(uint32_t val) {
-    std::ostringstream oss;
-    oss << "0x";
-    oss << std::hex << std::setw(8) << std::setfill('0') << val;
-    return oss.str();
-}
-
-#endif  // defined(XR_UTILS_INCLUDE_IMPLEMENTATION) || defined(XR_UTILS_INLINE_IMPLEMENTATION)

--- a/src/common/xr_utils.h
+++ b/src/common/xr_utils.h
@@ -1,0 +1,146 @@
+// Copyright (c) 2017-2019 The Khronos Group Inc.
+// Copyright (c) 2017-2019 Valve Corporation
+// Copyright (c) 2017-2019 LunarG, Inc.
+// Copyright (c) 2019 Collabora, Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: Ryan Pavlik <ryan.pavlik@collabora.com>
+//
+
+/*!
+ * @file
+ *
+ * Some utilities, primarily for working with OpenXR handles in a generic way.
+ *
+ * Most are trivial and inlined by default, but a few involve some non-trivial standard headers:
+ * the various `...ToHexString`functions.
+ * If you want those, you have two ways of using this header:
+ *
+ * - Out-of-line implementation: Just include this header where you need it, then
+ *   in one .cpp file, define XR_UTILS_INCLUDE_IMPLEMENTATION before you include it
+ *   to compile the implementation in that file.
+ * - Inline implementation: Increases the number of includes, but you don't have to
+ *   worry about how many files have defined XR_UTILS_INCLUDE_IMPLEMENTATION.
+ *   Define XR_UTILS_INLINE_IMPLEMENTATION in every file before including this.
+ */
+
+#pragma once
+
+#include <openxr/openxr.h>
+
+#include <string>
+
+#if defined(XR_UTILS_INLINE_IMPLEMENTATION) && defined(XR_UTILS_INCLUDE_IMPLEMENTATION)
+#error "Cannot define both XR_UTILS_INLINE_IMPLEMENTATION and XR_UTILS_INCLUDE_IMPLEMENTATION"
+#endif
+
+#if XR_PTR_SIZE == 8
+/// Convert a handle into a same-sized integer.
+template <typename T>
+static inline uint64_t MakeHandleGeneric(T handle) {
+    return reinterpret_cast<uint64_t>(handle);
+}
+
+/// Treat an integer as a handle
+template <typename T>
+static inline T& TreatIntegerAsHandle(uint64_t& handle) {
+    return reinterpret_cast<T&>(handle);
+}
+
+/// @overload
+template <typename T>
+static inline T const& TreatIntegerAsHandle(uint64_t const& handle) {
+    return reinterpret_cast<T const&>(handle);
+}
+
+/// Does a correctly-sized integer represent a null handle?
+static inline bool IsIntegerNullHandle(uint64_t handle) { return XR_NULL_HANDLE == reinterpret_cast<void*>(handle); }
+
+#else
+
+/// Convert a handle into a same-sized integer: no-op on 32-bit systems
+static inline uint64_t MakeHandleGeneric(uint64_t handle) { return handle; }
+
+/// Treat an integer as a handle: no-op on 32-bit systems
+template <typename T>
+static inline T& TreatIntegerAsHandle(uint64_t& handle) {
+    return handle;
+}
+
+/// @overload
+template <typename T>
+static inline T const& TreatIntegerAsHandle(uint64_t const& handle) {
+    return handle;
+}
+
+/// Does a correctly-sized integer represent a null handle?
+static inline bool IsIntegerNullHandle(uint64_t handle) { return XR_NULL_HANDLE == handle; }
+
+#endif
+
+#ifdef XR_UTILS_INLINE_IMPLEMENTATION
+#define XR_UTILS_STATIC_INLINE static inline
+#else
+#define XR_UTILS_STATIC_INLINE
+#endif
+
+/// Turns a uint64_t into a string formatted as hex.
+///
+/// The core of the HandleToHexString implementation is in here.
+XR_UTILS_STATIC_INLINE std::string Uint64ToHexString(uint64_t val);
+
+/// Turns a uint32_t into a string formatted as hex.
+XR_UTILS_STATIC_INLINE std::string Uint32ToHexString(uint32_t val);
+
+/// Turns an OpenXR handle into a string formatted as hex.
+template <typename T>
+static inline std::string HandleToHexString(T handle) {
+    return Uint64ToHexString(MakeHandleGeneric(handle));
+}
+
+#if XR_PTR_SIZE == 8
+/// Turns a pointer-sized integer into a string formatted as hex.
+static inline std::string UintptrToHexString(uintptr_t val) { return Uint64ToHexString(val); }
+#else
+/// Turns a pointer-sized integer into a string formatted as hex.
+static inline std::string UintptrToHexString(uintptr_t val) { return Uint32ToHexString(val); }
+#endif
+
+/// Convert a pointer to a string formatted as hex.
+template <typename T>
+static inline std::string PointerToHexString(T const* ptr) {
+    return UintptrToHexString(reinterpret_cast<uintptr_t>(ptr));
+}
+
+// Define this only once in your project, in a non-header-file, to include the implementation.
+#if defined(XR_UTILS_INCLUDE_IMPLEMENTATION) || defined(XR_UTILS_INLINE_IMPLEMENTATION)
+
+#include <sstream>
+#include <iomanip>
+
+XR_UTILS_STATIC_INLINE std::string Uint64ToHexString(uint64_t val) {
+    std::ostringstream oss;
+    oss << "0x";
+    oss << std::hex << std::setw(16) << std::setfill('0') << val;
+    return oss.str();
+}
+
+XR_UTILS_STATIC_INLINE std::string Uint32ToHexString(uint32_t val) {
+    std::ostringstream oss;
+    oss << "0x";
+    oss << std::hex << std::setw(8) << std::setfill('0') << val;
+    return oss.str();
+}
+
+#endif  // defined(XR_UTILS_INCLUDE_IMPLEMENTATION) || defined(XR_UTILS_INLINE_IMPLEMENTATION)

--- a/src/loader/CMakeLists.txt
+++ b/src/loader/CMakeLists.txt
@@ -46,34 +46,34 @@ SET(LOADER_EXTERNAL_GEN_FILES
     ${CMAKE_BINARY_DIR}/src/xr_generated_dispatch_table.c
     ${CMAKE_BINARY_DIR}/src/xr_generated_utilities.c
 )
+run_xr_xml_generate(loader_source_generator.py xr_generated_loader.hpp)
+run_xr_xml_generate(loader_source_generator.py xr_generated_loader.cpp)
 
 if(DYNAMIC_LOADER)
     add_definitions(-DXRAPI_DLL_EXPORT)
-	add_library(${LOADER_NAME} SHARED
-		api_layer_interface.cpp
-		loader_core.cpp
-		loader_instance.cpp
-		loader_logger.cpp
-		manifest_file.cpp
-		runtime_interface.cpp
-		${CMAKE_SOURCE_DIR}/src/common/filesystem_utils.cpp
-		${LOADER_EXTERNAL_GEN_FILES}
-		${openxr_loader_RESOURCE_FILE}
-#		${openxr_loader_EXPORTS_FILE}
-	)
+    set(LIBRARY_TYPE SHARED)
 else() # build static lib
-	add_library(${LOADER_NAME} STATIC
-		api_layer_interface.cpp
-		loader_core.cpp
-		loader_instance.cpp
-		loader_logger.cpp
-		manifest_file.cpp
-		runtime_interface.cpp
-		${CMAKE_SOURCE_DIR}/src/common/filesystem_utils.cpp
-		${LOADER_EXTERNAL_GEN_FILES}
-		${openxr_loader_RESOURCE_FILE}
-	)
+    set(LIBRARY_TYPE STATIC)
 endif()
+
+add_library(${LOADER_NAME} ${LIBRARY_TYPE}
+    api_layer_interface.cpp
+    api_layer_interface.hpp
+    loader_core.cpp
+    loader_instance.cpp
+    loader_instance.hpp
+    loader_logger.cpp
+    loader_logger.hpp
+    manifest_file.cpp
+    manifest_file.hpp
+    runtime_interface.cpp
+    runtime_interface.hpp
+    ${CMAKE_CURRENT_BINARY_DIR}/xr_generated_loader.hpp
+    ${CMAKE_CURRENT_BINARY_DIR}/xr_generated_loader.cpp
+    ${CMAKE_SOURCE_DIR}/src/common/filesystem_utils.cpp
+    ${LOADER_EXTERNAL_GEN_FILES}
+    ${openxr_loader_RESOURCE_FILE}
+)
 set_source_files_properties(
     ${LOADER_EXTERNAL_GEN_FILES}
     PROPERTIES GENERATED TRUE
@@ -81,7 +81,6 @@ set_source_files_properties(
 add_dependencies(${LOADER_NAME}
     generate_openxr_header
     xr_global_generated_files
-    loader_gen_files
     jsoncppAmalgamatedFiles
 )
 target_include_directories(${LOADER_NAME}
@@ -175,13 +174,4 @@ endif()
 
 install(TARGETS ${LOADER_NAME} DESTINATION lib)
 
-# Custom target for generated helper sources
-add_custom_target(loader_gen_files
-    DEPENDS
-        xr_generated_loader.hpp
-        xr_generated_loader.cpp
-)
-
 # Custom commands to build dependencies for above targets
-run_xr_xml_generate(utility_source_generator.py xr_generated_loader.hpp)
-run_xr_xml_generate(utility_source_generator.py xr_generated_loader.cpp)

--- a/src/loader/CMakeLists.txt
+++ b/src/loader/CMakeLists.txt
@@ -74,7 +74,8 @@ add_library(${LOADER_NAME} ${LIBRARY_TYPE}
     ${CMAKE_CURRENT_BINARY_DIR}/xr_generated_loader.cpp
     ${CMAKE_SOURCE_DIR}/src/common/filesystem_utils.cpp
     ${CMAKE_SOURCE_DIR}/src/common/filesystem_utils.hpp
-    ${CMAKE_SOURCE_DIR}/src/common/xr_utils.h
+    ${CMAKE_SOURCE_DIR}/src/common/hex_and_handles.cpp
+    ${CMAKE_SOURCE_DIR}/src/common/hex_and_handles.h
     ${LOADER_EXTERNAL_GEN_FILES}
     ${openxr_loader_RESOURCE_FILE}
 )

--- a/src/loader/CMakeLists.txt
+++ b/src/loader/CMakeLists.txt
@@ -64,6 +64,8 @@ add_library(${LOADER_NAME} ${LIBRARY_TYPE}
     loader_instance.hpp
     loader_logger.cpp
     loader_logger.hpp
+    loader_logger_recorders.cpp
+    loader_logger_recorders.hpp
     manifest_file.cpp
     manifest_file.hpp
     runtime_interface.cpp

--- a/src/loader/CMakeLists.txt
+++ b/src/loader/CMakeLists.txt
@@ -73,6 +73,8 @@ add_library(${LOADER_NAME} ${LIBRARY_TYPE}
     ${CMAKE_CURRENT_BINARY_DIR}/xr_generated_loader.hpp
     ${CMAKE_CURRENT_BINARY_DIR}/xr_generated_loader.cpp
     ${CMAKE_SOURCE_DIR}/src/common/filesystem_utils.cpp
+    ${CMAKE_SOURCE_DIR}/src/common/filesystem_utils.hpp
+    ${CMAKE_SOURCE_DIR}/src/common/xr_utils.h
     ${LOADER_EXTERNAL_GEN_FILES}
     ${openxr_loader_RESOURCE_FILE}
 )

--- a/src/loader/api_layer_interface.cpp
+++ b/src/loader/api_layer_interface.cpp
@@ -313,24 +313,21 @@ XrResult ApiLayerInterface::LoadApiLayers(const std::string& openxr_command, uin
                 if (!any_loaded) {
                     last_error = res;
                 }
-                std::string warning_message = "ApiLayerInterface::LoadApiLayers skipping layer ";
-                warning_message += manifest_file->LayerName();
-                warning_message += " due to failed negotiation with error ";
-                warning_message += std::to_string(res);
-                LoaderLogger::LogWarningMessage(openxr_command, warning_message);
+                std::ostringstream oss;
+                oss << "ApiLayerInterface::LoadApiLayers skipping layer " << manifest_file->LayerName()
+                    << " due to failed negotiation with error " << res;
+                LoaderLogger::LogWarningMessage(openxr_command, oss.str());
                 LoaderPlatformLibraryClose(layer_library);
                 continue;
             }
 
-            std::string info_message = "ApiLayerInterface::LoadApiLayers succeeded loading layer ";
-            info_message += manifest_file->LayerName();
-            info_message += " using interface version ";
-            info_message += std::to_string(api_layer_info.layerInterfaceVersion);
-            info_message += " and OpenXR API version ";
-            info_message += std::to_string(XR_VERSION_MAJOR(api_layer_info.layerXrVersion));
-            info_message += ".";
-            info_message += std::to_string(XR_VERSION_MINOR(api_layer_info.layerXrVersion));
-            LoaderLogger::LogInfoMessage(openxr_command, info_message);
+            {
+                std::ostringstream oss;
+                oss << "ApiLayerInterface::LoadApiLayers succeeded loading layer " << manifest_file->LayerName()
+                    << " using interface version " << api_layer_info.layerInterfaceVersion << " and OpenXR API version "
+                    << XR_VERSION_MAJOR(api_layer_info.layerXrVersion) << "." << XR_VERSION_MINOR(api_layer_info.layerXrVersion);
+                LoaderLogger::LogInfoMessage(openxr_command, oss.str());
+            }
 
             // Grab the list of extensions this layer supports for easy filtering after the
             // xrCreateInstance call

--- a/src/loader/loader_core.cpp
+++ b/src/loader/loader_core.cpp
@@ -503,7 +503,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrDestroyDebugUtilsMessengerEXT(XrDebugUtilsMesse
         LoaderLogger::LogErrorMessage(
             "xrDestroyDebugUtilsMessengerEXT",
             "xrDestroyDebugUtilsMessengerEXT trampoline encountered an unknown error.  Likely XrDebugUtilsMessengerEXT " +
-                HandleToString(messenger) + " is invalid");
+                HandleToHexString(messenger) + " is invalid");
         return XR_ERROR_HANDLE_INVALID;
     }
 }
@@ -556,16 +556,16 @@ XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermDestroyDebugUtilsMessengerEXT(XrDebug
             result = dispatch_table->DestroyDebugUtilsMessengerEXT(messenger);
         } else {
             // Delete the character we would've created
-            delete (reinterpret_cast<char *>(reinterpret_cast<uint64_t &>(messenger)));
+            delete (reinterpret_cast<char *>(MakeHandleGeneric(messenger)));
         }
         LoaderLogger::LogVerboseMessage("xrDestroyDebugUtilsMessengerEXT", "Completed loader terminator");
-        LoaderLogger::GetInstance().RemoveLogRecorder(reinterpret_cast<uint64_t &>(messenger));
+        LoaderLogger::GetInstance().RemoveLogRecorder(MakeHandleGeneric(messenger));
         RuntimeInterface::GetRuntime().ForgetDebugMessenger(messenger);
         return result;
     } catch (...) {
         LoaderLogger::LogErrorMessage("xrDestroyDebugUtilsMessengerEXT",
                                       "Terminator encountered an unknown error.  Likely XrDebugUtilsMessengerEXT " +
-                                          HandleToString(messenger) + " is invalid");
+                                          HandleToHexString(messenger) + " is invalid");
         return XR_ERROR_DEBUG_UTILS_MESSENGER_INVALID_EXT;
     }
 }
@@ -590,7 +590,7 @@ XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermSubmitDebugUtilsMessageEXT(XrInstance
     } catch (...) {
         LoaderLogger::LogErrorMessage("xrSubmitDebugUtilsMessageEXT",
                                       "xrSubmitDebugUtilsMessageEXT terminator encountered an unknown error.  Likely XrInstance " +
-                                          HandleToString(instance) + " is invalid");
+                                          HandleToHexString(instance) + " is invalid");
         return XR_ERROR_HANDLE_INVALID;
     }
 }
@@ -610,7 +610,7 @@ XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermSetDebugUtilsObjectNameEXT(XrInstance
     } catch (...) {
         LoaderLogger::LogErrorMessage("xrSetDebugUtilsObjectNameEXT",
                                       "xrSetDebugUtilsObjectNameEXT terminator encountered an unknown error.  Likely XrInstance " +
-                                          HandleToString(instance) + "is invalid");
+                                          HandleToHexString(instance) + "is invalid");
         return XR_ERROR_HANDLE_INVALID;
     }
 }

--- a/src/loader/loader_core.cpp
+++ b/src/loader/loader_core.cpp
@@ -214,15 +214,10 @@ LOADER_EXPORT XRAPI_ATTR XrResult XRAPI_CALL xrCreateInstance(const XrInstanceCr
             uint16_t loader_major = XR_VERSION_MAJOR(XR_CURRENT_API_VERSION);
             uint16_t loader_minor = XR_VERSION_MINOR(XR_CURRENT_API_VERSION);
             if (app_major > loader_major || (app_major == loader_major && app_minor > loader_minor)) {
-                std::string error_message = "xrCreateInstance called with invalid API version ";
-                error_message += std::to_string(app_major);
-                error_message += ".";
-                error_message += std::to_string(app_minor);
-                error_message += ".  Max supported version is ";
-                error_message += std::to_string(loader_major);
-                error_message += ".";
-                error_message += std::to_string(loader_minor);
-                LoaderLogger::LogErrorMessage("xrCreateInstance", error_message);
+                std::ostringstream oss;
+                oss << "xrCreateInstance called with invalid API version " << app_major << "." << app_minor
+                    << ".  Max supported version is " << loader_major << "." << loader_minor;
+                LoaderLogger::LogErrorMessage("xrCreateInstance", oss.str());
                 return XR_ERROR_DRIVER_INCOMPATIBLE;
             }
         }

--- a/src/loader/loader_core.cpp
+++ b/src/loader/loader_core.cpp
@@ -25,6 +25,7 @@
 #include <string>
 #include <mutex>
 #include <memory>
+#include <sstream>
 
 #include "xr_dependencies.h"
 #include <openxr/openxr.h>

--- a/src/loader/loader_core.cpp
+++ b/src/loader/loader_core.cpp
@@ -154,9 +154,8 @@ LOADER_EXPORT XRAPI_ATTR XrResult XRAPI_CALL xrEnumerateInstanceExtensionPropert
         } else if (nullptr != properties) {
             if (propertyCapacityInput < num_extension_properties) {
                 *propertyCountOutput = num_extension_properties;
-                LoaderLogger::LogErrorMessage(
-                    "xrEnumerateInstanceExtensionProperties",
-                    "VUID-xrEnumerateInstanceExtensionProperties-propertyCountOutput-parameter: insufficient space in array");
+                LoaderLogger::LogValidationErrorMessage("VUID-xrEnumerateInstanceExtensionProperties-propertyCountOutput-parameter",
+                                                        "xrEnumerateInstanceExtensionProperties", "insufficient space in array");
                 return XR_ERROR_SIZE_INSUFFICIENT;
             }
 
@@ -169,12 +168,12 @@ LOADER_EXPORT XRAPI_ATTR XrResult XRAPI_CALL xrEnumerateInstanceExtensionPropert
             for (uint32_t prop = 0; prop < propertyCapacityInput && prop < extension_properties.size(); ++prop) {
                 if (XR_TYPE_EXTENSION_PROPERTIES != properties[prop].type) {
                     properties_valid = false;
-                    LoaderLogger::LogErrorMessage("xrEnumerateInstanceExtensionProperties",
-                                                  "VUID-XrExtensionProperties-type-type: unknown type in properties");
+                    LoaderLogger::LogValidationErrorMessage("VUID-XrExtensionProperties-type-type",
+                                                            "xrEnumerateInstanceExtensionProperties", "unknown type in properties");
                 }
                 if (nullptr != properties[prop].next) {
-                    LoaderLogger::LogErrorMessage("xrEnumerateInstanceExtensionProperties",
-                                                  "VUID-XrExtensionProperties-next-next: expected NULL");
+                    LoaderLogger::LogValidationErrorMessage("VUID-XrExtensionProperties-next-next",
+                                                            "xrEnumerateInstanceExtensionProperties", "expected NULL");
                     properties_valid = false;
                 }
                 if (properties_valid) {
@@ -182,9 +181,8 @@ LOADER_EXPORT XRAPI_ATTR XrResult XRAPI_CALL xrEnumerateInstanceExtensionPropert
                 }
             }
             if (!properties_valid) {
-                LoaderLogger::LogErrorMessage(
-                    "xrEnumerateInstanceExtensionProperties",
-                    "VUID-xrEnumerateInstanceExtensionProperties-properties-parameter: invalid properties");
+                LoaderLogger::LogValidationErrorMessage("VUID-xrEnumerateInstanceExtensionProperties-properties-parameter",
+                                                        "xrEnumerateInstanceExtensionProperties", "invalid properties");
                 return XR_ERROR_VALIDATION_FAILURE;
             } else if (nullptr != propertyCountOutput) {
                 *propertyCountOutput = num_to_copy;
@@ -204,7 +202,7 @@ LOADER_EXPORT XRAPI_ATTR XrResult XRAPI_CALL xrCreateInstance(const XrInstanceCr
     try {
         LoaderLogger::LogVerboseMessage("xrCreateInstance", "Entering loader trampoline");
         if (nullptr == info) {
-            LoaderLogger::LogErrorMessage("xrCreateInstance", "VUID-xrCreateInstance-info-parameter: must be non-NULL");
+            LoaderLogger::LogValidationErrorMessage("VUID-xrCreateInstance-info-parameter", "xrCreateInstance", "must be non-NULL");
             return XR_ERROR_VALIDATION_FAILURE;
         } else {
             // If application requested OpenXR API version is higher than the loader version, then we need to throw
@@ -222,8 +220,9 @@ LOADER_EXPORT XRAPI_ATTR XrResult XRAPI_CALL xrCreateInstance(const XrInstanceCr
             }
         }
         if (nullptr == instance) {
-            LoaderLogger::LogErrorMessage("xrCreateInstance", "VUID-xrCreateInstance-instance-parameter: must be non-NULL");
-            return XR_ERROR_HANDLE_INVALID;
+            LoaderLogger::LogValidationErrorMessage("VUID-xrCreateInstance-instance-parameter", "xrCreateInstance",
+                                                    "must be non-NULL");
+            return XR_ERROR_VALIDATION_FAILURE;
         }
 
         std::vector<std::unique_ptr<ApiLayerInterface>> api_layer_interfaces;
@@ -311,7 +310,8 @@ LOADER_EXPORT XRAPI_ATTR XrResult XRAPI_CALL xrDestroyInstance(XrInstance instan
 
         LoaderInstance *const loader_instance = g_instance_map.Get(instance);
         if (loader_instance == nullptr) {
-            LoaderLogger::LogErrorMessage("xrDestroyInstance", "VUID-xrDestroyInstance-instance-parameter: invalid instance");
+            LoaderLogger::LogValidationErrorMessage("VUID-xrDestroyInstance-instance-parameter", "xrDestroyInstance",
+                                                    "invalid instance");
             return XR_ERROR_HANDLE_INVALID;
         }
 
@@ -350,13 +350,13 @@ LOADER_EXPORT XRAPI_ATTR XrResult XRAPI_CALL xrDestroyInstance(XrInstance instan
 // Validate that the applicationInfo structure in the XrInstanceCreateInfo is valid.
 static bool ValidateApplicationInfo(LoaderInstance *loader_instance, const XrApplicationInfo &info) {
     if (IsMissingNullTerminator<XR_MAX_APPLICATION_NAME_SIZE>(info.applicationName)) {
-        LoaderLogger::LogErrorMessage(
-            "xrCreateInstance", "VUID-XrApplicationInfo-applicationName-parameter: application name missing NULL terminator.");
+        LoaderLogger::LogValidationErrorMessage("VUID-XrApplicationInfo-applicationName-parameter", "xrCreateInstance",
+                                                "application name missing NULL terminator.");
         return false;
     }
     if (IsMissingNullTerminator<XR_MAX_ENGINE_NAME_SIZE>(info.engineName)) {
-        LoaderLogger::LogErrorMessage("xrCreateInstance",
-                                      "VUID-XrApplicationInfo-engineName-parameter: engine name missing NULL terminator.");
+        LoaderLogger::LogValidationErrorMessage("VUID-XrApplicationInfo-engineName-parameter", "xrCreateInstance",
+                                                "engine name missing NULL terminator.");
         return false;
     }
     return true;
@@ -366,26 +366,26 @@ static bool ValidateApplicationInfo(LoaderInstance *loader_instance, const XrApp
 static bool ValidateInstanceCreateInfo(LoaderInstance *loader_instance, const XrInstanceCreateInfo *info) {
     // Should have a valid 'type'
     if (XR_TYPE_INSTANCE_CREATE_INFO != info->type) {
-        LoaderLogger::LogErrorMessage("xrCreateInstance",
-                                      "VUID-XrInstanceCreateInfo-type-type: expected XR_TYPE_INSTANCE_CREATE_INFO.");
+        LoaderLogger::LogValidationErrorMessage("VUID-XrInstanceCreateInfo-type-type", "xrCreateInstance",
+                                                "expected XR_TYPE_INSTANCE_CREATE_INFO.");
         return false;
     }
     // Flags must be 0
     if (0 != info->createFlags) {
-        LoaderLogger::LogErrorMessage("xrCreateInstance", "VUID-XrInstanceCreateInfo-createFlags-zerobitmask: flags must be 0.");
+        LoaderLogger::LogValidationErrorMessage("VUID-XrInstanceCreateInfo-createFlags-zerobitmask", "xrCreateInstance",
+                                                "flags must be 0.");
         return false;
     }
     // ApplicationInfo struct must be valid
     if (!ValidateApplicationInfo(loader_instance, info->applicationInfo)) {
-        LoaderLogger::LogErrorMessage("xrCreateInstance",
-                                      "VUID-XrInstanceCreateInfo-applicationInfo-parameter: info->applicationInfo is not valid.");
+        LoaderLogger::LogValidationErrorMessage("VUID-XrInstanceCreateInfo-applicationInfo-parameter", "xrCreateInstance",
+                                                "info->applicationInfo is not valid.");
         return false;
     }
     // VUID-XrInstanceCreateInfo-enabledApiLayerNames-parameter already tested in LoadApiLayers()
     if (info->enabledExtensionCount && nullptr == info->enabledExtensionNames) {
-        LoaderLogger::LogErrorMessage(
-            "xrCreateInstance",
-            "VUID-XrInstanceCreateInfo-enabledExtensionNames-parameter: enabledExtensionCount is non-0 but array is NULL");
+        LoaderLogger::LogValidationErrorMessage("VUID-XrInstanceCreateInfo-enabledExtensionNames-parameter", "xrCreateInstance",
+                                                "enabledExtensionCount is non-0 but array is NULL");
         return false;
     }
     return true;
@@ -395,8 +395,8 @@ XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermCreateInstance(const XrInstanceCreate
     LoaderLogger::LogVerboseMessage("xrCreateInstance", "Entering loader terminator");
     LoaderInstance *loader_instance = reinterpret_cast<LoaderInstance *>(*instance);
     if (!ValidateInstanceCreateInfo(loader_instance, info)) {
-        LoaderLogger::LogErrorMessage("xrCreateInstance",
-                                      "VUID-xrCreateInstance-info-parameter: something wrong with XrInstanceCreateInfo contents");
+        LoaderLogger::LogValidationErrorMessage("VUID-xrCreateInstance-info-parameter", "xrCreateInstance",
+                                                "something wrong with XrInstanceCreateInfo contents");
         return XR_ERROR_VALIDATION_FAILURE;
     }
     XrResult result = RuntimeInterface::GetRuntime().CreateInstance(info, instance);
@@ -429,8 +429,8 @@ XRAPI_ATTR XrResult XRAPI_CALL xrCreateDebugUtilsMessengerEXT(XrInstance instanc
 
         LoaderInstance *loader_instance = g_instance_map.Get(instance);
         if (loader_instance == nullptr) {
-            LoaderLogger::LogErrorMessage("xrCreateDebugUtilsMessengerEXT",
-                                          "VUID-xrCreateDebugUtilsMessengerEXT-instance-parameter: invalid instance");
+            LoaderLogger::LogValidationErrorMessage("VUID-xrCreateDebugUtilsMessengerEXT-instance-parameter",
+                                                    "xrCreateDebugUtilsMessengerEXT", "invalid instance");
             return XR_ERROR_HANDLE_INVALID;
         }
 
@@ -479,8 +479,8 @@ XRAPI_ATTR XrResult XRAPI_CALL xrDestroyDebugUtilsMessengerEXT(XrDebugUtilsMesse
 
         LoaderInstance *loader_instance = g_debugutilsmessengerext_map.Get(messenger);
         if (loader_instance == nullptr) {
-            LoaderLogger::LogErrorMessage("xrDestroyDebugUtilsMessengerEXT",
-                                          "VUID-xrDestroyDebugUtilsMessengerEXT-messenger-parameter: invalid messenger");
+            LoaderLogger::LogValidationErrorMessage("VUID-xrDestroyDebugUtilsMessengerEXT-messenger-parameter",
+                                                    "xrDestroyDebugUtilsMessengerEXT", "invalid messenger");
 
             return XR_ERROR_DEBUG_UTILS_MESSENGER_INVALID_EXT;
         }
@@ -515,8 +515,8 @@ XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermCreateDebugUtilsMessengerEXT(XrInstan
     try {
         LoaderLogger::LogVerboseMessage("xrCreateDebugUtilsMessengerEXT", "Entering loader terminator");
         if (nullptr == messenger) {
-            LoaderLogger::LogErrorMessage("xrCreateDebugUtilsMessengerEXT",
-                                          "VUID-xrCreateDebugUtilsMessengerEXT-messenger-parameter: invalid messenger pointer");
+            LoaderLogger::LogValidationErrorMessage("VUID-xrCreateDebugUtilsMessengerEXT-messenger-parameter",
+                                                    "xrCreateDebugUtilsMessengerEXT", "invalid messenger pointer");
             return XR_ERROR_VALIDATION_FAILURE;
         }
         const XrGeneratedDispatchTable *dispatch_table = RuntimeInterface::GetRuntime().GetDispatchTable(instance);

--- a/src/loader/loader_core.cpp
+++ b/src/loader/loader_core.cpp
@@ -655,26 +655,21 @@ XRAPI_ATTR XrResult XRAPI_CALL xrSessionBeginDebugUtilsLabelRegionEXT(XrSession 
             loader_instance = map_iter->second;
         }
 
-        std::vector<XrLoaderLogObjectInfo> loader_objects;
-        XrLoaderLogObjectInfo object_info = {};
-        object_info.type = XR_OBJECT_TYPE_SESSION;
-        object_info.handle = reinterpret_cast<uint64_t &>(session);
-        loader_objects.push_back(object_info);
         if (nullptr == loader_instance) {
             LoaderLogger::LogValidationErrorMessage("VUID-xrSessionBeginDebugUtilsLabelRegionEXT-session-parameter",
                                                     "xrSessionBeginDebugUtilsLabelRegionEXT", "session is not a valid XrSession",
-                                                    loader_objects);
+                                                    {XrLoaderLogObjectInfo{session, XR_OBJECT_TYPE_SESSION}});
             return XR_ERROR_HANDLE_INVALID;
         }
         if (!loader_instance->ExtensionIsEnabled(XR_EXT_DEBUG_UTILS_EXTENSION_NAME)) {
             LoaderLogger::LogValidationErrorMessage("TBD", "xrSessionBeginDebugUtilsLabelRegionEXT",
                                                     "Extension entrypoint called without enabling appropriate extension",
-                                                    loader_objects);
+                                                    {XrLoaderLogObjectInfo{session, XR_OBJECT_TYPE_SESSION}});
             return XR_ERROR_FUNCTION_UNSUPPORTED;
         } else if (nullptr == labelInfo) {
             LoaderLogger::LogValidationErrorMessage("VUID-xrSessionBeginDebugUtilsLabelRegionEXT-labelInfo-parameter",
                                                     "xrSessionBeginDebugUtilsLabelRegionEXT", "labelInfo must be non-NULL",
-                                                    loader_objects);
+                                                    {XrLoaderLogObjectInfo{session, XR_OBJECT_TYPE_SESSION}});
             return XR_ERROR_VALIDATION_FAILURE;
         }
 
@@ -704,14 +699,9 @@ XRAPI_ATTR XrResult XRAPI_CALL xrSessionEndDebugUtilsLabelRegionEXT(XrSession se
         }
 
         if (nullptr == loader_instance) {
-            XrLoaderLogObjectInfo bad_object = {};
-            bad_object.type = XR_OBJECT_TYPE_SESSION;
-            bad_object.handle = reinterpret_cast<uint64_t &>(session);
-            std::vector<XrLoaderLogObjectInfo> loader_objects;
-            loader_objects.push_back(bad_object);
             LoaderLogger::LogValidationErrorMessage("VUID-xrSessionEndDebugUtilsLabelRegionEXT-session-parameter",
                                                     "xrSessionEndDebugUtilsLabelRegionEXT", "session is not a valid XrSession",
-                                                    loader_objects);
+                                                    {XrLoaderLogObjectInfo{session, XR_OBJECT_TYPE_SESSION}});
             return XR_ERROR_HANDLE_INVALID;
         } else if (!loader_instance->ExtensionIsEnabled(XR_EXT_DEBUG_UTILS_EXTENSION_NAME)) {
             return XR_ERROR_FUNCTION_UNSUPPORTED;
@@ -741,26 +731,21 @@ XRAPI_ATTR XrResult XRAPI_CALL xrSessionInsertDebugUtilsLabelEXT(XrSession sessi
             loader_instance = map_iter->second;
         }
 
-        XrLoaderLogObjectInfo object_info = {};
-        object_info.type = XR_OBJECT_TYPE_SESSION;
-        object_info.handle = reinterpret_cast<uint64_t &>(session);
-        std::vector<XrLoaderLogObjectInfo> loader_objects;
-        loader_objects.push_back(object_info);
         if (nullptr == loader_instance) {
             LoaderLogger::LogValidationErrorMessage("VUID-xrSessionInsertDebugUtilsLabelEXT-session-parameter",
                                                     "xrSessionInsertDebugUtilsLabelEXT", "session is not a valid XrSession",
-                                                    loader_objects);
+                                                    {XrLoaderLogObjectInfo{session, XR_OBJECT_TYPE_SESSION}});
             return XR_ERROR_HANDLE_INVALID;
         }
         if (!loader_instance->ExtensionIsEnabled(XR_EXT_DEBUG_UTILS_EXTENSION_NAME)) {
             LoaderLogger::LogValidationErrorMessage("TBD", "xrSessionInsertDebugUtilsLabelEXT",
                                                     "Extension entrypoint called without enabling appropriate extension",
-                                                    loader_objects);
+                                                    {XrLoaderLogObjectInfo{session, XR_OBJECT_TYPE_SESSION}});
             return XR_ERROR_FUNCTION_UNSUPPORTED;
         } else if (nullptr == labelInfo) {
             LoaderLogger::LogValidationErrorMessage("VUID-xrSessionInsertDebugUtilsLabelEXT-labelInfo-parameter",
                                                     "xrSessionInsertDebugUtilsLabelEXT", "labelInfo must be non-NULL",
-                                                    loader_objects);
+                                                    {XrLoaderLogObjectInfo{session, XR_OBJECT_TYPE_SESSION}});
             return XR_ERROR_VALIDATION_FAILURE;
         }
 

--- a/src/loader/loader_core.cpp
+++ b/src/loader/loader_core.cpp
@@ -32,7 +32,7 @@
 
 #include "loader_logger.hpp"
 #include "loader_instance.hpp"
-#include "xr_generated_loader.cpp"
+#include "xr_generated_loader.hpp"
 
 // Flag to cause the one time to init to only occur one time.
 std::once_flag g_one_time_init_flag;

--- a/src/loader/loader_core.cpp
+++ b/src/loader/loader_core.cpp
@@ -32,6 +32,7 @@
 #include <openxr/openxr_platform.h>
 
 #include "loader_logger.hpp"
+#include "loader_logger_recorders.hpp"
 #include "loader_instance.hpp"
 #include "xr_generated_loader.hpp"
 
@@ -530,8 +531,7 @@ XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermCreateDebugUtilsMessengerEXT(XrInstan
             *messenger = reinterpret_cast<XrDebugUtilsMessengerEXT>(temp_mess_ptr);
         }
         if (XR_SUCCESS == result) {
-            std::unique_ptr<LoaderLogRecorder> base_recorder(new DebugUtilsLogRecorder(createInfo, *messenger));
-            LoaderLogger::GetInstance().AddLogRecorder(base_recorder);
+            LoaderLogger::GetInstance().AddLogRecorder(MakeDebugUtilsLoaderLogRecorder(createInfo, *messenger));
             RuntimeInterface::GetRuntime().TrackDebugMessenger(instance, *messenger);
         }
         LoaderLogger::LogVerboseMessage("xrCreateDebugUtilsMessengerEXT", "Completed loader terminator");

--- a/src/loader/loader_instance.cpp
+++ b/src/loader/loader_instance.cpp
@@ -161,10 +161,11 @@ XrResult LoaderInstance::CreateInstance(std::vector<std::unique_ptr<ApiLayerInte
                 LoaderLogger::LogErrorMessage("xrCreateInstance",
                                               "LoaderInstance::CreateInstance failed creating top-level dispatch table");
             } else {
-                std::unique_lock<std::mutex> lock(g_instance_mutex);
-                auto exists = g_instance_map.find(*instance);
-                if (exists == g_instance_map.end()) {
-                    g_instance_map[*instance] = loader_instance;
+                last_error = g_instance_map.Insert(*instance, *loader_instance);
+                if (XR_FAILED(last_error)) {
+                    LoaderLogger::LogErrorMessage(
+                        "xrCreateInstance",
+                        "LoaderInstance::CreateInstance failed inserting new instance into map: may be null or not unique");
                 }
             }
         }

--- a/src/loader/loader_instance.cpp
+++ b/src/loader/loader_instance.cpp
@@ -175,7 +175,7 @@ XrResult LoaderInstance::CreateInstance(std::vector<std::unique_ptr<ApiLayerInte
             oss << "LoaderInstance::CreateInstance succeeded with ";
             oss << loader_instance->LayerInterfaces().size();
             oss << " layers enabled and runtime interface - created instance = ";
-            oss << HandleToString(*instance);
+            oss << HandleToHexString(*instance);
             LoaderLogger::LogInfoMessage("xrCreateInstance", oss.str());
             // Make the unique_ptr no longer delete this.
             loader_instance.release();
@@ -208,7 +208,7 @@ LoaderInstance::LoaderInstance(std::vector<std::unique_ptr<ApiLayerInterface>>&&
 LoaderInstance::~LoaderInstance() {
     std::ostringstream oss;
     oss << "Destroying LoaderInstance = ";
-    oss << Uint64ToHexString(reinterpret_cast<uintptr_t>(this));
+    oss << PointerToHexString(this);
     LoaderLogger::LogInfoMessage("xrDestroyInstance", oss.str());
 }
 

--- a/src/loader/loader_instance.cpp
+++ b/src/loader/loader_instance.cpp
@@ -170,13 +170,12 @@ XrResult LoaderInstance::CreateInstance(std::vector<std::unique_ptr<ApiLayerInte
         }
 
         if (XR_SUCCEEDED(last_error)) {
-            std::string info_message = "LoaderInstance::CreateInstance succeeded with ";
-            info_message += std::to_string(loader_instance->LayerInterfaces().size());
-            info_message += " layers enabled and runtime interface - created instance = 0x";
             std::ostringstream oss;
-            oss << std::hex << reinterpret_cast<uintptr_t>(loader_instance);
-            info_message += oss.str();
-            LoaderLogger::LogInfoMessage("xrCreateInstance", info_message);
+            oss << "LoaderInstance::CreateInstance succeeded with ";
+            oss << loader_instance->LayerInterfaces().size();
+            oss << " layers enabled and runtime interface - created instance = ";
+            oss << HandleToString(*instance);
+            LoaderLogger::LogInfoMessage("xrCreateInstance", oss.str());
             // Make the unique_ptr no longer delete this.
             loader_instance.release();
         }
@@ -209,11 +208,10 @@ LoaderInstance::LoaderInstance(std::vector<std::unique_ptr<ApiLayerInterface>>& 
 }
 
 LoaderInstance::~LoaderInstance() {
-    std::string info_message = "Destroying LoaderInstance = 0x";
     std::ostringstream oss;
-    oss << std::hex << reinterpret_cast<uintptr_t>(this);
-    info_message += oss.str();
-    LoaderLogger::LogInfoMessage("xrDestroyInstance", info_message);
+    oss << "Destroying LoaderInstance = ";
+    oss << Uint64ToHexString(reinterpret_cast<uintptr_t>(this));
+    LoaderLogger::LogInfoMessage("xrDestroyInstance", oss.str());
 }
 
 XrResult LoaderInstance::CreateDispatchTable(XrInstance instance) {

--- a/src/loader/loader_instance.hpp
+++ b/src/loader/loader_instance.hpp
@@ -24,9 +24,11 @@
 
 #include "loader_platform.hpp"
 #include "platform_utils.hpp"
+#include "extra_algorithms.h"
 #include "runtime_interface.hpp"
 #include "api_layer_interface.hpp"
 #include "xr_generated_dispatch_table.h"
+
 class LoaderInstance;
 
 typedef std::unique_lock<std::mutex> UniqueLock;
@@ -56,21 +58,6 @@ class HandleLoaderMap {
     map_t instance_map_;
     std::mutex mutex_;
 };
-
-/// Like std::remove_if, except it works on associative containers and it actually removes this.
-///
-/// The iterator stuff in here is subtle - .erase() invalidates only that iterator, but it returns a non-invalidated iterator to the
-/// next valid element which we can use instead of incrementing.
-template <typename T, typename Pred>
-inline void map_erase_if(T& container, Pred&& predicate) {
-    for (auto it = container.begin(); it != container.end();) {
-        if (predicate(*it)) {
-            it = container.erase(it);
-        } else {
-            ++it;
-        }
-    }
-}
 
 class LoaderInstance {
    public:

--- a/src/loader/loader_instance.hpp
+++ b/src/loader/loader_instance.hpp
@@ -44,7 +44,8 @@ class HandleLoaderMap {
     LoaderInstance* Get(HandleType handle);
 
     /// Insert an info for the supplied handle.
-    /// Returns XR_ERROR_RUNTIME_FAILURE if it's null or already there.
+    /// Returns XR_ERROR_RUNTIME_FAILURE if it's null.
+    /// Does not error if already there, because the loader is not currently very good at cleaning up handles.
     XrResult Insert(HandleType handle, LoaderInstance& loader);
 
     /// Remove the info associated with the supplied handle.
@@ -114,11 +115,15 @@ inline XrResult HandleLoaderMap<HandleType>::Insert(HandleType handle, LoaderIns
         return XR_ERROR_RUNTIME_FAILURE;
     }
     UniqueLock lock(mutex_);
+    //! @todo This check is currently disabled, because the loader is not good at cleaning up handles when their parent handles are
+    //! destroyed.
+#if 0
     auto entry_returned = instance_map_.find(handle);
     if (entry_returned != instance_map_.end()) {
         // Internal error in loader or runtime.
         return XR_ERROR_RUNTIME_FAILURE;
     }
+#endif
     instance_map_[handle] = &loader;
     return XR_SUCCESS;
 }

--- a/src/loader/loader_instance.hpp
+++ b/src/loader/loader_instance.hpp
@@ -59,14 +59,13 @@ class HandleLoaderMap {
 
 /// Like std::remove_if, except it works on associative containers and it actually removes this.
 ///
-/// The iterator stuff in here is subtle - .erase() invalidates only that iterator, so we must advance first.
+/// The iterator stuff in here is subtle - .erase() invalidates only that iterator, but it returns a non-invalidated iterator to the
+/// next valid element which we can use instead of incrementing.
 template <typename T, typename Pred>
 inline void map_erase_if(T& container, Pred&& predicate) {
     for (auto it = container.begin(); it != container.end();) {
         if (predicate(*it)) {
-            auto here = it;
-            ++it;
-            container.erase(here);
+            it = container.erase(it);
         } else {
             ++it;
         }

--- a/src/loader/loader_instance.hpp
+++ b/src/loader/loader_instance.hpp
@@ -76,10 +76,10 @@ inline void map_erase_if(T& container, Pred&& predicate) {
 class LoaderInstance {
    public:
     // Factory method
-    static XrResult CreateInstance(std::vector<std::unique_ptr<ApiLayerInterface>>& layer_interfaces,
+    static XrResult CreateInstance(std::vector<std::unique_ptr<ApiLayerInterface>>&& layer_interfaces,
                                    const XrInstanceCreateInfo* info, XrInstance* instance);
 
-    LoaderInstance(std::vector<std::unique_ptr<ApiLayerInterface>>& api_layer_interfaces);
+    LoaderInstance(std::vector<std::unique_ptr<ApiLayerInterface>>&& api_layer_interfaces);
     virtual ~LoaderInstance();
 
     bool IsValid() { return _unique_id == 0xDECAFBAD; }

--- a/src/loader/loader_logger.cpp
+++ b/src/loader/loader_logger.cpp
@@ -17,10 +17,12 @@
 // Author: Mark Young <marky@lunarg.com>
 //
 
+#include <iomanip>
 #include <iostream>
 #include <memory>
 #include <vector>
 #include <string>
+#include <sstream>
 
 #include "xr_dependencies.h"
 #include <openxr/openxr.h>
@@ -40,6 +42,12 @@ StdErrLoaderLogRecorder::StdErrLoaderLogRecorder(void* user_data)
     Start();
 }
 
+std::string Uint64ToHexString(uint64_t val) {
+    std::ostringstream oss;
+    oss << "0x";
+    oss << std::hex << std::setw(16) << std::setfill('0') << val;
+    return oss.str();
+}
 bool StdErrLoaderLogRecorder::LogMessage(XrLoaderLogMessageSeverityFlagBits message_severity,
                                          XrLoaderLogMessageTypeFlags message_type,
                                          const XrLoaderLogMessengerCallbackData* callback_data) {

--- a/src/loader/loader_logger.cpp
+++ b/src/loader/loader_logger.cpp
@@ -50,6 +50,16 @@ std::string Uint64ToHexString(uint64_t val) {
     oss << std::hex << std::setw(16) << std::setfill('0') << val;
     return oss.str();
 }
+
+std::string XrLoaderLogObjectInfo::ToString() const {
+    std::ostringstream oss;
+    oss << Uint64ToHexString(handle);
+    if (!name.empty()) {
+        oss << " (" << name << ")";
+    }
+    return oss.str();
+}
+
 bool StdErrLoaderLogRecorder::LogMessage(XrLoaderLogMessageSeverityFlagBits message_severity,
                                          XrLoaderLogMessageTypeFlags message_type,
                                          const XrLoaderLogMessengerCallbackData* callback_data) {
@@ -73,10 +83,7 @@ bool StdErrLoaderLogRecorder::LogMessage(XrLoaderLogMessageSeverityFlagBits mess
                   << std::endl;
 
         for (uint32_t obj = 0; obj < callback_data->object_count; ++obj) {
-            std::cerr << "    Object[" << std::to_string(obj) << "] = " << std::to_string(callback_data->objects[obj].handle);
-            if (!callback_data->objects[obj].name.empty()) {
-                std::cerr << " (" << callback_data->objects[obj].name << ")";
-            }
+            std::cerr << "    Object[" << obj << "] = " << callback_data->objects[obj].ToString();
             std::cerr << std::endl;
         }
         for (uint32_t label = 0; label < callback_data->session_labels_count; ++label) {

--- a/src/loader/loader_logger.cpp
+++ b/src/loader/loader_logger.cpp
@@ -367,12 +367,11 @@ LoaderLogger::LoaderLogger() {
 void LoaderLogger::AddLogRecorder(std::unique_ptr<LoaderLogRecorder>& recorder) { _recorders.push_back(std::move(recorder)); }
 
 void LoaderLogger::RemoveLogRecorder(uint64_t unique_id) {
-    for (uint32_t index = 0; index < _recorders.size(); ++index) {
-        if (_recorders[index]->UniqueId() == unique_id) {
-            _recorders.erase(_recorders.begin() + index);
-            break;
-        }
-    }
+    auto e = _recorders.end();
+    auto new_end = std::remove_if(_recorders.begin(), e, [=](std::unique_ptr<LoaderLogRecorder> const& recorder) {
+        return recorder->UniqueId() == unique_id;
+    });
+    _recorders.erase(new_end);
 }
 
 bool LoaderLogger::LogMessage(XrLoaderLogMessageSeverityFlagBits message_severity, XrLoaderLogMessageTypeFlags message_type,

--- a/src/loader/loader_logger.cpp
+++ b/src/loader/loader_logger.cpp
@@ -17,8 +17,6 @@
 // Author: Mark Young <marky@lunarg.com>
 //
 
-#define XR_UTILS_INCLUDE_IMPLEMENTATION
-#include "xr_utils.h"
 
 #include <algorithm>
 #include <iomanip>
@@ -33,6 +31,7 @@
 #include <openxr/openxr.h>
 #include <openxr/openxr_platform.h>
 
+#include "hex_and_handles.h"
 #include "extra_algorithms.h"
 #include "loader_platform.hpp"
 #include "platform_utils.hpp"

--- a/src/loader/loader_logger.cpp
+++ b/src/loader/loader_logger.cpp
@@ -17,6 +17,9 @@
 // Author: Mark Young <marky@lunarg.com>
 //
 
+#define XR_UTILS_INCLUDE_IMPLEMENTATION
+#include "xr_utils.h"
+
 #include <algorithm>
 #include <iomanip>
 #include <iostream>
@@ -37,13 +40,6 @@
 
 std::unique_ptr<LoaderLogger> LoaderLogger::_instance;
 std::once_flag LoaderLogger::_once_flag;
-
-std::string Uint64ToHexString(uint64_t val) {
-    std::ostringstream oss;
-    oss << "0x";
-    oss << std::hex << std::setw(16) << std::setfill('0') << val;
-    return oss.str();
-}
 
 std::string XrLoaderLogObjectInfo::ToString() const {
     std::ostringstream oss;
@@ -284,7 +280,7 @@ bool LoaderLogger::LogDebugUtilsMessage(XrDebugUtilsMessageSeverityFlagsEXT mess
             // If this is a session, see if there are any labels associated with it for us to add
             // to the callback content.
             if (XR_OBJECT_TYPE_SESSION == current_obj.objectType) {
-                XrSession session = reinterpret_cast<XrSession&>(current_obj.objectHandle);
+                XrSession session = TreatIntegerAsHandle<XrSession>(current_obj.objectHandle);
                 LookUpSessionLabels(session, labels);
             }
         }

--- a/src/loader/loader_logger.cpp
+++ b/src/loader/loader_logger.cpp
@@ -33,6 +33,7 @@
 #include <openxr/openxr.h>
 #include <openxr/openxr_platform.h>
 
+#include "extra_algorithms.h"
 #include "loader_platform.hpp"
 #include "platform_utils.hpp"
 #include "loader_logger.hpp"
@@ -53,9 +54,7 @@ std::string XrLoaderLogObjectInfo::ToString() const {
 void ObjectInfoCollection::AddObjectName(uint64_t object_handle, XrObjectType object_type, const std::string& object_name) {
     // If name is empty, we should erase it
     if (object_name.empty()) {
-        auto new_end = std::remove_if(_object_info.begin(), _object_info.end(),
-                                      [=](XrLoaderLogObjectInfo const& info) { return info.handle == object_handle; });
-        _object_info.erase(new_end);
+        vector_remove_if_and_erase(_object_info, [=](XrLoaderLogObjectInfo const& info) { return info.handle == object_handle; });
         return;
     }
     // Otherwise, add it or update the name
@@ -205,11 +204,8 @@ LoaderLogger::LoaderLogger() {
 void LoaderLogger::AddLogRecorder(std::unique_ptr<LoaderLogRecorder>&& recorder) { _recorders.push_back(std::move(recorder)); }
 
 void LoaderLogger::RemoveLogRecorder(uint64_t unique_id) {
-    auto e = _recorders.end();
-    auto new_end = std::remove_if(_recorders.begin(), e, [=](std::unique_ptr<LoaderLogRecorder> const& recorder) {
-        return recorder->UniqueId() == unique_id;
-    });
-    _recorders.erase(new_end);
+    vector_remove_if_and_erase(
+        _recorders, [=](std::unique_ptr<LoaderLogRecorder> const& recorder) { return recorder->UniqueId() == unique_id; });
 }
 
 bool LoaderLogger::LogMessage(XrLoaderLogMessageSeverityFlagBits message_severity, XrLoaderLogMessageTypeFlags message_type,

--- a/src/loader/loader_logger.hpp
+++ b/src/loader/loader_logger.hpp
@@ -80,6 +80,8 @@ struct XrLoaderLogObjectInfo {
 
     template <typename T>
     XrLoaderLogObjectInfo(T h, XrObjectType t) : handle(reinterpret_cast<uint64_t>(h)), type(t) {}
+
+    std::string ToString() const;
 };
 
 //! True if the two object infos have the same handle value and handle type

--- a/src/loader/loader_logger.hpp
+++ b/src/loader/loader_logger.hpp
@@ -160,47 +160,6 @@ class LoaderLogRecorder {
     XrLoaderLogMessageTypeFlags _message_types;
 };
 
-// Standard Error logger, always on for now
-class StdErrLoaderLogRecorder : public LoaderLogRecorder {
-   public:
-    StdErrLoaderLogRecorder(void* user_data);
-    ~StdErrLoaderLogRecorder() {}
-
-    bool LogMessage(XrLoaderLogMessageSeverityFlagBits message_severity, XrLoaderLogMessageTypeFlags message_type,
-                    const XrLoaderLogMessengerCallbackData* callback_data) override;
-};
-
-// Standard Output logger used with XR_LOADER_DEBUG
-class StdOutLoaderLogRecorder : public LoaderLogRecorder {
-   public:
-    StdOutLoaderLogRecorder(void* user_data, XrLoaderLogMessageSeverityFlags flags);
-    ~StdOutLoaderLogRecorder() {}
-
-    bool LogMessage(XrLoaderLogMessageSeverityFlagBits message_severity, XrLoaderLogMessageTypeFlags message_type,
-                    const XrLoaderLogMessengerCallbackData* callback_data) override;
-};
-
-// Debug Utils logger used with XR_EXT_debug_utils
-class DebugUtilsLogRecorder : public LoaderLogRecorder {
-   public:
-    DebugUtilsLogRecorder(const XrDebugUtilsMessengerCreateInfoEXT* create_info, XrDebugUtilsMessengerEXT debug_messenger);
-    ~DebugUtilsLogRecorder() {}
-
-    bool LogMessage(XrLoaderLogMessageSeverityFlagBits message_severity, XrLoaderLogMessageTypeFlags message_type,
-                    const XrLoaderLogMessengerCallbackData* callback_data) override;
-
-    // Extension-specific logging functions
-    bool LogDebugUtilsMessage(XrDebugUtilsMessageSeverityFlagsEXT message_severity, XrDebugUtilsMessageTypeFlagsEXT message_type,
-                              const XrDebugUtilsMessengerCallbackDataEXT* callback_data) override;
-
-   private:
-    PFN_xrDebugUtilsMessengerCallbackEXT _user_callback;
-};
-
-// TODO: Add other Derived classes:
-//  - FileLoaderLogRecorder     - During/after xrCreateInstance
-//  - PipeLoaderLogRecorder?    - During/after xrCreateInstance
-
 class ObjectInfoCollection {
    public:
     //! Called from LoaderXrTermSetDebugUtilsObjectNameEXT - an empty name means remove
@@ -241,7 +200,7 @@ class LoaderLogger {
         return *(_instance.get());
     }
 
-    void AddLogRecorder(std::unique_ptr<LoaderLogRecorder>& recorder);
+    void AddLogRecorder(std::unique_ptr<LoaderLogRecorder>&& recorder);
     void RemoveLogRecorder(uint64_t unique_id);
 
     //! Called from LoaderXrTermSetDebugUtilsObjectNameEXT - an empty name means remove

--- a/src/loader/loader_logger.hpp
+++ b/src/loader/loader_logger.hpp
@@ -21,10 +21,11 @@
 
 #include <memory>
 #include <mutex>
-#include <stack>
 #include <string>
 #include <unordered_map>
 #include <vector>
+
+#include <openxr/openxr.h>
 
 // Use internal versions of flags similar to XR_EXT_debug_utils so that
 // we're not tightly coupled to that extension.  This way, if the extension

--- a/src/loader/loader_logger.hpp
+++ b/src/loader/loader_logger.hpp
@@ -19,11 +19,12 @@
 
 #pragma once
 
-#include <mutex>
 #include <memory>
-#include <vector>
-#include <unordered_map>
+#include <mutex>
 #include <stack>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 // Use internal versions of flags similar to XR_EXT_debug_utils so that
 // we're not tightly coupled to that extension.  This way, if the extension
@@ -52,9 +53,18 @@ static inline std::string HandleToString(T handle) {
 }
 
 struct XrLoaderLogObjectInfo {
+    //! Type-erased handle value
     uint64_t handle;
+
+    //! Kind of object this handle refers to
     XrObjectType type;
+
+    //! To be assigned by the application - not part of this object's identity
     std::string name;
+    XrLoaderLogObjectInfo() = default;
+
+    template <typename T>
+    XrLoaderLogObjectInfo(T h, XrObjectType t) : handle(reinterpret_cast<uint64_t>(h)), type(t) {}
 };
 
 //! True if the two object infos have the same handle value and handle type

--- a/src/loader/loader_logger.hpp
+++ b/src/loader/loader_logger.hpp
@@ -79,8 +79,12 @@ struct XrLoaderLogObjectInfo {
 
     XrLoaderLogObjectInfo() = default;
 
+    //! Create from a typed handle and object type
     template <typename T>
     XrLoaderLogObjectInfo(T h, XrObjectType t) : handle(reinterpret_cast<uint64_t>(h)), type(t) {}
+
+    //! Create from an untyped handle value (integer) and object type
+    XrLoaderLogObjectInfo(uint64_t h, XrObjectType t) : handle(h), type(t) {}
 
     std::string ToString() const;
 };

--- a/src/loader/loader_logger.hpp
+++ b/src/loader/loader_logger.hpp
@@ -41,6 +41,16 @@ typedef XrFlags64 XrLoaderLogMessageSeverityFlags;
 typedef XrFlags64 XrLoaderLogMessageTypeFlagBits;
 typedef XrFlags64 XrLoaderLogMessageTypeFlags;
 
+//! Turns a uint64_t into a string formatted as hex.
+//!
+//! The core of the HandleToString implementation is in here.
+std::string Uint64ToHexString(uint64_t val);
+
+template <typename T>
+static inline std::string HandleToString(T handle) {
+    return Uint64ToHexString(reinterpret_cast<uint64_t>(handle));
+}
+
 struct XrLoaderLogObjectInfo {
     uint64_t handle;
     XrObjectType type;

--- a/src/loader/loader_logger.hpp
+++ b/src/loader/loader_logger.hpp
@@ -287,6 +287,9 @@ class LoaderLogger {
     LoaderLogger(const LoaderLogger&) = delete;
     LoaderLogger& operator=(const LoaderLogger&) = delete;
 
+    /// Retrieve labels for the given session, if any, and push them in reverse order on the vector.
+    void LookUpSessionLabels(XrSession session, std::vector<XrDebugUtilsLabelEXT>& labels) const;
+
     void RemoveIndividualLabel(std::vector<InternalSessionLabel*>* label_vec);
 
     static std::unique_ptr<LoaderLogger> _instance;

--- a/src/loader/loader_logger.hpp
+++ b/src/loader/loader_logger.hpp
@@ -47,6 +47,17 @@ struct XrLoaderLogObjectInfo {
     std::string name;
 };
 
+//! True if the two object infos have the same handle value and handle type
+static inline bool Equivalent(XrLoaderLogObjectInfo const& a, XrLoaderLogObjectInfo const& b) {
+    return a.handle == b.handle && a.type == b.type;
+}
+//! @overload
+static inline bool Equivalent(XrDebugUtilsObjectNameInfoEXT const& a, XrLoaderLogObjectInfo const& b) {
+    return a.objectHandle == b.handle && a.objectType == b.type;
+}
+//! @overload
+static inline bool Equivalent(XrLoaderLogObjectInfo const& a, XrDebugUtilsObjectNameInfoEXT const& b) { return Equivalent(b, a); }
+
 struct XrLoaderLogMessengerCallbackData {
     const char* message_id;
     const char* command_name;

--- a/src/loader/loader_logger.hpp
+++ b/src/loader/loader_logger.hpp
@@ -144,6 +144,13 @@ class LoaderLogRecorder {
     virtual bool LogMessage(XrLoaderLogMessageSeverityFlagBits message_severity, XrLoaderLogMessageTypeFlags message_type,
                             const XrLoaderLogMessengerCallbackData* callback_data) = 0;
 
+    // Extension-specific logging functions - defaults to do nothing.
+    virtual bool LogDebugUtilsMessage(XrDebugUtilsMessageSeverityFlagsEXT message_severity,
+                                      XrDebugUtilsMessageTypeFlagsEXT message_type,
+                                      const XrDebugUtilsMessengerCallbackDataEXT* callback_data) {
+        return false;
+    }
+
    protected:
     bool _active;
     XrLoaderLogType _type;
@@ -159,8 +166,8 @@ class StdErrLoaderLogRecorder : public LoaderLogRecorder {
     StdErrLoaderLogRecorder(void* user_data);
     ~StdErrLoaderLogRecorder() {}
 
-    virtual bool LogMessage(XrLoaderLogMessageSeverityFlagBits message_severity, XrLoaderLogMessageTypeFlags message_type,
-                            const XrLoaderLogMessengerCallbackData* callback_data);
+    bool LogMessage(XrLoaderLogMessageSeverityFlagBits message_severity, XrLoaderLogMessageTypeFlags message_type,
+                    const XrLoaderLogMessengerCallbackData* callback_data) override;
 };
 
 // Standard Output logger used with XR_LOADER_DEBUG
@@ -169,8 +176,8 @@ class StdOutLoaderLogRecorder : public LoaderLogRecorder {
     StdOutLoaderLogRecorder(void* user_data, XrLoaderLogMessageSeverityFlags flags);
     ~StdOutLoaderLogRecorder() {}
 
-    virtual bool LogMessage(XrLoaderLogMessageSeverityFlagBits message_severity, XrLoaderLogMessageTypeFlags message_type,
-                            const XrLoaderLogMessengerCallbackData* callback_data);
+    bool LogMessage(XrLoaderLogMessageSeverityFlagBits message_severity, XrLoaderLogMessageTypeFlags message_type,
+                    const XrLoaderLogMessengerCallbackData* callback_data) override;
 };
 
 // Debug Utils logger used with XR_EXT_debug_utils
@@ -179,12 +186,12 @@ class DebugUtilsLogRecorder : public LoaderLogRecorder {
     DebugUtilsLogRecorder(const XrDebugUtilsMessengerCreateInfoEXT* create_info, XrDebugUtilsMessengerEXT debug_messenger);
     ~DebugUtilsLogRecorder() {}
 
-    virtual bool LogMessage(XrLoaderLogMessageSeverityFlagBits message_severity, XrLoaderLogMessageTypeFlags message_type,
-                            const XrLoaderLogMessengerCallbackData* callback_data);
+    bool LogMessage(XrLoaderLogMessageSeverityFlagBits message_severity, XrLoaderLogMessageTypeFlags message_type,
+                    const XrLoaderLogMessengerCallbackData* callback_data) override;
 
     // Extension-specific logging functions
     bool LogDebugUtilsMessage(XrDebugUtilsMessageSeverityFlagsEXT message_severity, XrDebugUtilsMessageTypeFlagsEXT message_type,
-                              const XrDebugUtilsMessengerCallbackDataEXT* callback_data);
+                              const XrDebugUtilsMessengerCallbackDataEXT* callback_data) override;
 
    private:
     PFN_xrDebugUtilsMessengerCallbackEXT _user_callback;

--- a/src/loader/loader_logger.hpp
+++ b/src/loader/loader_logger.hpp
@@ -27,7 +27,7 @@
 
 #include <openxr/openxr.h>
 
-#include "xr_utils.h"
+#include "hex_and_handles.h"
 
 // Use internal versions of flags similar to XR_EXT_debug_utils so that
 // we're not tightly coupled to that extension.  This way, if the extension

--- a/src/loader/loader_logger.hpp
+++ b/src/loader/loader_logger.hpp
@@ -193,6 +193,16 @@ class ObjectInfoCollection {
     // Object names that have been set for given objects
     std::vector<XrLoaderLogObjectInfo> _object_info;
 };
+
+struct InternalSessionLabel {
+    XrDebugUtilsLabelEXT debug_utils_label;
+    std::string label_name;
+    bool is_individual_label;
+};
+
+using InternalSessionLabelPtr = std::unique_ptr<InternalSessionLabel>;
+using InternalSessionLabelList = std::vector<InternalSessionLabelPtr>;
+
 class LoaderLogger {
    public:
     static LoaderLogger& GetInstance() {
@@ -250,12 +260,6 @@ class LoaderLogger {
                               const XrDebugUtilsMessengerCallbackDataEXT* callback_data);
 
    private:
-    struct InternalSessionLabel {
-        XrDebugUtilsLabelEXT debug_utils_label;
-        std::string label_name;
-        bool is_individual_label;
-    };
-
     LoaderLogger();
     LoaderLogger(const LoaderLogger&) = delete;
     LoaderLogger& operator=(const LoaderLogger&) = delete;
@@ -263,7 +267,9 @@ class LoaderLogger {
     /// Retrieve labels for the given session, if any, and push them in reverse order on the vector.
     void LookUpSessionLabels(XrSession session, std::vector<XrDebugUtilsLabelEXT>& labels) const;
 
-    void RemoveIndividualLabel(std::vector<InternalSessionLabel*>* label_vec);
+    void RemoveIndividualLabel(InternalSessionLabelList& label_vec);
+    InternalSessionLabelList* GetSessionLabelList(XrSession session);
+    InternalSessionLabelList& GetOrCreateSessionLabelList(XrSession session);
 
     static std::unique_ptr<LoaderLogger> _instance;
     static std::once_flag _once_flag;
@@ -273,7 +279,7 @@ class LoaderLogger {
 
     ObjectInfoCollection _object_names;
     // Session labels
-    std::unordered_map<XrSession, std::vector<InternalSessionLabel*>*> _session_labels;
+    std::unordered_map<XrSession, std::unique_ptr<InternalSessionLabelList>> _session_labels;
 };
 
 // Utility functions for converting to/from XR_EXT_debug_utils values

--- a/src/loader/loader_logger_recorders.cpp
+++ b/src/loader/loader_logger_recorders.cpp
@@ -116,7 +116,7 @@ DebugUtilsLogRecorder::DebugUtilsLogRecorder(const XrDebugUtilsMessengerCreateIn
                         DebugUtilsMessageTypesToLoaderLogMessageTypes(create_info->messageTypes)),
       _user_callback(create_info->userCallback) {
     // Use the debug messenger value to uniquely identify this logger with that messenger
-    _unique_id = reinterpret_cast<uint64_t&>(debug_messenger);
+    _unique_id = MakeHandleGeneric(debug_messenger);
     Start();
 }
 

--- a/src/loader/loader_logger_recorders.cpp
+++ b/src/loader/loader_logger_recorders.cpp
@@ -1,0 +1,232 @@
+// Copyright (c) 2017-2019 The Khronos Group Inc.
+// Copyright (c) 2017-2019 Valve Corporation
+// Copyright (c) 2017-2019 LunarG, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: Mark Young <marky@lunarg.com>
+//
+
+#include <sstream>
+#include <iostream>
+
+#include "loader_logger_recorders.hpp"
+
+// Anonymous namespace to keep these types private
+namespace {
+// Standard Error logger, always on for now
+class StdErrLoaderLogRecorder : public LoaderLogRecorder {
+   public:
+    StdErrLoaderLogRecorder(void* user_data);
+    ~StdErrLoaderLogRecorder() {}
+
+    bool LogMessage(XrLoaderLogMessageSeverityFlagBits message_severity, XrLoaderLogMessageTypeFlags message_type,
+                    const XrLoaderLogMessengerCallbackData* callback_data) override;
+};
+
+// Standard Output logger used with XR_LOADER_DEBUG
+class StdOutLoaderLogRecorder : public LoaderLogRecorder {
+   public:
+    StdOutLoaderLogRecorder(void* user_data, XrLoaderLogMessageSeverityFlags flags);
+    ~StdOutLoaderLogRecorder() {}
+
+    bool LogMessage(XrLoaderLogMessageSeverityFlagBits message_severity, XrLoaderLogMessageTypeFlags message_type,
+                    const XrLoaderLogMessengerCallbackData* callback_data) override;
+};
+
+// Debug Utils logger used with XR_EXT_debug_utils
+class DebugUtilsLogRecorder : public LoaderLogRecorder {
+   public:
+    DebugUtilsLogRecorder(const XrDebugUtilsMessengerCreateInfoEXT* create_info, XrDebugUtilsMessengerEXT debug_messenger);
+    ~DebugUtilsLogRecorder() {}
+
+    bool LogMessage(XrLoaderLogMessageSeverityFlagBits message_severity, XrLoaderLogMessageTypeFlags message_type,
+                    const XrLoaderLogMessengerCallbackData* callback_data) override;
+
+    // Extension-specific logging functions
+    bool LogDebugUtilsMessage(XrDebugUtilsMessageSeverityFlagsEXT message_severity, XrDebugUtilsMessageTypeFlagsEXT message_type,
+                              const XrDebugUtilsMessengerCallbackDataEXT* callback_data) override;
+
+   private:
+    PFN_xrDebugUtilsMessengerCallbackEXT _user_callback;
+};
+
+// Standard Error logger, always on for now
+StdErrLoaderLogRecorder::StdErrLoaderLogRecorder(void* user_data)
+    : LoaderLogRecorder(XR_LOADER_LOG_STDERR, user_data, XR_LOADER_LOG_MESSAGE_SEVERITY_ERROR_BIT, 0xFFFFFFFFUL) {
+    // Automatically start
+    Start();
+}
+
+bool StdErrLoaderLogRecorder::LogMessage(XrLoaderLogMessageSeverityFlagBits message_severity,
+                                         XrLoaderLogMessageTypeFlags message_type,
+                                         const XrLoaderLogMessengerCallbackData* callback_data) {
+    if (_active && XR_LOADER_LOG_MESSAGE_SEVERITY_ERROR_BIT <= message_severity) {
+        std::cerr << "Error [";
+        switch (message_type) {
+            case XR_LOADER_LOG_MESSAGE_TYPE_GENERAL_BIT:
+                std::cerr << "GENERAL";
+                break;
+            case XR_LOADER_LOG_MESSAGE_TYPE_SPECIFICATION_BIT:
+                std::cerr << "SPEC";
+                break;
+            case XR_LOADER_LOG_MESSAGE_TYPE_PERFORMANCE_BIT:
+                std::cerr << "PERF";
+                break;
+            default:
+                std::cerr << "UNKNOWN";
+                break;
+        }
+        std::cerr << " | " << callback_data->command_name << " | " << callback_data->message_id << "] : " << callback_data->message
+                  << std::endl;
+
+        for (uint32_t obj = 0; obj < callback_data->object_count; ++obj) {
+            std::cerr << "    Object[" << obj << "] = " << callback_data->objects[obj].ToString();
+            std::cerr << std::endl;
+        }
+        for (uint32_t label = 0; label < callback_data->session_labels_count; ++label) {
+            std::cerr << "    SessionLabel[" << std::to_string(label) << "] = " << callback_data->session_labels[label].labelName;
+            std::cerr << std::endl;
+        }
+    }
+
+    // Return of "true" means that we should exit the application after the logged message.  We
+    // don't want to do that for our internal logging.  Only let a user return true.
+    return false;
+}
+
+// Standard Output logger used with XR_LOADER_DEBUG
+StdOutLoaderLogRecorder::StdOutLoaderLogRecorder(void* user_data, XrLoaderLogMessageSeverityFlags flags)
+    : LoaderLogRecorder(XR_LOADER_LOG_STDOUT, user_data, flags, 0xFFFFFFFFUL) {
+    // Automatically start
+    Start();
+}
+
+bool StdOutLoaderLogRecorder::LogMessage(XrLoaderLogMessageSeverityFlagBits message_severity,
+                                         XrLoaderLogMessageTypeFlags message_type,
+                                         const XrLoaderLogMessengerCallbackData* callback_data) {
+    if (_active && 0 != (_message_severities & message_severity) && 0 != (_message_types & message_type)) {
+        if (XR_LOADER_LOG_MESSAGE_SEVERITY_INFO_BIT > message_severity) {
+            std::cout << "Verbose [";
+        } else if (XR_LOADER_LOG_MESSAGE_SEVERITY_WARNING_BIT > message_severity) {
+            std::cout << "Info [";
+        } else if (XR_LOADER_LOG_MESSAGE_SEVERITY_ERROR_BIT > message_severity) {
+            std::cout << "Warning [";
+        } else {
+            std::cout << "Error [";
+        }
+        switch (message_type) {
+            case XR_LOADER_LOG_MESSAGE_TYPE_GENERAL_BIT:
+                std::cout << "GENERAL";
+                break;
+            case XR_LOADER_LOG_MESSAGE_TYPE_SPECIFICATION_BIT:
+                std::cout << "SPEC";
+                break;
+            case XR_LOADER_LOG_MESSAGE_TYPE_PERFORMANCE_BIT:
+                std::cout << "PERF";
+                break;
+            default:
+                std::cout << "UNKNOWN";
+                break;
+        }
+        std::cout << " | " << callback_data->command_name << " | " << callback_data->message_id << "] : " << callback_data->message
+                  << std::endl;
+
+        for (uint32_t obj = 0; obj < callback_data->object_count; ++obj) {
+            std::cout << "    Object[" << obj << "] = " << callback_data->objects[obj].ToString();
+            std::cout << std::endl;
+        }
+        for (uint32_t label = 0; label < callback_data->session_labels_count; ++label) {
+            std::cout << "    SessionLabel[" << std::to_string(label) << "] = " << callback_data->session_labels[label].labelName;
+            std::cout << std::endl;
+        }
+    }
+
+    // Return of "true" means that we should exit the application after the logged message.  We
+    // don't want to do that for our internal logging.  Only let a user return true.
+    return false;
+}
+
+// A logger associated with the XR_EXT_debug_utils extension
+
+DebugUtilsLogRecorder::DebugUtilsLogRecorder(const XrDebugUtilsMessengerCreateInfoEXT* create_info,
+                                             XrDebugUtilsMessengerEXT debug_messenger)
+    : LoaderLogRecorder(XR_LOADER_LOG_DEBUG_UTILS, static_cast<void*>(create_info->userData),
+                        DebugUtilsSeveritiesToLoaderLogMessageSeverities(create_info->messageSeverities),
+                        DebugUtilsMessageTypesToLoaderLogMessageTypes(create_info->messageTypes)),
+      _user_callback(create_info->userCallback) {
+    // Use the debug messenger value to uniquely identify this logger with that messenger
+    _unique_id = reinterpret_cast<uint64_t&>(debug_messenger);
+    Start();
+}
+
+// Extension-specific logging functions
+bool DebugUtilsLogRecorder::LogMessage(XrLoaderLogMessageSeverityFlagBits message_severity,
+                                       XrLoaderLogMessageTypeFlags message_type,
+                                       const XrLoaderLogMessengerCallbackData* callback_data) {
+    bool should_exit = false;
+    if (_active && 0 != (_message_severities & message_severity) && 0 != (_message_types & message_type)) {
+        XrDebugUtilsMessageSeverityFlagsEXT utils_severity = DebugUtilsSeveritiesToLoaderLogMessageSeverities(message_severity);
+        XrDebugUtilsMessageTypeFlagsEXT utils_type = LoaderLogMessageTypesToDebugUtilsMessageTypes(message_type);
+
+        // Convert the loader log message into the debug utils log message information
+        XrDebugUtilsMessengerCallbackDataEXT utils_callback_data = {};
+        utils_callback_data.type = XR_TYPE_DEBUG_UTILS_MESSENGER_CALLBACK_DATA_EXT;
+        utils_callback_data.messageId = callback_data->message_id;
+        utils_callback_data.functionName = callback_data->command_name;
+        utils_callback_data.message = callback_data->message;
+        std::vector<XrDebugUtilsObjectNameInfoEXT> utils_objects;
+        utils_objects.resize(callback_data->object_count);
+        for (uint8_t object = 0; object < callback_data->object_count; ++object) {
+            utils_objects[object].type = XR_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
+            utils_objects[object].next = nullptr;
+            utils_objects[object].objectHandle = callback_data->objects[object].handle;
+            utils_objects[object].objectType = callback_data->objects[object].type;
+            utils_objects[object].objectName = callback_data->objects[object].name.c_str();
+        }
+        utils_callback_data.objectCount = callback_data->object_count;
+        utils_callback_data.objects = utils_objects.data();
+        utils_callback_data.sessionLabelCount = callback_data->session_labels_count;
+        utils_callback_data.sessionLabels = callback_data->session_labels;
+
+        // Call the user callback with the appropriate info
+        // Return of "true" means that we should exit the application after the logged message.
+        should_exit = (_user_callback(utils_severity, utils_type, &utils_callback_data, _user_data) == XR_TRUE);
+    }
+
+    return should_exit;
+}
+
+bool DebugUtilsLogRecorder::LogDebugUtilsMessage(XrDebugUtilsMessageSeverityFlagsEXT message_severity,
+                                                 XrDebugUtilsMessageTypeFlagsEXT message_type,
+                                                 const XrDebugUtilsMessengerCallbackDataEXT* callback_data) {
+    // Call the user callback with the appropriate info
+    // Return of "true" means that we should exit the application after the logged message.
+    return (_user_callback(message_severity, message_type, callback_data, _user_data) == XR_TRUE);
+}
+
+}  // namespace
+
+std::unique_ptr<LoaderLogRecorder> MakeStdOutLoaderLogRecorder(void* user_data, XrLoaderLogMessageSeverityFlags flags) {
+    std::unique_ptr<LoaderLogRecorder> recorder(new StdOutLoaderLogRecorder(user_data, flags));
+    return recorder;
+}
+std::unique_ptr<LoaderLogRecorder> MakeStdErrLoaderLogRecorder(void* user_data) {
+    std::unique_ptr<LoaderLogRecorder> recorder(new StdErrLoaderLogRecorder(user_data));
+    return recorder;
+}
+std::unique_ptr<LoaderLogRecorder> MakeDebugUtilsLoaderLogRecorder(const XrDebugUtilsMessengerCreateInfoEXT* create_info,
+                                                                   XrDebugUtilsMessengerEXT debug_messenger) {
+    std::unique_ptr<LoaderLogRecorder> recorder(new DebugUtilsLogRecorder(create_info, debug_messenger));
+    return recorder;
+}

--- a/src/loader/loader_logger_recorders.hpp
+++ b/src/loader/loader_logger_recorders.hpp
@@ -1,0 +1,40 @@
+// Copyright (c) 2017-2019 The Khronos Group Inc.
+// Copyright (c) 2017-2019 Valve Corporation
+// Copyright (c) 2017-2019 LunarG, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: Ryan Pavlik <ryan.pavlik@collabora.com>
+//
+
+#pragma once
+
+#include "loader_logger.hpp"
+
+#include <openxr/openxr.h>
+
+#include <memory>
+
+//! Standard Error logger, always on for now
+std::unique_ptr<LoaderLogRecorder> MakeStdErrLoaderLogRecorder(void* user_data);
+
+//! Standard Output logger used with XR_LOADER_DEBUG
+std::unique_ptr<LoaderLogRecorder> MakeStdOutLoaderLogRecorder(void* user_data, XrLoaderLogMessageSeverityFlags flags);
+
+// Debug Utils logger used with XR_EXT_debug_utils
+std::unique_ptr<LoaderLogRecorder> MakeDebugUtilsLoaderLogRecorder(const XrDebugUtilsMessengerCreateInfoEXT* create_info,
+                                                                   XrDebugUtilsMessengerEXT debug_messenger);
+
+// TODO: Add other Derived classes:
+//  - FileLoaderLogRecorder     - During/after xrCreateInstance
+//  - PipeLoaderLogRecorder?    - During/after xrCreateInstance

--- a/src/loader/manifest_file.cpp
+++ b/src/loader/manifest_file.cpp
@@ -621,7 +621,6 @@ void RuntimeManifestFile::CreateIfValid(std::string filename, std::vector<std::u
                     LoaderLogger::LogErrorMessage("", error_message);
                     return;
                 }
-                lib_path = lib_path;
             } else {
                 // Otherwise, treat the library path as a relative path based on the JSON file.
                 std::string combined_path;
@@ -886,7 +885,6 @@ void ApiLayerManifestFile::CreateIfValid(ManifestFileType type, std::string file
                     LoaderLogger::LogErrorMessage("", error_message);
                     return;
                 }
-                library_path = library_path;
             } else {
                 // Otherwise, treat the library path as a relative path based on the JSON file.
                 std::string combined_path;

--- a/src/loader/runtime_interface.hpp
+++ b/src/loader/runtime_interface.hpp
@@ -23,6 +23,7 @@
 #include <vector>
 #include <unordered_map>
 #include <mutex>
+#include <memory>
 
 #include "loader_platform.hpp"
 #include "xr_generated_dispatch_table.h"
@@ -57,7 +58,7 @@ class RuntimeInterface {
     static uint32_t _single_runtime_count;
     LoaderPlatformLibraryHandle _runtime_library;
     PFN_xrGetInstanceProcAddr _get_instant_proc_addr;
-    std::unordered_map<XrInstance, XrGeneratedDispatchTable*> _dispatch_table_map;
+    std::unordered_map<XrInstance, std::unique_ptr<XrGeneratedDispatchTable>> _dispatch_table_map;
     std::mutex _dispatch_table_mutex;
     std::unordered_map<XrDebugUtilsMessengerEXT, XrInstance> _messenger_to_instance_map;
     std::mutex _messenger_to_instance_mutex;

--- a/src/scripts/api_dump_generator.py
+++ b/src/scripts/api_dump_generator.py
@@ -119,7 +119,7 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
             preamble += '#include <iomanip>\n'
             preamble += '#include <unordered_map>\n\n'
             preamble += '#include "xr_generated_api_dump.hpp"\n'
-            preamble += '#include "xr_utils.h"\n'
+            preamble += '#include "hex_and_handles.h"\n'
         write(preamble, file=self.outFile)
 
     # Write out all the information for the appropriate file,

--- a/src/scripts/api_dump_generator.py
+++ b/src/scripts/api_dump_generator.py
@@ -119,6 +119,7 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
             preamble += '#include <iomanip>\n'
             preamble += '#include <unordered_map>\n\n'
             preamble += '#include "xr_generated_api_dump.hpp"\n'
+            preamble += '#include "xr_utils.h"\n'
         write(preamble, file=self.outFile)
 
     # Write out all the information for the appropriate file,
@@ -928,11 +929,7 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
             struct_union_check += self.writeIndent(1)
             struct_union_check += 'try {\n'
             struct_union_check += self.writeIndent(2)
-            struct_union_check += 'std::ostringstream oss_union;\n'
-            struct_union_check += self.writeIndent(2)
-            struct_union_check += 'oss_union << std::hex << reinterpret_cast<const void*>(value);\n'
-            struct_union_check += self.writeIndent(2)
-            struct_union_check += 'contents.push_back(std::make_tuple(type_string, prefix, oss_union.str()));\n'
+            struct_union_check += 'contents.push_back(std::make_tuple(type_string, prefix, PointerToHexString(value)));\n'
             struct_union_check += self.writeIndent(2)
             struct_union_check += 'if (is_pointer) {\n'
             struct_union_check += self.writeIndent(3)
@@ -995,11 +992,7 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
                 struct_union_check += self.writeIndent(indent)
                 struct_union_check += '// Fallback path - Just output generic information about the base struct\n'
             struct_union_check += self.writeIndent(indent)
-            struct_union_check += 'std::ostringstream oss_struct;\n'
-            struct_union_check += self.writeIndent(indent)
-            struct_union_check += 'oss_struct << std::hex << reinterpret_cast<const void*>(value);\n'
-            struct_union_check += self.writeIndent(indent)
-            struct_union_check += 'contents.push_back(std::make_tuple(type_string, prefix, oss_struct.str()));\n'
+            struct_union_check += 'contents.push_back(std::make_tuple(type_string, prefix, PointerToHexString(value)));\n'
             struct_union_check += self.writeIndent(indent)
             struct_union_check += 'if (is_pointer) {\n'
             struct_union_check += self.writeIndent(indent + 1)
@@ -1028,9 +1021,7 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
         struct_union_check += 'bool ApiDumpDecodeNextChain(XrGeneratedDispatchTable* gen_dispatch_table, const void* value, std::string prefix,\n'
         struct_union_check += '                            std::vector<std::tuple<std::string, std::string, std::string>> &contents) {\n'
         struct_union_check += '    try {\n'
-        struct_union_check += '        std::ostringstream oss_next;\n'
-        struct_union_check += '        oss_next << std::hex << reinterpret_cast<const void*>(value);\n'
-        struct_union_check += '        contents.push_back(std::make_tuple("const void *", prefix, oss_next.str()));\n'
+        struct_union_check += '        contents.push_back(std::make_tuple("const void *", prefix, PointerToHexString(value)));\n'
         struct_union_check += '        if (nullptr == value) {\n'
         struct_union_check += '            return true;\n'
         struct_union_check += '        }\n'
@@ -1241,13 +1232,9 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
         generated_commands += '        // Generate output for this command\n'
         generated_commands += '        std::vector<std::tuple<std::string, std::string, std::string>> contents;\n'
         generated_commands += '        contents.push_back(std::make_tuple("XrResult", "xrGetInstanceProcAddr", ""));\n'
-        generated_commands += '        std::ostringstream oss_instance;\n'
-        generated_commands += '        oss_instance << std::hex << reinterpret_cast<const void*>(instance);\n'
-        generated_commands += '        contents.push_back(std::make_tuple("XrInstance", "instance", oss_instance.str()));\n'
+        generated_commands += '        contents.push_back(std::make_tuple("XrInstance", "instance", HandleToHexString(instance)));\n'
         generated_commands += '        contents.push_back(std::make_tuple("const char*", "name", name));\n'
-        generated_commands += '        std::ostringstream oss_function;\n'
-        generated_commands += '        oss_function << std::hex << reinterpret_cast<const void*>(function);\n'
-        generated_commands += '        contents.push_back(std::make_tuple("PFN_xrVoidFunction*", "function", oss_function.str()));\n'
+        generated_commands += '        contents.push_back(std::make_tuple("PFN_xrVoidFunction*", "function", PointerToHexString(reinterpret_cast<const void*>(function))));\n'
         generated_commands += '        ApiDumpLayerRecordContent(contents);\n'
 
         count = 0

--- a/src/scripts/loader_source_generator.py
+++ b/src/scripts/loader_source_generator.py
@@ -632,7 +632,7 @@ class LoaderSourceOutputGenerator(AutomaticSourceOutputGenerator):
                     generated_funcs += '    } catch (...) {\n'
                     generated_funcs += '        LoaderLogger::LogErrorMessage("%s", "%s trampoline encountered an unknown error.  Likely XrInstance "\n' % (
                         cur_cmd.name, cur_cmd.name)
-                    generated_funcs += '            + HandleToString(%s) + " is invalid");\n' % cur_cmd.params[0].name
+                    generated_funcs += '            + HandleToHexString(%s) + " is invalid");\n' % cur_cmd.params[0].name
                     if has_return:
                         generated_funcs += '        return XR_ERROR_HANDLE_INVALID;\n'
                 elif has_return:

--- a/src/scripts/loader_source_generator.py
+++ b/src/scripts/loader_source_generator.py
@@ -681,13 +681,9 @@ class LoaderSourceOutputGenerator(AutomaticSourceOutputGenerator):
                     generated_funcs += '        return XR_ERROR_INITIALIZATION_FAILED;\n'
                 elif cur_cmd.params[0].type == 'XrInstance':
                     generated_funcs += '    } catch (...) {\n'
-                    generated_funcs += '        std::string error_message = "%s trampoline encountered an unknown error.  Likely XrInstance 0x";\n' % cur_cmd.name
-                    generated_funcs += '        std::ostringstream oss;\n'
-                    generated_funcs += '        oss << std::hex << reinterpret_cast<const void*>(%s);\n' % cur_cmd.params[
-                        0].name
-                    generated_funcs += '        error_message += oss.str();\n'
-                    generated_funcs += '        error_message += " is invalid";\n'
-                    generated_funcs += '        LoaderLogger::LogErrorMessage("%s", error_message);\n' % cur_cmd.name
+                    generated_funcs += '        LoaderLogger::LogErrorMessage("%s", "%s trampoline encountered an unknown error.  Likely XrInstance "\n' % (
+                        cur_cmd.name, cur_cmd.name)
+                    generated_funcs += '            + HandleToString(%s) + " is invalid");\n' % cur_cmd.params[0].name
                     if has_return:
                         generated_funcs += '        return XR_ERROR_HANDLE_INVALID;\n'
                 elif has_return:

--- a/src/tests/loader_test/loader_test.cpp
+++ b/src/tests/loader_test/loader_test.cpp
@@ -25,9 +25,14 @@
 #include "filesystem_utils.hpp"
 #include "loader_test_utils.hpp"
 
+#include "xr_utils.h"
+
 #include "xr_dependencies.h"
 #include <openxr/openxr.h>
 #include <openxr/openxr_platform.h>
+
+#include <type_traits>
+static_assert(sizeof(XrStructureType) == 4, "This should be a 32-bit enum");
 
 // Filter out the loader's messages to std::cerr if this is defined to 1.  This allows a
 // clean output for the test.
@@ -1615,7 +1620,7 @@ DEFINE_TEST(TestDebugUtils) {
             TEST_NOT_EQUAL(pfn_set_debug_utils_object_name_ext, nullptr,
                            "TestDebugUtils invalid xrSetDebugUtilsObjectNameEXT function pointer");
             strcpy(object_name, "My Instance Obj");
-            object_handle = reinterpret_cast<uint64_t&>(instance);
+            object_handle = MakeHandleGeneric(instance);
             objects[0].type = XR_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
             objects[0].next = nullptr;
             objects[0].objectType = XR_OBJECT_TYPE_INSTANCE;
@@ -1795,12 +1800,12 @@ DEFINE_TEST(TestDebugUtils) {
                 objects[0].type = XR_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
                 objects[0].next = nullptr;
                 objects[0].objectType = XR_OBJECT_TYPE_INSTANCE;
-                objects[0].objectHandle = reinterpret_cast<uint64_t&>(instance);
+                objects[0].objectHandle = MakeHandleGeneric(instance);
                 objects[0].objectName = nullptr;
                 objects[1].type = XR_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
                 objects[1].next = nullptr;
                 objects[1].objectType = XR_OBJECT_TYPE_SESSION;
-                objects[1].objectHandle = reinterpret_cast<uint64_t&>(session);
+                objects[1].objectHandle = MakeHandleGeneric(session);
                 objects[1].objectName = nullptr;
                 debug_utils_callback_data.objects = &objects[0];
 

--- a/src/tests/loader_test/loader_test.cpp
+++ b/src/tests/loader_test/loader_test.cpp
@@ -25,7 +25,7 @@
 #include "filesystem_utils.hpp"
 #include "loader_test_utils.hpp"
 
-#include "xr_utils.h"
+#include "hex_and_handles.h"
 
 #include "xr_dependencies.h"
 #include <openxr/openxr.h>


### PR DESCRIPTION
The main thing I did here is the same basic cleanup I performed on the validation layer a while ago: replaced duplicated "lock, look up in map, unlock" logic with classes that do that all in one call.

The manual new and delete made me nervous so I switched nearly all of them to unique_ptrs now too.

It also changes a few XR_ERROR_VALIDATION_FAILURE into XR_ERROR_HANDLE_INVALID for consistency.

Handful of other changes too. De-duplicates and makes it easier at least for me to read and follow, hopefully for others too.

Commit messages should be useful.