### PR TITLE
Make Loader Exception Free

### DIFF
--- a/doc/loader/OpenXR_loader_design.html
+++ b/doc/loader/OpenXR_loader_design.html
@@ -3856,12 +3856,6 @@ std::experimental::filesystem::path search_path;</code></pre>
 </div>
 </div>
 <div class="paragraph">
-<div class="title">Exceptions</div>
-<p>The OpenXR loader relies on throwing and catching C++ exceptions.  Adding code
-should take this into account and properly wrap executing code with a "try"/"catch"
-block.</p>
-</div>
-<div class="paragraph">
 <div class="title">Experimental Filesystem Usage</div>
 <p>In order to simplify the file management, especially with regards to loading JSON
 manifest files or finding dynamic library files, the experimental/filesystem is used.
@@ -3885,14 +3879,11 @@ find elements of this functionality with the prefix
 <pre class="highlight"><code class="language-cpp" data-lang="cpp">#include &lt;experimental/filesystem&gt;
 
 static void checkAllFilesInThePath(const std::string &amp;search_path) {
-    try {
-        // If the file exists, try to add it
-        if (std::experimental::filesystem::is_regular_file(search_path)) {
-            std::experimental::filesystem::path absolute_path =
-                std::experimental::filesystem::absolute(search_path);
-        }
-    } catch (...) {
-    }
+      // If the file exists, try to add it
+      if (std::experimental::filesystem::is_regular_file(search_path)) {
+          std::experimental::filesystem::path absolute_path =
+              std::experimental::filesystem::absolute(search_path);
+      }
 }</code></pre>
 </div>
 </div>
@@ -5092,55 +5083,35 @@ same <code>LoaderInstance*</code>.</p>
     XrSession*                                  session) {
     bool primary_locked = false;
     bool secondary_locked = false;
-    try {
-        g_instance_mutex.lock();
-        secondary_locked = true;
-        LoaderInstance *loader_instance = g_instance_map[instance];
-        g_instance_mutex.unlock();
-        secondary_locked = false;
-        if (nullptr == loader_instance) {
-            XrLoaderLogObjectInfo bad_object = {};
-            bad_object.type = XR_OBJECT_TYPE_INSTANCE;
-            bad_object.handle = reinterpret_cast&lt;uint64_t&amp;&gt;(instance);
-            std::vector&lt;XrLoaderLogObjectInfo&gt; loader_objects;
-            loader_objects.push_back(bad_object);
-            LoaderLogger::LogValidationErrorMessage("VUID-xrCreateSession-instance-parameter", "xrCreateSession",
-                                                    "instance is not a valid XrInstance", loader_objects);
-            return XR_ERROR_HANDLE_INVALID;
-        }
-        const std::unique_ptr&lt;XrGeneratedDispatchTable&gt;&amp; dispatch_table = loader_instance-&gt;DispatchTable();
-        XrResult result = XR_SUCCESS;
-        result = dispatch_table-&gt;CreateSession(instance, createInfo, session);
-        if (XR_SUCCESS == result &amp;&amp; nullptr != session) {
-            auto exists = g_session_map.find(*session);
-            if (exists == g_session_map.end()) {
-                g_session_mutex.lock();
-                primary_locked = true;
-                g_session_map[*session] = loader_instance;
-                g_session_mutex.unlock();
-                primary_locked = false;
-            }
-        }
-        return result;
-    } catch (std::bad_alloc &amp;) {
-        if (primary_locked) {
-            g_session_mutex.unlock();
-        }
-        if (secondary_locked) {
-            g_instance_mutex.unlock();
-        }
-        LoaderLogger::LogErrorMessage("xrCreateSession", "xrCreateSession trampoline failed allocating memory");
-        return XR_ERROR_OUT_OF_MEMORY;
-    } catch (...) {
-        if (primary_locked) {
-            g_session_mutex.unlock();
-        }
-        if (secondary_locked) {
-            g_instance_mutex.unlock();
-        }
-        LoaderLogger::LogErrorMessage("xrCreateSession", "xrCreateSession trampoline encountered an unknown error");
-        return XR_ERROR_INITIALIZATION_FAILED;
+    g_instance_mutex.lock();
+    secondary_locked = true;
+    LoaderInstance *loader_instance = g_instance_map[instance];
+    g_instance_mutex.unlock();
+    secondary_locked = false;
+    if (nullptr == loader_instance) {
+        XrLoaderLogObjectInfo bad_object = {};
+        bad_object.type = XR_OBJECT_TYPE_INSTANCE;
+        bad_object.handle = reinterpret_cast&lt;uint64_t&amp;&gt;(instance);
+        std::vector&lt;XrLoaderLogObjectInfo&gt; loader_objects;
+        loader_objects.push_back(bad_object);
+        LoaderLogger::LogValidationErrorMessage("VUID-xrCreateSession-instance-parameter", "xrCreateSession",
+                                                "instance is not a valid XrInstance", loader_objects);
+        return XR_ERROR_HANDLE_INVALID;
     }
+    const std::unique_ptr&lt;XrGeneratedDispatchTable&gt;&amp; dispatch_table = loader_instance-&gt;DispatchTable();
+    XrResult result = XR_SUCCESS;
+    result = dispatch_table-&gt;CreateSession(instance, createInfo, session);
+    if (XR_SUCCESS == result &amp;&amp; nullptr != session) {
+        auto exists = g_session_map.find(*session);
+        if (exists == g_session_map.end()) {
+            g_session_mutex.lock();
+            primary_locked = true;
+            g_session_map[*session] = loader_instance;
+            g_session_mutex.unlock();
+            primary_locked = false;
+        }
+    }
+    return result;
 }</code></pre>
 </div>
 </div>
@@ -5158,45 +5129,33 @@ is called.</p>
     XrSession                                   session) {
     bool primary_locked = false;
     bool secondary_locked = false;
-    try {
-        g_session_mutex.lock();
-        secondary_locked = true;
-        LoaderInstance *loader_instance = g_session_map[session];
-        g_session_mutex.unlock();
-        secondary_locked = false;
-        if (nullptr == loader_instance) {
-            XrLoaderLogObjectInfo bad_object = {};
-            bad_object.type = XR_OBJECT_TYPE_SESSION;
-            bad_object.handle = reinterpret_cast&lt;uint64_t&amp;&gt;(session);
-            std::vector&lt;XrLoaderLogObjectInfo&gt; loader_objects;
-            loader_objects.push_back(bad_object);
-            LoaderLogger::LogValidationErrorMessage("VUID-xrDestroySession-session-parameter", "xrDestroySession",
-                                                    "session is not a valid XrSession", loader_objects);
-            return XR_ERROR_HANDLE_INVALID;
-        }
-        const std::unique_ptr&lt;XrGeneratedDispatchTable&gt;&amp; dispatch_table = loader_instance-&gt;DispatchTable();
-        XrResult result = XR_SUCCESS;
-        result = dispatch_table-&gt;DestroySession(session);
-        auto exists = g_session_map.find(session);
-        if (exists != g_session_map.end()) {
-            g_session_mutex.lock();
-            primary_locked = true;
-            g_session_map.erase(session);
-            g_session_mutex.unlock();
-            primary_locked = false;
-        }
-        return result;
-    } catch (...) {
-        if (primary_locked) {
-            g_session_mutex.unlock();
-        }
-        if (secondary_locked) {
-            g_session_mutex.unlock();
-        }
-        LoaderLogger::LogErrorMessage("xrDestroySession", "xrDestroySession trampoline encountered an unknown error");
-        // NOTE: Most calls only allow XR_SUCCESS as a return code
-        return XR_SUCCESS;
+    g_session_mutex.lock();
+    secondary_locked = true;
+    LoaderInstance *loader_instance = g_session_map[session];
+    g_session_mutex.unlock();
+    secondary_locked = false;
+    if (nullptr == loader_instance) {
+        XrLoaderLogObjectInfo bad_object = {};
+        bad_object.type = XR_OBJECT_TYPE_SESSION;
+        bad_object.handle = reinterpret_cast&lt;uint64_t&amp;&gt;(session);
+        std::vector&lt;XrLoaderLogObjectInfo&gt; loader_objects;
+        loader_objects.push_back(bad_object);
+        LoaderLogger::LogValidationErrorMessage("VUID-xrDestroySession-session-parameter", "xrDestroySession",
+                                                "session is not a valid XrSession", loader_objects);
+        return XR_ERROR_HANDLE_INVALID;
     }
+    const std::unique_ptr&lt;XrGeneratedDispatchTable&gt;&amp; dispatch_table = loader_instance-&gt;DispatchTable();
+    XrResult result = XR_SUCCESS;
+    result = dispatch_table-&gt;DestroySession(session);
+    auto exists = g_session_map.find(session);
+    if (exists != g_session_map.end()) {
+        g_session_mutex.lock();
+        primary_locked = true;
+        g_session_map.erase(session);
+        g_session_mutex.unlock();
+        primary_locked = false;
+    }
+    return result;
 }</code></pre>
 </div>
 </div>

--- a/src/api_layers/api_dump.cpp
+++ b/src/api_layers/api_dump.cpp
@@ -59,133 +59,125 @@ static std::mutex g_record_mutex = {};
 
 // HTML utilities
 bool ApiDumpLayerWriteHtmlHeader(void) {
-    try {
-        std::unique_lock<std::mutex> mlock(g_record_mutex);
-        std::ofstream html_file;
-        html_file.open(g_record_info.file_name, std::ios::out);
-        html_file << "<!doctype html>\n"
-                     "<html>\n"
-                     "    <head>\n"
-                     "        <title>OpenXR API Dump</title>\n"
-                     "        <style type='text/css'>\n"
-                     "        html {\n"
-                     "            background-color: #0b1e48;\n"
-                     "            background-image: url('https://vulkan.lunarg.com/img/bg-starfield.jpg');\n"
-                     "            background-position: center;\n"
-                     "            -webkit-background-size: cover;\n"
-                     "            -moz-background-size: cover;\n"
-                     "            -o-background-size: cover;\n"
-                     "            background-size: cover;\n"
-                     "            background-attachment: fixed;\n"
-                     "            background-repeat: no-repeat;\n"
-                     "            height: 100%;\n"
-                     "        }\n"
-                     "        #header {\n"
-                     "            z-index: -1;\n"
-                     "        }\n"
-                     "        #header>img {\n"
-                     "            position: absolute;\n"
-                     "            width: 160px;\n"
-                     "            margin-left: -280px;\n"
-                     "            top: -10px;\n"
-                     "            left: 50%;\n"
-                     "        }\n"
-                     "        #header>h1 {\n"
-                     "            font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;\n"
-                     "            font-size: 44px;\n"
-                     "            font-weight: 200;\n"
-                     "            text-shadow: 4px 4px 5px #000;\n"
-                     "            color: #eee;\n"
-                     "            position: absolute;\n"
-                     "            width: 400px;\n"
-                     "            margin-left: -80px;\n"
-                     "            top: 8px;\n"
-                     "            left: 50%;\n"
-                     "        }\n"
-                     "        body {\n"
-                     "            font-family: Consolas, monaco, monospace;\n"
-                     "            font-size: 14px;\n"
-                     "            line-height: 20px;\n"
-                     "            color: #eee;\n"
-                     "            height: 100%;\n"
-                     "            margin: 0;\n"
-                     "            overflow: hidden;\n"
-                     "        }\n"
-                     "        #wrapper {\n"
-                     "            background-color: rgba(0, 0, 0, 0.7);\n"
-                     "            border: 1px solid #446;\n"
-                     "            box-shadow: 0px 0px 10px #000;\n"
-                     "            padding: 8px 12px;\n"
-                     "            display: inline-block;\n"
-                     "            position: absolute;\n"
-                     "            top: 80px;\n"
-                     "            bottom: 25px;\n"
-                     "            left: 50px;\n"
-                     "            right: 50px;\n"
-                     "            overflow: auto;\n"
-                     "        }\n"
-                     "        details>*:not(summary) {\n"
-                     "            margin-left: 22px;\n"
-                     "        }\n"
-                     "        summary:only-child {\n"
-                     "            display: block;\n"
-                     "            padding-left: 15px;\n"
-                     "        }\n"
-                     "        details>summary:only-child::-webkit-details-marker {\n"
-                     "            display: none;\n"
-                     "            padding-left: 15px;\n"
-                     "        }\n"
-                     "        .headervar, .headertype, .headerval {\n"
-                     "            display: inline;\n"
-                     "            margin: 0 9px;\n"
-                     "        }\n"
-                     "        .var, .type, .val {\n"
-                     "            display: inline;\n"
-                     "            margin: 0 6px;\n"
-                     "        }\n"
-                     "        .headertype, .type {\n"
-                     "            color: #acf;\n"
-                     "        }\n"
-                     "        .headerval, .val {\n"
-                     "            color: #afa;\n"
-                     "            text-align: right;\n"
-                     "        }\n"
-                     "        .thd {\n"
-                     "            color: #888;\n"
-                     "        }\n"
-                     "        </style>\n"
-                     "    </head>\n"
-                     "    <body>\n"
-                     "        <div id='header'>\n"
-                     "            <img src='https://lunarg.com/wp-content/uploads/2016/02/LunarG-wReg-150.png' />\n"
-                     "            <h1>OpenXR API Dump</h1>\n"
-                     "        </div>\n"
-                     "        <div id='wrapper'>\n";
-        return true;
-    } catch (...) {
-        return false;
-    }
+    std::unique_lock<std::mutex> mlock(g_record_mutex);
+    std::ofstream html_file;
+    html_file.open(g_record_info.file_name, std::ios::out);
+    html_file << "<!doctype html>\n"
+                 "<html>\n"
+                 "    <head>\n"
+                 "        <title>OpenXR API Dump</title>\n"
+                 "        <style type='text/css'>\n"
+                 "        html {\n"
+                 "            background-color: #0b1e48;\n"
+                 "            background-image: url('https://vulkan.lunarg.com/img/bg-starfield.jpg');\n"
+                 "            background-position: center;\n"
+                 "            -webkit-background-size: cover;\n"
+                 "            -moz-background-size: cover;\n"
+                 "            -o-background-size: cover;\n"
+                 "            background-size: cover;\n"
+                 "            background-attachment: fixed;\n"
+                 "            background-repeat: no-repeat;\n"
+                 "            height: 100%;\n"
+                 "        }\n"
+                 "        #header {\n"
+                 "            z-index: -1;\n"
+                 "        }\n"
+                 "        #header>img {\n"
+                 "            position: absolute;\n"
+                 "            width: 160px;\n"
+                 "            margin-left: -280px;\n"
+                 "            top: -10px;\n"
+                 "            left: 50%;\n"
+                 "        }\n"
+                 "        #header>h1 {\n"
+                 "            font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;\n"
+                 "            font-size: 44px;\n"
+                 "            font-weight: 200;\n"
+                 "            text-shadow: 4px 4px 5px #000;\n"
+                 "            color: #eee;\n"
+                 "            position: absolute;\n"
+                 "            width: 400px;\n"
+                 "            margin-left: -80px;\n"
+                 "            top: 8px;\n"
+                 "            left: 50%;\n"
+                 "        }\n"
+                 "        body {\n"
+                 "            font-family: Consolas, monaco, monospace;\n"
+                 "            font-size: 14px;\n"
+                 "            line-height: 20px;\n"
+                 "            color: #eee;\n"
+                 "            height: 100%;\n"
+                 "            margin: 0;\n"
+                 "            overflow: hidden;\n"
+                 "        }\n"
+                 "        #wrapper {\n"
+                 "            background-color: rgba(0, 0, 0, 0.7);\n"
+                 "            border: 1px solid #446;\n"
+                 "            box-shadow: 0px 0px 10px #000;\n"
+                 "            padding: 8px 12px;\n"
+                 "            display: inline-block;\n"
+                 "            position: absolute;\n"
+                 "            top: 80px;\n"
+                 "            bottom: 25px;\n"
+                 "            left: 50px;\n"
+                 "            right: 50px;\n"
+                 "            overflow: auto;\n"
+                 "        }\n"
+                 "        details>*:not(summary) {\n"
+                 "            margin-left: 22px;\n"
+                 "        }\n"
+                 "        summary:only-child {\n"
+                 "            display: block;\n"
+                 "            padding-left: 15px;\n"
+                 "        }\n"
+                 "        details>summary:only-child::-webkit-details-marker {\n"
+                 "            display: none;\n"
+                 "            padding-left: 15px;\n"
+                 "        }\n"
+                 "        .headervar, .headertype, .headerval {\n"
+                 "            display: inline;\n"
+                 "            margin: 0 9px;\n"
+                 "        }\n"
+                 "        .var, .type, .val {\n"
+                 "            display: inline;\n"
+                 "            margin: 0 6px;\n"
+                 "        }\n"
+                 "        .headertype, .type {\n"
+                 "            color: #acf;\n"
+                 "        }\n"
+                 "        .headerval, .val {\n"
+                 "            color: #afa;\n"
+                 "            text-align: right;\n"
+                 "        }\n"
+                 "        .thd {\n"
+                 "            color: #888;\n"
+                 "        }\n"
+                 "        </style>\n"
+                 "    </head>\n"
+                 "    <body>\n"
+                 "        <div id='header'>\n"
+                 "            <img src='https://lunarg.com/wp-content/uploads/2016/02/LunarG-wReg-150.png' />\n"
+                 "            <h1>OpenXR API Dump</h1>\n"
+                 "        </div>\n"
+                 "        <div id='wrapper'>\n";
+    return true;
 }
 
 bool ApiDumpLayerWriteHtmlFooter(void) {
-    try {
-        std::unique_lock<std::mutex> mlock(g_record_mutex);
-        std::ofstream html_file;
-        html_file.open(g_record_info.file_name, std::ios::out | std::ios::app);
-        html_file << "        </div>\n"
-                     "    </body>\n"
-                     "</html>";
+    std::unique_lock<std::mutex> mlock(g_record_mutex);
+    std::ofstream html_file;
+    html_file.open(g_record_info.file_name, std::ios::out | std::ios::app);
+    html_file << "        </div>\n"
+                 "    </body>\n"
+                 "</html>";
 
-        // Writing the footer means we're done.
-        if (g_record_info.initialized) {
-            g_record_info.initialized = false;
-            g_record_info.type = RECORD_NONE;
-        }
-
-        return true;
-    } catch (...) {
-        return false;
+    // Writing the footer means we're done.
+    if (g_record_info.initialized) {
+        g_record_info.initialized = false;
+        g_record_info.type = RECORD_NONE;
     }
+
+    return true;
 }
 
 // Api Dump Utility function to return an instance based on the generated dispatch table
@@ -402,163 +394,159 @@ XrResult ApiDumpLayerXrCreateInstance(const XrInstanceCreateInfo *info, XrInstan
 
 XrResult ApiDumpLayerXrCreateApiLayerInstance(const XrInstanceCreateInfo *info, const struct XrApiLayerCreateInfo *apiLayerInfo,
                                               XrInstance *instance) {
-    try {
-        PFN_xrGetInstanceProcAddr next_get_instance_proc_addr = nullptr;
-        PFN_xrCreateApiLayerInstance next_create_api_layer_instance = nullptr;
-        XrApiLayerCreateInfo new_api_layer_info = {};
-        bool first_time = !g_record_info.initialized;
+    PFN_xrGetInstanceProcAddr next_get_instance_proc_addr = nullptr;
+    PFN_xrCreateApiLayerInstance next_create_api_layer_instance = nullptr;
+    XrApiLayerCreateInfo new_api_layer_info = {};
+    bool first_time = !g_record_info.initialized;
 
-        if (!g_record_info.initialized) {
-            g_record_info.initialized = true;
-            g_record_info.type = RECORD_TEXT_COUT;
-        }
+    if (!g_record_info.initialized) {
+        g_record_info.initialized = true;
+        g_record_info.type = RECORD_TEXT_COUT;
+    }
 
-        char *export_type = PlatformUtilsGetEnv("XR_API_DUMP_EXPORT_TYPE");
-        char *file_name = PlatformUtilsGetEnv("XR_API_DUMP_FILE_NAME");
-        if (nullptr != file_name) {
-            g_record_info.file_name = file_name;
-            g_record_info.type = RECORD_TEXT_FILE;
-            PlatformUtilsFreeEnv(file_name);
-        }
+    char *export_type = PlatformUtilsGetEnv("XR_API_DUMP_EXPORT_TYPE");
+    char *file_name = PlatformUtilsGetEnv("XR_API_DUMP_FILE_NAME");
+    if (nullptr != file_name) {
+        g_record_info.file_name = file_name;
+        g_record_info.type = RECORD_TEXT_FILE;
+        PlatformUtilsFreeEnv(file_name);
+    }
 
-        if (nullptr != export_type) {
-            std::string string_export_type = export_type;
-            PlatformUtilsFreeEnv(export_type);
-            std::transform(string_export_type.begin(), string_export_type.end(), string_export_type.begin(),
-                           [](unsigned char c) { return std::tolower(c); });
+    if (nullptr != export_type) {
+        std::string string_export_type = export_type;
+        PlatformUtilsFreeEnv(export_type);
+        std::transform(string_export_type.begin(), string_export_type.end(), string_export_type.begin(),
+                       [](unsigned char c) { return std::tolower(c); });
 
-            if (string_export_type == "text") {
-                if (g_record_info.file_name.size() > 0) {
-                    g_record_info.type = RECORD_TEXT_FILE;
-                } else {
-                    g_record_info.type = RECORD_TEXT_COUT;
-                }
-            } else if (string_export_type == "html" && first_time) {
-                g_record_info.type = RECORD_HTML_FILE;
-                if (!ApiDumpLayerWriteHtmlHeader()) {
-                    return XR_ERROR_INITIALIZATION_FAILED;
-                }
-            } else if (string_export_type == "code") {
-                g_record_info.type = RECORD_CODE_FILE;
+        if (string_export_type == "text") {
+            if (g_record_info.file_name.size() > 0) {
+                g_record_info.type = RECORD_TEXT_FILE;
+            } else {
+                g_record_info.type = RECORD_TEXT_COUT;
             }
+        } else if (string_export_type == "html" && first_time) {
+            g_record_info.type = RECORD_HTML_FILE;
+            if (!ApiDumpLayerWriteHtmlHeader()) {
+                return XR_ERROR_INITIALIZATION_FAILED;
+            }
+        } else if (string_export_type == "code") {
+            g_record_info.type = RECORD_CODE_FILE;
         }
+    }
 
-        // Validate the API layer info and next API layer info structures before we try to use them
-        if (nullptr == apiLayerInfo || XR_LOADER_INTERFACE_STRUCT_API_LAYER_CREATE_INFO != apiLayerInfo->structType ||
-            XR_API_LAYER_CREATE_INFO_STRUCT_VERSION > apiLayerInfo->structVersion ||
-            sizeof(XrApiLayerCreateInfo) > apiLayerInfo->structSize || nullptr == apiLayerInfo->loaderInstance ||
-            nullptr == apiLayerInfo->nextInfo ||
-            XR_LOADER_INTERFACE_STRUCT_API_LAYER_NEXT_INFO != apiLayerInfo->nextInfo->structType ||
-            XR_API_LAYER_NEXT_INFO_STRUCT_VERSION > apiLayerInfo->nextInfo->structVersion ||
-            sizeof(XrApiLayerNextInfo) > apiLayerInfo->nextInfo->structSize ||
-            0 != strcmp("XR_APILAYER_LUNARG_api_dump", apiLayerInfo->nextInfo->layerName) ||
-            nullptr == apiLayerInfo->nextInfo->nextGetInstanceProcAddr ||
-            nullptr == apiLayerInfo->nextInfo->nextCreateApiLayerInstance) {
-            return XR_ERROR_INITIALIZATION_FAILED;
-        }
-
-        // Generate output for this command as if it were the standard xrCreateInstance
-        std::vector<std::tuple<std::string, std::string, std::string>> contents;
-        contents.push_back(std::make_tuple("XrResult", "xrCreateInstance", ""));
-        std::ostringstream oss_info;
-        oss_info << std::hex << reinterpret_cast<const void *>(info);
-        contents.push_back(std::make_tuple("const XrInstanceCreateInfo*", "info", oss_info.str()));
-        if (nullptr != info) {
-            std::string prefix = "info->";
-            contents.push_back(std::make_tuple("XrStructureType", "info->type", std::to_string(info->type)));
-            std::string next_prefix = prefix;
-            next_prefix += "next";
-            // Decode the next chain if it exists
-            if (!ApiDumpDecodeNextChain(nullptr, info->next, next_prefix, contents)) {
-                throw std::invalid_argument("Invalid Operation");
-            }
-            std::string flags_prefix = prefix;
-            flags_prefix += "createFlags";
-            contents.push_back(std::make_tuple("XrInstanceCreateFlags", flags_prefix, std::to_string(info->createFlags)));
-            std::string applicationinfo_prefix = prefix;
-            applicationinfo_prefix += "applicationInfo";
-            if (!ApiDumpOutputXrStruct(nullptr, &info->applicationInfo, applicationinfo_prefix, "XrApplicationInfo", true,
-                                       contents)) {
-                throw std::invalid_argument("Invalid Operation");
-            }
-            std::string enabledapilayercount_prefix = prefix;
-            enabledapilayercount_prefix += "enabledApiLayerCount";
-            std::ostringstream oss_enabledApiLayerCount;
-            oss_enabledApiLayerCount << "0x" << std::hex << (info->enabledApiLayerCount);
-            contents.push_back(std::make_tuple("uint32_t", enabledapilayercount_prefix, oss_enabledApiLayerCount.str()));
-            std::string enabledapilayernames_prefix = prefix;
-            enabledapilayernames_prefix += "enabledApiLayerNames";
-            std::ostringstream oss_enabledApiLayerNames_array;
-            oss_enabledApiLayerNames_array << "0x" << std::hex << (info->enabledApiLayerNames);
-            contents.push_back(
-                std::make_tuple("const char* const*", enabledapilayernames_prefix, oss_enabledApiLayerNames_array.str()));
-            for (uint32_t info_enabledapilayernames_inc = 0; info_enabledapilayernames_inc < info->enabledApiLayerCount;
-                 ++info_enabledapilayernames_inc) {
-                std::string enabledapilayernames_array_prefix = enabledapilayernames_prefix;
-                enabledapilayernames_array_prefix += "[";
-                enabledapilayernames_array_prefix += std::to_string(info_enabledapilayernames_inc);
-                enabledapilayernames_array_prefix += "]";
-                std::ostringstream oss_enabledApiLayerNames;
-                oss_enabledApiLayerNames << "0x" << std::hex << (*info->enabledApiLayerNames[info_enabledapilayernames_inc]);
-                contents.push_back(
-                    std::make_tuple("const char* const*", enabledapilayernames_array_prefix, oss_enabledApiLayerNames.str()));
-            }
-            std::string enabledextensioncount_prefix = prefix;
-            enabledextensioncount_prefix += "enabledExtensionCount";
-            std::ostringstream oss_enabledExtensionCount;
-            oss_enabledExtensionCount << "0x" << std::hex << (info->enabledExtensionCount);
-            contents.push_back(std::make_tuple("uint32_t", enabledextensioncount_prefix, oss_enabledExtensionCount.str()));
-            std::string enabledextensionnames_prefix = prefix;
-            enabledextensionnames_prefix += "enabledExtensionNames";
-            std::ostringstream oss_enabledExtensionNames_array;
-            oss_enabledExtensionNames_array << "0x" << std::hex << (info->enabledExtensionNames);
-            contents.push_back(
-                std::make_tuple("const char* const*", enabledextensionnames_prefix, oss_enabledExtensionNames_array.str()));
-            for (uint32_t info_enabledextensionnames_inc = 0; info_enabledextensionnames_inc < info->enabledExtensionCount;
-                 ++info_enabledextensionnames_inc) {
-                std::string enabledextensionnames_array_prefix = enabledextensionnames_prefix;
-                enabledextensionnames_array_prefix += "[";
-                enabledextensionnames_array_prefix += std::to_string(info_enabledextensionnames_inc);
-                enabledextensionnames_array_prefix += "]";
-                std::ostringstream oss_enabledExtensionNames;
-                oss_enabledExtensionNames << "0x" << std::hex << (*info->enabledExtensionNames[info_enabledextensionnames_inc]);
-                contents.push_back(
-                    std::make_tuple("const char* const*", enabledextensionnames_array_prefix, oss_enabledExtensionNames.str()));
-            }
-        }
-
-        std::ostringstream oss_instance;
-        oss_instance << std::hex << reinterpret_cast<uintptr_t>(instance);
-        std::string hex_instance = "0x";
-        hex_instance += oss_instance.str();
-        contents.push_back(std::make_tuple("XrInstance*", "instance", hex_instance));
-        ApiDumpLayerRecordContent(contents);
-
-        // Copy the contents of the layer info struct, but then move the next info up by
-        // one slot so that the next layer gets information.
-        memcpy(&new_api_layer_info, apiLayerInfo, sizeof(XrApiLayerCreateInfo));
-        new_api_layer_info.nextInfo = apiLayerInfo->nextInfo->next;
-
-        // Get the function pointers we need
-        next_get_instance_proc_addr = apiLayerInfo->nextInfo->nextGetInstanceProcAddr;
-        next_create_api_layer_instance = apiLayerInfo->nextInfo->nextCreateApiLayerInstance;
-
-        // Create the instance
-        XrInstance returned_instance = *instance;
-        XrResult result = next_create_api_layer_instance(info, &new_api_layer_info, &returned_instance);
-        *instance = returned_instance;
-
-        // Create the dispatch table to the next levels
-        XrGeneratedDispatchTable *next_dispatch = new XrGeneratedDispatchTable();
-        GeneratedXrPopulateDispatchTable(next_dispatch, returned_instance, next_get_instance_proc_addr);
-
-        std::unique_lock<std::mutex> mlock(g_instance_dispatch_mutex);
-        g_instance_dispatch_map[returned_instance] = next_dispatch;
-
-        return result;
-    } catch (...) {
+    // Validate the API layer info and next API layer info structures before we try to use them
+    if (nullptr == apiLayerInfo || XR_LOADER_INTERFACE_STRUCT_API_LAYER_CREATE_INFO != apiLayerInfo->structType ||
+        XR_API_LAYER_CREATE_INFO_STRUCT_VERSION > apiLayerInfo->structVersion ||
+        sizeof(XrApiLayerCreateInfo) > apiLayerInfo->structSize || nullptr == apiLayerInfo->loaderInstance ||
+        nullptr == apiLayerInfo->nextInfo ||
+        XR_LOADER_INTERFACE_STRUCT_API_LAYER_NEXT_INFO != apiLayerInfo->nextInfo->structType ||
+        XR_API_LAYER_NEXT_INFO_STRUCT_VERSION > apiLayerInfo->nextInfo->structVersion ||
+        sizeof(XrApiLayerNextInfo) > apiLayerInfo->nextInfo->structSize ||
+        0 != strcmp("XR_APILAYER_LUNARG_api_dump", apiLayerInfo->nextInfo->layerName) ||
+        nullptr == apiLayerInfo->nextInfo->nextGetInstanceProcAddr ||
+        nullptr == apiLayerInfo->nextInfo->nextCreateApiLayerInstance) {
         return XR_ERROR_INITIALIZATION_FAILED;
     }
+
+    // Generate output for this command as if it were the standard xrCreateInstance
+    std::vector<std::tuple<std::string, std::string, std::string>> contents;
+    contents.push_back(std::make_tuple("XrResult", "xrCreateInstance", ""));
+    std::ostringstream oss_info;
+    oss_info << std::hex << reinterpret_cast<const void *>(info);
+    contents.push_back(std::make_tuple("const XrInstanceCreateInfo*", "info", oss_info.str()));
+    if (nullptr != info) {
+        std::string prefix = "info->";
+        contents.push_back(std::make_tuple("XrStructureType", "info->type", std::to_string(info->type)));
+        std::string next_prefix = prefix;
+        next_prefix += "next";
+        // Decode the next chain if it exists
+        if (!ApiDumpDecodeNextChain(nullptr, info->next, next_prefix, contents)) {
+            return XR_ERROR_INITIALIZATION_FAILED;
+        }
+        std::string flags_prefix = prefix;
+        flags_prefix += "createFlags";
+        contents.push_back(std::make_tuple("XrInstanceCreateFlags", flags_prefix, std::to_string(info->createFlags)));
+        std::string applicationinfo_prefix = prefix;
+        applicationinfo_prefix += "applicationInfo";
+        if (!ApiDumpOutputXrStruct(nullptr, &info->applicationInfo, applicationinfo_prefix, "XrApplicationInfo", true,
+                                   contents)) {
+            return XR_ERROR_INITIALIZATION_FAILED;
+        }
+        std::string enabledapilayercount_prefix = prefix;
+        enabledapilayercount_prefix += "enabledApiLayerCount";
+        std::ostringstream oss_enabledApiLayerCount;
+        oss_enabledApiLayerCount << "0x" << std::hex << (info->enabledApiLayerCount);
+        contents.push_back(std::make_tuple("uint32_t", enabledapilayercount_prefix, oss_enabledApiLayerCount.str()));
+        std::string enabledapilayernames_prefix = prefix;
+        enabledapilayernames_prefix += "enabledApiLayerNames";
+        std::ostringstream oss_enabledApiLayerNames_array;
+        oss_enabledApiLayerNames_array << "0x" << std::hex << (info->enabledApiLayerNames);
+        contents.push_back(
+            std::make_tuple("const char* const*", enabledapilayernames_prefix, oss_enabledApiLayerNames_array.str()));
+        for (uint32_t info_enabledapilayernames_inc = 0; info_enabledapilayernames_inc < info->enabledApiLayerCount;
+             ++info_enabledapilayernames_inc) {
+            std::string enabledapilayernames_array_prefix = enabledapilayernames_prefix;
+            enabledapilayernames_array_prefix += "[";
+            enabledapilayernames_array_prefix += std::to_string(info_enabledapilayernames_inc);
+            enabledapilayernames_array_prefix += "]";
+            std::ostringstream oss_enabledApiLayerNames;
+            oss_enabledApiLayerNames << "0x" << std::hex << (*info->enabledApiLayerNames[info_enabledapilayernames_inc]);
+            contents.push_back(
+                std::make_tuple("const char* const*", enabledapilayernames_array_prefix, oss_enabledApiLayerNames.str()));
+        }
+        std::string enabledextensioncount_prefix = prefix;
+        enabledextensioncount_prefix += "enabledExtensionCount";
+        std::ostringstream oss_enabledExtensionCount;
+        oss_enabledExtensionCount << "0x" << std::hex << (info->enabledExtensionCount);
+        contents.push_back(std::make_tuple("uint32_t", enabledextensioncount_prefix, oss_enabledExtensionCount.str()));
+        std::string enabledextensionnames_prefix = prefix;
+        enabledextensionnames_prefix += "enabledExtensionNames";
+        std::ostringstream oss_enabledExtensionNames_array;
+        oss_enabledExtensionNames_array << "0x" << std::hex << (info->enabledExtensionNames);
+        contents.push_back(
+            std::make_tuple("const char* const*", enabledextensionnames_prefix, oss_enabledExtensionNames_array.str()));
+        for (uint32_t info_enabledextensionnames_inc = 0; info_enabledextensionnames_inc < info->enabledExtensionCount;
+             ++info_enabledextensionnames_inc) {
+            std::string enabledextensionnames_array_prefix = enabledextensionnames_prefix;
+            enabledextensionnames_array_prefix += "[";
+            enabledextensionnames_array_prefix += std::to_string(info_enabledextensionnames_inc);
+            enabledextensionnames_array_prefix += "]";
+            std::ostringstream oss_enabledExtensionNames;
+            oss_enabledExtensionNames << "0x" << std::hex << (*info->enabledExtensionNames[info_enabledextensionnames_inc]);
+            contents.push_back(
+                std::make_tuple("const char* const*", enabledextensionnames_array_prefix, oss_enabledExtensionNames.str()));
+        }
+    }
+
+    std::ostringstream oss_instance;
+    oss_instance << std::hex << reinterpret_cast<uintptr_t>(instance);
+    std::string hex_instance = "0x";
+    hex_instance += oss_instance.str();
+    contents.push_back(std::make_tuple("XrInstance*", "instance", hex_instance));
+    ApiDumpLayerRecordContent(contents);
+
+    // Copy the contents of the layer info struct, but then move the next info up by
+    // one slot so that the next layer gets information.
+    memcpy(&new_api_layer_info, apiLayerInfo, sizeof(XrApiLayerCreateInfo));
+    new_api_layer_info.nextInfo = apiLayerInfo->nextInfo->next;
+
+    // Get the function pointers we need
+    next_get_instance_proc_addr = apiLayerInfo->nextInfo->nextGetInstanceProcAddr;
+    next_create_api_layer_instance = apiLayerInfo->nextInfo->nextCreateApiLayerInstance;
+
+    // Create the instance
+    XrInstance returned_instance = *instance;
+    XrResult result = next_create_api_layer_instance(info, &new_api_layer_info, &returned_instance);
+    *instance = returned_instance;
+
+    // Create the dispatch table to the next levels
+    XrGeneratedDispatchTable *next_dispatch = new XrGeneratedDispatchTable();
+    GeneratedXrPopulateDispatchTable(next_dispatch, returned_instance, next_get_instance_proc_addr);
+
+    std::unique_lock<std::mutex> mlock(g_instance_dispatch_mutex);
+    g_instance_dispatch_map[returned_instance] = next_dispatch;
+
+    return result;
 }
 
 XrResult ApiDumpLayerXrDestroyInstance(XrInstance instance) {
@@ -573,17 +561,8 @@ XrResult ApiDumpLayerXrDestroyInstance(XrInstance instance) {
     ApiDumpLayerRecordContent(contents);
 
     std::unique_lock<std::mutex> mlock(g_instance_dispatch_mutex);
-    XrGeneratedDispatchTable *next_dispatch = nullptr;
-    auto map_iter = g_instance_dispatch_map.find(instance);
-    if (map_iter != g_instance_dispatch_map.end()) {
-        next_dispatch = map_iter->second;
-    }
+    XrGeneratedDispatchTable *next_dispatch = g_instance_dispatch_map[instance];
     mlock.unlock();
-
-    if (nullptr == next_dispatch) {
-        return XR_ERROR_HANDLE_INVALID;
-    }
-
     next_dispatch->DestroyInstance(instance);
     ApiDumpCleanUpMapsForTable(next_dispatch);
 

--- a/src/common/filesystem_utils.cpp
+++ b/src/common/filesystem_utils.cpp
@@ -104,104 +104,64 @@
 // We can use one of the C++ filesystem packages
 
 bool FileSysUtilsIsRegularFile(const std::string& path) {
-    try {
-        return FS_PREFIX::is_regular_file(path);
-    } catch (...) {
-        return false;
-    }
+    return FS_PREFIX::is_regular_file(path);
 }
 
 bool FileSysUtilsIsDirectory(const std::string& path) {
-    try {
-        return FS_PREFIX::is_directory(path);
-    } catch (...) {
-        return false;
-    }
+    return FS_PREFIX::is_directory(path);
 }
 
 bool FileSysUtilsPathExists(const std::string& path) {
-    try {
-        return FS_PREFIX::exists(path);
-    } catch (...) {
-        return false;
-    }
+    return FS_PREFIX::exists(path);
 }
 
 bool FileSysUtilsIsAbsolutePath(const std::string& path) {
-    try {
-        FS_PREFIX::path file_path(path);
-        return file_path.is_absolute();
-    } catch (...) {
-        return false;
-    }
+    FS_PREFIX::path file_path(path);
+    return file_path.is_absolute();
 }
 
 bool FileSysUtilsGetCurrentPath(std::string& path) {
-    try {
-        FS_PREFIX::path cur_path = FS_PREFIX::current_path();
-        path = cur_path.string();
-        return true;
-    } catch (...) {
-    }
-    return false;
+    FS_PREFIX::path cur_path = FS_PREFIX::current_path();
+    path = cur_path.string();
+    return true;
 }
 
 bool FileSysUtilsGetParentPath(const std::string& file_path, std::string& parent_path) {
-    try {
-        FS_PREFIX::path path_var(file_path);
-        parent_path = path_var.parent_path().string();
-        return true;
-    } catch (...) {
-    }
-    return false;
+    FS_PREFIX::path path_var(file_path);
+    parent_path = path_var.parent_path().string();
+    return true;
 }
 
 bool FileSysUtilsGetAbsolutePath(const std::string& path, std::string& absolute) {
-    try {
-        absolute = FS_PREFIX::absolute(path).string();
-        return true;
-    } catch (...) {
-    }
-    return false;
+    absolute = FS_PREFIX::absolute(path).string();
+    return true;
 }
 
 bool FileSysUtilsCombinePaths(const std::string& parent, const std::string& child, std::string& combined) {
-    try {
-        FS_PREFIX::path parent_path(parent);
-        FS_PREFIX::path child_path(child);
-        FS_PREFIX::path full_path = parent_path / child_path;
-        combined = full_path.string();
-        return true;
-    } catch (...) {
-    }
-    return false;
+    FS_PREFIX::path parent_path(parent);
+    FS_PREFIX::path child_path(child);
+    FS_PREFIX::path full_path = parent_path / child_path;
+    combined = full_path.string();
+    return true;
 }
 
 bool FileSysUtilsParsePathList(std::string& path_list, std::vector<std::string>& paths) {
-    try {
-        std::string::size_type start = 0;
-        std::string::size_type location = path_list.find(PATH_SEPARATOR);
-        while (location != std::string::npos) {
-            paths.push_back(path_list.substr(start, location));
-            start = location + 1;
-            location = path_list.find(PATH_SEPARATOR, start);
-        }
+    std::string::size_type start = 0;
+    std::string::size_type location = path_list.find(PATH_SEPARATOR);
+    while (location != std::string::npos) {
         paths.push_back(path_list.substr(start, location));
-        return true;
-    } catch (...) {
+        start = location + 1;
+        location = path_list.find(PATH_SEPARATOR, start);
     }
-    return false;
+    paths.push_back(path_list.substr(start, location));
+    return true;
 }
 
 bool FileSysUtilsFindFilesInPath(const std::string& path, std::vector<std::string>& files) {
-    try {
-        for (auto& dir_iter : FS_PREFIX::directory_iterator(path)) {
-            files.push_back(dir_iter.path().filename().string());
-        }
-        return true;
-    } catch (...) {
+    for (auto& dir_iter : FS_PREFIX::directory_iterator(path)) {
+        files.push_back(dir_iter.path().filename().string());
     }
-    return false;
+    return true;
 }
 
 #elif defined(XR_OS_WINDOWS)
@@ -209,123 +169,88 @@ bool FileSysUtilsFindFilesInPath(const std::string& path, std::vector<std::strin
 // Workaround for MS VS 2010/2013 don't support the experimental filesystem
 
 bool FileSysUtilsIsRegularFile(const std::string& path) {
-    try {
-        return (1 != PathIsDirectoryA(path.c_str()));
-    } catch (...) {
-        return false;
-    }
+    return (1 != PathIsDirectoryA(path.c_str()));
 }
 
 bool FileSysUtilsIsDirectory(const std::string& path) {
-    try {
-        return (1 == PathIsDirectoryA(path.c_str()));
-    } catch (...) {
-        return false;
-    }
+    return (1 == PathIsDirectoryA(path.c_str()));
 }
 
 bool FileSysUtilsPathExists(const std::string& path) {
-    try {
-        return (1 == PathFileExistsA(path.c_str()));
-    } catch (...) {
-        return false;
-    }
+    return (1 == PathFileExistsA(path.c_str()));
 }
 
 bool FileSysUtilsIsAbsolutePath(const std::string& path) {
-    try {
-        if ((path[0] == '\\') || (path[1] == ':' && (path[2] == '\\' || path[2] == '/'))) {
-            return true;
-        }
-    } catch (...) {
+    if ((path[0] == '\\') || (path[1] == ':' && (path[2] == '\\' || path[2] == '/'))) {
+        return true;
     }
     return false;
 }
 
 bool FileSysUtilsGetCurrentPath(std::string& path) {
-    try {
-        char tmp_path[MAX_PATH];
-        if (nullptr != _getcwd(tmp_path, MAX_PATH - 1)) {
-            path = tmp_path;
-            return true;
-        }
-    } catch (...) {
+    char tmp_path[MAX_PATH];
+    if (nullptr != _getcwd(tmp_path, MAX_PATH - 1)) {
+        path = tmp_path;
+        return true;
     }
     return false;
 }
 
 bool FileSysUtilsGetParentPath(const std::string& file_path, std::string& parent_path) {
-    try {
-        std::string full_path;
-        if (FileSysUtilsGetAbsolutePath(file_path, full_path)) {
-            std::string::size_type lastSeperator = full_path.find_last_of(DIRECTORY_SYMBOL);
-            parent_path = (lastSeperator == 0) ? full_path : full_path.substr(0, lastSeperator);
-            return true;
-        }
-    } catch (...) {
+    std::string full_path;
+    if (FileSysUtilsGetAbsolutePath(file_path, full_path)) {
+        std::string::size_type lastSeperator = full_path.find_last_of(DIRECTORY_SYMBOL);
+        parent_path = (lastSeperator == 0) ? full_path : full_path.substr(0, lastSeperator);
+        return true;
     }
     return false;
 }
 
 bool FileSysUtilsGetAbsolutePath(const std::string& path, std::string& absolute) {
-    try {
-        char tmp_path[MAX_PATH];
-        if (0 != GetFullPathNameA(path.c_str(), MAX_PATH, tmp_path, NULL)) {
-            absolute = tmp_path;
-            return true;
-        }
-    } catch (...) {
+    char tmp_path[MAX_PATH];
+    if (0 != GetFullPathNameA(path.c_str(), MAX_PATH, tmp_path, NULL)) {
+        absolute = tmp_path;
+        return true;
     }
     return false;
 }
 
 bool FileSysUtilsCombinePaths(const std::string& parent, const std::string& child, std::string& combined) {
-    try {
-        std::string::size_type parent_len = parent.length();
-        if (0 == parent_len || "." == parent || ".\\" == parent || "./" == parent) {
-            combined = child;
-            return true;
-        }
-        char last_char = parent[parent_len - 1];
-        if (last_char == DIRECTORY_SYMBOL) {
-            parent_len--;
-        }
-        combined = parent.substr(0, parent_len) + DIRECTORY_SYMBOL + child;
+    std::string::size_type parent_len = parent.length();
+    if (0 == parent_len || "." == parent || ".\\" == parent || "./" == parent) {
+        combined = child;
         return true;
-    } catch (...) {
     }
-    return false;
+    char last_char = parent[parent_len - 1];
+    if (last_char == DIRECTORY_SYMBOL) {
+        parent_len--;
+    }
+    combined = parent.substr(0, parent_len) + DIRECTORY_SYMBOL + child;
+    return true;
 }
 
 bool FileSysUtilsParsePathList(std::string& path_list, std::vector<std::string>& paths) {
-    try {
-        std::string::size_type start = 0;
-        std::string::size_type location = path_list.find(PATH_SEPARATOR);
-        while (location != std::string::npos) {
-            paths.push_back(path_list.substr(start, location));
-            start = location + 1;
-            location = path_list.find(PATH_SEPARATOR, start);
-        }
+    std::string::size_type start = 0;
+    std::string::size_type location = path_list.find(PATH_SEPARATOR);
+    while (location != std::string::npos) {
         paths.push_back(path_list.substr(start, location));
-        return true;
-    } catch (...) {
+        start = location + 1;
+        location = path_list.find(PATH_SEPARATOR, start);
     }
-    return false;
+    paths.push_back(path_list.substr(start, location));
+    return true;
 }
 
 bool FileSysUtilsFindFilesInPath(const std::string& path, std::vector<std::string>& files) {
-    try {
-        WIN32_FIND_DATAA file_data;
-        HANDLE file_handle = FindFirstFileA(path.c_str(), &file_data);
-        if (file_handle != INVALID_HANDLE_VALUE) {
-            do {
-                if (!(file_data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)) {
-                    files.push_back(file_data.cFileName);
-                }
-            } while (FindNextFileA(file_handle, &file_data));
-            return true;
-        }
-    } catch (...) {
+    WIN32_FIND_DATAA file_data;
+    HANDLE file_handle = FindFirstFileA(path.c_str(), &file_data);
+    if (file_handle != INVALID_HANDLE_VALUE) {
+        do {
+            if (!(file_data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)) {
+                files.push_back(file_data.cFileName);
+            }
+        } while (FindNextFileA(file_handle, &file_data));
+        return true;
     }
     return false;
 }
@@ -341,125 +266,88 @@ bool FileSysUtilsFindFilesInPath(const std::string& path, std::vector<std::strin
 // simple POSIX-compatible implementation of the <filesystem> pieces used by OpenXR
 
 bool FileSysUtilsIsRegularFile(const std::string& path) {
-    try {
-        struct stat path_stat;
-        stat(path.c_str(), &path_stat);
-        return S_ISREG(path_stat.st_mode);
-    } catch (...) {
-    }
-    return false;
+    struct stat path_stat;
+    stat(path.c_str(), &path_stat);
+    return S_ISREG(path_stat.st_mode);
 }
 
 bool FileSysUtilsIsDirectory(const std::string& path) {
-    try {
-        struct stat path_stat;
-        stat(path.c_str(), &path_stat);
-        return S_ISDIR(path_stat.st_mode);
-    } catch (...) {
-    }
-    return false;
+    struct stat path_stat;
+    stat(path.c_str(), &path_stat);
+    return S_ISDIR(path_stat.st_mode);
 }
 
 bool FileSysUtilsPathExists(const std::string& path) {
-    try {
-        return (access(path.c_str(), F_OK) != -1);
-    } catch (...) {
-    }
-    return false;
+    return (access(path.c_str(), F_OK) != -1);
 }
 
 bool FileSysUtilsIsAbsolutePath(const std::string& path) {
-    try {
-        return (path[0] == DIRECTORY_SYMBOL);
-    } catch (...) {
-    }
-    return false;
+    return (path[0] == DIRECTORY_SYMBOL);
 }
 
 bool FileSysUtilsGetCurrentPath(std::string& path) {
-    try {
-        char tmp_path[PATH_MAX];
-        if (nullptr != getcwd(tmp_path, PATH_MAX - 1)) {
-            path = tmp_path;
-            return true;
-        }
-    } catch (...) {
+    char tmp_path[PATH_MAX];
+    if (nullptr != getcwd(tmp_path, PATH_MAX - 1)) {
+        path = tmp_path;
+        return true;
     }
     return false;
 }
 
 bool FileSysUtilsGetParentPath(const std::string& file_path, std::string& parent_path) {
-    try {
-        std::string full_path;
-        if (FileSysUtilsGetAbsolutePath(file_path, full_path)) {
-            std::string::size_type lastSeperator = full_path.find_last_of(DIRECTORY_SYMBOL);
-            parent_path = (lastSeperator == 0) ? full_path : full_path.substr(0, lastSeperator - 1);
-            return true;
-        }
-    } catch (...) {
+    std::string full_path;
+    if (FileSysUtilsGetAbsolutePath(file_path, full_path)) {
+        std::string::size_type lastSeperator = full_path.find_last_of(DIRECTORY_SYMBOL);
+        parent_path = (lastSeperator == 0) ? full_path : full_path.substr(0, lastSeperator - 1);
+        return true;
     }
     return false;
 }
 
 bool FileSysUtilsGetAbsolutePath(const std::string& path, std::string& absolute) {
-    try {
-        char buf[PATH_MAX];
-        if (nullptr != realpath(path.c_str(), buf)) {
-            absolute = buf;
-            return true;
-        }
-    } catch (...) {
+    char buf[PATH_MAX];
+    if (nullptr != realpath(path.c_str(), buf)) {
+        absolute = buf;
+        return true;
     }
     return false;
 }
 
 bool FileSysUtilsCombinePaths(const std::string& parent, const std::string& child, std::string& combined) {
-    try {
-        std::string::size_type parent_len = parent.length();
-        if (0 == parent_len || "." == parent || "./" == parent) {
-            combined = child;
-            return true;
-        }
-        char last_char = parent[parent_len - 1];
-        if (last_char == DIRECTORY_SYMBOL) {
-            parent_len--;
-        }
-        combined = parent.substr(0, parent_len) + DIRECTORY_SYMBOL + child;
+    std::string::size_type parent_len = parent.length();
+    if (0 == parent_len || "." == parent || "./" == parent) {
+        combined = child;
         return true;
-    } catch (...) {
     }
-    return false;
+    char last_char = parent[parent_len - 1];
+    if (last_char == DIRECTORY_SYMBOL) {
+        parent_len--;
+    }
+    combined = parent.substr(0, parent_len) + DIRECTORY_SYMBOL + child;
+    return true;
 }
 
 bool FileSysUtilsParsePathList(std::string& path_list, std::vector<std::string>& paths) {
-    try {
-        std::string::size_type start = 0;
-        std::string::size_type location = path_list.find(PATH_SEPARATOR);
-        while (location != std::string::npos) {
-            paths.push_back(path_list.substr(start, location));
-            start = location + 1;
-            location = path_list.find(PATH_SEPARATOR, start);
-        }
+    std::string::size_type start = 0;
+    std::string::size_type location = path_list.find(PATH_SEPARATOR);
+    while (location != std::string::npos) {
         paths.push_back(path_list.substr(start, location));
-        return true;
-    } catch (...) {
+        start = location + 1;
+        location = path_list.find(PATH_SEPARATOR, start);
     }
-    return false;
+    paths.push_back(path_list.substr(start, location));
+    return true;
 }
 
 bool FileSysUtilsFindFilesInPath(const std::string& path, std::vector<std::string>& files) {
-    try {
-        DIR* dir;
-        struct dirent* entry;
-        dir = opendir(path.c_str());
-        while (dir && (entry = readdir(dir))) {
-            files.push_back(entry->d_name);
-        }
-        closedir(dir);
-        return true;
-    } catch (...) {
+    DIR* dir;
+    struct dirent* entry;
+    dir = opendir(path.c_str());
+    while (dir && (entry = readdir(dir))) {
+        files.push_back(entry->d_name);
     }
-    return false;
+    closedir(dir);
+    return true;
 }
 
 #endif

--- a/src/external/jsoncpp/include/json/config.h
+++ b/src/external/jsoncpp/include/json/config.h
@@ -22,7 +22,7 @@
 // If non-zero, the library uses exceptions to report bad input instead of C
 // assertion macros. The default is to use exceptions.
 #ifndef JSON_USE_EXCEPTION
-#define JSON_USE_EXCEPTION 1
+#define JSON_USE_EXCEPTION 0
 #endif
 
 /// If defined, indicates that the source file is amalgated

--- a/src/loader/api_layer_interface.cpp
+++ b/src/loader/api_layer_interface.cpp
@@ -32,349 +32,321 @@
 
 // Add any layers defined in the loader layer environment variable.
 static void AddEnvironmentApiLayers(const std::string& openxr_command, std::vector<std::string>& enabled_layers) {
-    try {
-        char* layer_environment_variable = PlatformUtilsGetEnv(OPENXR_ENABLE_LAYERS_ENV_VAR);
-        if (nullptr != layer_environment_variable) {
-            std::string layers = layer_environment_variable;
-            PlatformUtilsFreeEnv(layer_environment_variable);
+    char* layer_environment_variable = PlatformUtilsGetEnv(OPENXR_ENABLE_LAYERS_ENV_VAR);
+    if (nullptr != layer_environment_variable) {
+        std::string layers = layer_environment_variable;
+        PlatformUtilsFreeEnv(layer_environment_variable);
 
-            std::size_t last_found = 0;
-            std::size_t found = layers.find_first_of(PATH_SEPARATOR);
-            std::string cur_search;
+        std::size_t last_found = 0;
+        std::size_t found = layers.find_first_of(PATH_SEPARATOR);
+        std::string cur_search;
 
-            // Handle any path listings in the string (separated by the appropriate path separator)
-            while (found != std::string::npos) {
-                cur_search = layers.substr(last_found, found);
-                enabled_layers.push_back(cur_search);
-                last_found = found + 1;
-                found = layers.find_first_of(PATH_SEPARATOR, last_found);
-            }
-
-            // If there's something remaining in the string, copy it over
-            if (last_found < layers.size()) {
-                cur_search = layers.substr(last_found);
-                enabled_layers.push_back(cur_search);
-            }
+        // Handle any path listings in the string (separated by the appropriate path separator)
+        while (found != std::string::npos) {
+            cur_search = layers.substr(last_found, found);
+            enabled_layers.push_back(cur_search);
+            last_found = found + 1;
+            found = layers.find_first_of(PATH_SEPARATOR, last_found);
         }
-    } catch (...) {
-        LoaderLogger::LogErrorMessage(openxr_command, "AddEnvironmentApiLayers - unknown error occurred");
-        throw;
+
+        // If there's something remaining in the string, copy it over
+        if (last_found < layers.size()) {
+            cur_search = layers.substr(last_found);
+            enabled_layers.push_back(cur_search);
+        }
     }
 }
 
 XrResult ApiLayerInterface::GetApiLayerProperties(const std::string& openxr_command, uint32_t incoming_count,
                                                   uint32_t* outgoing_count, XrApiLayerProperties* api_layer_properties) {
-    try {
-        std::vector<std::unique_ptr<ApiLayerManifestFile>> manifest_files;
-        uint32_t manifest_count = 0;
+    std::vector<std::unique_ptr<ApiLayerManifestFile>> manifest_files;
+    uint32_t manifest_count = 0;
 
-        // Find any implicit layers which we may need to report information for.
-        XrResult result = ApiLayerManifestFile::FindManifestFiles(MANIFEST_TYPE_IMPLICIT_API_LAYER, manifest_files);
-        if (XR_SUCCESS == result) {
-            // Find any explicit layers which we may need to report information for.
-            result = ApiLayerManifestFile::FindManifestFiles(MANIFEST_TYPE_EXPLICIT_API_LAYER, manifest_files);
-        }
-        if (XR_SUCCESS != result) {
-            LoaderLogger::LogErrorMessage(
-                openxr_command, "ApiLayerInterface::GetApiLayerProperties - failed searching for API layer manifest files");
-            return result;
-        }
-
-        manifest_count = static_cast<uint32_t>(manifest_files.size());
-        if (0 == incoming_count) {
-            *outgoing_count = manifest_count;
-        } else if (nullptr != api_layer_properties) {
-            if (incoming_count < manifest_count && nullptr != api_layer_properties) {
-                LoaderLogger::LogErrorMessage(
-                    "xrEnumerateInstanceExtensionProperties",
-                    "VUID-xrEnumerateApiLayerProperties-propertyCapacityInput-parameter: insufficient space in array");
-                *outgoing_count = manifest_count;
-                return XR_ERROR_SIZE_INSUFFICIENT;
-            }
-
-            uint32_t prop = 0;
-            bool properties_valid = true;
-            for (; prop < incoming_count && prop < manifest_count; ++prop) {
-                if (XR_TYPE_API_LAYER_PROPERTIES != api_layer_properties[prop].type) {
-                    LoaderLogger::LogErrorMessage(openxr_command,
-                                                  "VUID-XrApiLayerProperties-type-type: unknown type in api_layer_properties");
-                    properties_valid = false;
-                }
-                if (nullptr != api_layer_properties[prop].next) {
-                    LoaderLogger::LogErrorMessage(openxr_command, "VUID-XrApiLayerProperties-next-next: expected NULL");
-                    properties_valid = false;
-                }
-                if (properties_valid) {
-                    api_layer_properties[prop] = manifest_files[prop]->GetApiLayerProperties();
-                }
-            }
-            if (!properties_valid) {
-                LoaderLogger::LogErrorMessage(openxr_command,
-                                              "VUID-xrEnumerateApiLayerProperties-properties-parameter: invalid properties");
-                return XR_ERROR_VALIDATION_FAILURE;
-            } else if (nullptr != outgoing_count) {
-                *outgoing_count = prop;
-            }
-        }
-        return XR_SUCCESS;
-    } catch (...) {
-        LoaderLogger::LogErrorMessage(openxr_command, "ApiLayerInterface::GetApiLayerProperties - unknown error occurred");
-        return XR_ERROR_VALIDATION_FAILURE;
+    // Find any implicit layers which we may need to report information for.
+    XrResult result = ApiLayerManifestFile::FindManifestFiles(MANIFEST_TYPE_IMPLICIT_API_LAYER, manifest_files);
+    if (XR_SUCCESS == result) {
+        // Find any explicit layers which we may need to report information for.
+        result = ApiLayerManifestFile::FindManifestFiles(MANIFEST_TYPE_EXPLICIT_API_LAYER, manifest_files);
     }
+    if (XR_SUCCESS != result) {
+        LoaderLogger::LogErrorMessage(
+            openxr_command, "ApiLayerInterface::GetApiLayerProperties - failed searching for API layer manifest files");
+        return result;
+    }
+
+    manifest_count = static_cast<uint32_t>(manifest_files.size());
+    if (0 == incoming_count) {
+        *outgoing_count = manifest_count;
+    } else if (nullptr != api_layer_properties) {
+        if (incoming_count < manifest_count && nullptr != api_layer_properties) {
+            LoaderLogger::LogErrorMessage(
+                "xrEnumerateInstanceExtensionProperties",
+                "VUID-xrEnumerateApiLayerProperties-propertyCapacityInput-parameter: insufficient space in array");
+            *outgoing_count = manifest_count;
+            return XR_ERROR_SIZE_INSUFFICIENT;
+        }
+
+        uint32_t prop = 0;
+        bool properties_valid = true;
+        for (; prop < incoming_count && prop < manifest_count; ++prop) {
+            if (XR_TYPE_API_LAYER_PROPERTIES != api_layer_properties[prop].type) {
+                LoaderLogger::LogErrorMessage(openxr_command,
+                                              "VUID-XrApiLayerProperties-type-type: unknown type in api_layer_properties");
+                properties_valid = false;
+            }
+            if (nullptr != api_layer_properties[prop].next) {
+                LoaderLogger::LogErrorMessage(openxr_command, "VUID-XrApiLayerProperties-next-next: expected NULL");
+                properties_valid = false;
+            }
+            if (properties_valid) {
+                api_layer_properties[prop] = manifest_files[prop]->GetApiLayerProperties();
+            }
+        }
+        if (!properties_valid) {
+            LoaderLogger::LogErrorMessage(openxr_command,
+                                          "VUID-xrEnumerateApiLayerProperties-properties-parameter: invalid properties");
+            return XR_ERROR_VALIDATION_FAILURE;
+        } else if (nullptr != outgoing_count) {
+            *outgoing_count = prop;
+        }
+    }
+    return XR_SUCCESS;
 }
 
 XrResult ApiLayerInterface::GetInstanceExtensionProperties(const std::string& openxr_command, const char* layer_name,
                                                            std::vector<XrExtensionProperties>& extension_properties) {
-    try {
-        std::vector<std::unique_ptr<ApiLayerManifestFile>> manifest_files;
+    std::vector<std::unique_ptr<ApiLayerManifestFile>> manifest_files;
 
-        // If a layer name is supplied, only use the information out of that one layer
-        if (nullptr != layer_name && 0 != strlen(layer_name)) {
-            XrResult result = ApiLayerManifestFile::FindManifestFiles(MANIFEST_TYPE_IMPLICIT_API_LAYER, manifest_files);
-            if (XR_SUCCESS == result) {
-                // Find any explicit layers which we may need to report information for.
-                result = ApiLayerManifestFile::FindManifestFiles(MANIFEST_TYPE_EXPLICIT_API_LAYER, manifest_files);
-                if (XR_SUCCESS != result) {
-                    LoaderLogger::LogErrorMessage(
-                        openxr_command,
-                        "ApiLayerInterface::GetInstanceExtensionProperties - failed searching for API layer manifest files");
-                    return result;
-                }
-
-                bool found = false;
-                uint32_t num_files = static_cast<uint32_t>(manifest_files.size());
-                for (uint32_t man_file = 0; man_file < num_files; ++man_file) {
-                    // If a layer with the provided name exists, get it's instance extension information.
-                    if (manifest_files[man_file]->LayerName() == layer_name) {
-                        manifest_files[man_file]->GetInstanceExtensionProperties(extension_properties);
-                        found = true;
-                        break;
-                    }
-                }
-
-                // If nothing found, report 0
-                if (!found) {
-                    return XR_ERROR_API_LAYER_NOT_PRESENT;
-                }
-            }
-            // Otherwise, we want to add only implicit API layers and explicit API layers enabled using the environment variables
-        } else {
-            XrResult result = ApiLayerManifestFile::FindManifestFiles(MANIFEST_TYPE_IMPLICIT_API_LAYER, manifest_files);
-            if (XR_SUCCESS == result) {
-                // Find any environmentally enabled explicit layers.  If they're present, treat them like implicit layers
-                // since we know that they're going to be enabled.
-                std::vector<std::string> env_enabled_layers;
-                AddEnvironmentApiLayers(openxr_command, env_enabled_layers);
-                if (env_enabled_layers.size() > 0) {
-                    std::vector<std::unique_ptr<ApiLayerManifestFile>> exp_layer_man_files = {};
-                    result = ApiLayerManifestFile::FindManifestFiles(MANIFEST_TYPE_EXPLICIT_API_LAYER, exp_layer_man_files);
-                    if (XR_SUCCESS == result) {
-                        for (auto l_iter = exp_layer_man_files.begin();
-                             exp_layer_man_files.size() > 0 && l_iter != exp_layer_man_files.end();
-                             /* No iterate */) {
-                            for (std::string& enabled_layer : env_enabled_layers) {
-                                // If this is an enabled layer, transfer it over to the manifest list.
-                                if (enabled_layer == (*l_iter)->LayerName()) {
-                                    manifest_files.push_back(std::move(*l_iter));
-                                    break;
-                                }
-                            }
-                            exp_layer_man_files.erase(l_iter);
-                        }
-                    }
-                }
+    // If a layer name is supplied, only use the information out of that one layer
+    if (nullptr != layer_name && 0 != strlen(layer_name)) {
+        XrResult result = ApiLayerManifestFile::FindManifestFiles(MANIFEST_TYPE_IMPLICIT_API_LAYER, manifest_files);
+        if (XR_SUCCESS == result) {
+            // Find any explicit layers which we may need to report information for.
+            result = ApiLayerManifestFile::FindManifestFiles(MANIFEST_TYPE_EXPLICIT_API_LAYER, manifest_files);
+            if (XR_SUCCESS != result) {
+                LoaderLogger::LogErrorMessage(
+                    openxr_command,
+                    "ApiLayerInterface::GetInstanceExtensionProperties - failed searching for API layer manifest files");
+                return result;
             }
 
-            // Grab the layer instance extensions information
+            bool found = false;
             uint32_t num_files = static_cast<uint32_t>(manifest_files.size());
             for (uint32_t man_file = 0; man_file < num_files; ++man_file) {
-                manifest_files[man_file]->GetInstanceExtensionProperties(extension_properties);
+                // If a layer with the provided name exists, get it's instance extension information.
+                if (manifest_files[man_file]->LayerName() == layer_name) {
+                    manifest_files[man_file]->GetInstanceExtensionProperties(extension_properties);
+                    found = true;
+                    break;
+                }
+            }
+
+            // If nothing found, report 0
+            if (!found) {
+                return XR_ERROR_API_LAYER_NOT_PRESENT;
             }
         }
-        return XR_SUCCESS;
-    } catch (...) {
-        LoaderLogger::LogErrorMessage(openxr_command, "ApiLayerInterface::GetInstanceExtensionProperties - unknown error occurred");
-        return XR_ERROR_INITIALIZATION_FAILED;
+        // Otherwise, we want to add only implicit API layers and explicit API layers enabled using the environment variables
+    } else {
+        XrResult result = ApiLayerManifestFile::FindManifestFiles(MANIFEST_TYPE_IMPLICIT_API_LAYER, manifest_files);
+        if (XR_SUCCESS == result) {
+            // Find any environmentally enabled explicit layers.  If they're present, treat them like implicit layers
+            // since we know that they're going to be enabled.
+            std::vector<std::string> env_enabled_layers;
+            AddEnvironmentApiLayers(openxr_command, env_enabled_layers);
+            if (env_enabled_layers.size() > 0) {
+                std::vector<std::unique_ptr<ApiLayerManifestFile>> exp_layer_man_files = {};
+                result = ApiLayerManifestFile::FindManifestFiles(MANIFEST_TYPE_EXPLICIT_API_LAYER, exp_layer_man_files);
+                if (XR_SUCCESS == result) {
+                    for (auto l_iter = exp_layer_man_files.begin();
+                         exp_layer_man_files.size() > 0 && l_iter != exp_layer_man_files.end();
+                         /* No iterate */) {
+                        for (std::string& enabled_layer : env_enabled_layers) {
+                            // If this is an enabled layer, transfer it over to the manifest list.
+                            if (enabled_layer == (*l_iter)->LayerName()) {
+                                manifest_files.push_back(std::move(*l_iter));
+                                break;
+                            }
+                        }
+                        exp_layer_man_files.erase(l_iter);
+                    }
+                }
+            }
+        }
+
+        // Grab the layer instance extensions information
+        uint32_t num_files = static_cast<uint32_t>(manifest_files.size());
+        for (uint32_t man_file = 0; man_file < num_files; ++man_file) {
+            manifest_files[man_file]->GetInstanceExtensionProperties(extension_properties);
+        }
     }
+    return XR_SUCCESS;
 }
 
 XrResult ApiLayerInterface::LoadApiLayers(const std::string& openxr_command, uint32_t enabled_api_layer_count,
                                           const char* const* enabled_api_layer_names,
                                           std::vector<std::unique_ptr<ApiLayerInterface>>& api_layer_interfaces) {
     XrResult last_error = XR_SUCCESS;
-    try {
-        bool any_loaded = false;
-        std::vector<bool> layer_found;
-        std::vector<std::unique_ptr<ApiLayerManifestFile>> layer_manifest_files = {};
+    bool any_loaded = false;
+    std::vector<bool> layer_found;
+    std::vector<std::unique_ptr<ApiLayerManifestFile>> layer_manifest_files = {};
 
-        // Find any implicit layers which we may need to report information for.
-        XrResult result = ApiLayerManifestFile::FindManifestFiles(MANIFEST_TYPE_IMPLICIT_API_LAYER, layer_manifest_files);
-        if (XR_SUCCESS == result) {
-            // Find any explicit layers which we may need to report information for.
-            result = ApiLayerManifestFile::FindManifestFiles(MANIFEST_TYPE_EXPLICIT_API_LAYER, layer_manifest_files);
-        }
-
-        // Put all the enabled layers into a string vector
-        std::vector<std::string> enabled_api_layers = {};
-        AddEnvironmentApiLayers(openxr_command, enabled_api_layers);
-        if (enabled_api_layer_count > 0) {
-            if (nullptr == enabled_api_layer_names) {
-                LoaderLogger::LogErrorMessage(
-                    "xrCreateInstance",
-                    "VUID-XrInstanceCreateInfo-enabledApiLayerNames-parameter: enabledApiLayerCount is non-0 but array is NULL");
-                LoaderLogger::LogErrorMessage(
-                    "xrCreateInstance", "VUID-xrCreateInstance-info-parameter: something wrong with XrInstanceCreateInfo contents");
-                return XR_ERROR_VALIDATION_FAILURE;
-            }
-            uint32_t num_env_api_layers = static_cast<uint32_t>(enabled_api_layers.size());
-            uint32_t total_api_layers = num_env_api_layers + enabled_api_layer_count;
-            enabled_api_layers.resize(total_api_layers);
-            for (uint32_t layer = 0; layer < enabled_api_layer_count; ++layer) {
-                enabled_api_layers[num_env_api_layers + layer] = enabled_api_layer_names[layer];
-            }
-        }
-
-        // Initialize the layer found vector to false
-        layer_found.resize(enabled_api_layers.size());
-        for (uint32_t layer = 0; layer < layer_found.size(); ++layer) {
-            layer_found[layer] = false;
-        }
-
-        for (std::unique_ptr<ApiLayerManifestFile>& manifest_file : layer_manifest_files) {
-            bool enabled = false;
-
-            // Always add implicit layers.  They would only be in this list if they were enabled
-            // (i.e. the disable environment variable is not set).
-            if (manifest_file->Type() == MANIFEST_TYPE_IMPLICIT_API_LAYER) {
-                enabled = true;
-            } else {
-                // Only add explicit layers if they are called out by the application
-                for (uint32_t layer = 0; layer < enabled_api_layers.size(); ++layer) {
-                    if (enabled_api_layers[layer] == manifest_file->LayerName()) {
-                        layer_found[layer] = true;
-                        enabled = true;
-                        break;
-                    }
-                }
-            }
-
-            // If this layer isn't enabled, skip it.
-            if (!enabled) {
-                continue;
-            }
-
-            LoaderPlatformLibraryHandle layer_library = LoaderPlatformLibraryOpen(manifest_file->LibraryPath());
-            if (nullptr == layer_library) {
-                if (!any_loaded) {
-                    last_error = XR_ERROR_FILE_ACCESS_ERROR;
-                }
-                std::string library_message = LoaderPlatformLibraryOpenError(manifest_file->LibraryPath());
-                std::string warning_message = "ApiLayerInterface::LoadApiLayers skipping layer ";
-                warning_message += manifest_file->LayerName();
-                warning_message += ", failed to load with message \"";
-                warning_message += library_message;
-                warning_message += "\"";
-                LoaderLogger::LogWarningMessage(openxr_command, warning_message);
-                continue;
-            }
-
-            // Get and settle on an layer interface version (using any provided name if required).
-            std::string function_name = manifest_file->GetFunctionName("xrNegotiateLoaderApiLayerInterface");
-            PFN_xrNegotiateLoaderApiLayerInterface negotiate = reinterpret_cast<PFN_xrNegotiateLoaderApiLayerInterface>(
-                LoaderPlatformLibraryGetProcAddr(layer_library, function_name));
-
-            // Loader info for negotiation
-            XrNegotiateLoaderInfo loader_info = {};
-            loader_info.structType = XR_LOADER_INTERFACE_STRUCT_LOADER_INFO;
-            loader_info.structVersion = XR_LOADER_INFO_STRUCT_VERSION;
-            loader_info.structSize = sizeof(XrNegotiateLoaderInfo);
-            loader_info.minInterfaceVersion = 1;
-            loader_info.maxInterfaceVersion = XR_CURRENT_LOADER_API_LAYER_VERSION;
-            loader_info.minXrVersion = XR_MAKE_VERSION(0, 1, 0);
-            loader_info.maxXrVersion = XR_MAKE_VERSION(1, 0, 0);
-
-            // Set up the layer return structure
-            XrNegotiateApiLayerRequest api_layer_info = {};
-            api_layer_info.structType = XR_LOADER_INTERFACE_STRUCT_API_LAYER_REQUEST;
-            api_layer_info.structVersion = XR_API_LAYER_INFO_STRUCT_VERSION;
-            api_layer_info.structSize = sizeof(XrNegotiateApiLayerRequest);
-
-            XrResult res = negotiate(&loader_info, manifest_file->LayerName().c_str(), &api_layer_info);
-            // If we supposedly succeeded, but got a nullptr for getInstanceProcAddr
-            // then something still went wrong, so return with an error.
-            if (XR_SUCCESS == res && nullptr == api_layer_info.getInstanceProcAddr) {
-                std::string warning_message = "ApiLayerInterface::LoadApiLayers skipping layer ";
-                warning_message += manifest_file->LayerName();
-                warning_message += ", negotiation did not return a valid getInstanceProcAddr";
-                LoaderLogger::LogWarningMessage(openxr_command, warning_message);
-                res = XR_ERROR_FILE_CONTENTS_INVALID;
-            }
-            if (XR_SUCCESS != res) {
-                if (!any_loaded) {
-                    last_error = res;
-                }
-                std::string warning_message = "ApiLayerInterface::LoadApiLayers skipping layer ";
-                warning_message += manifest_file->LayerName();
-                warning_message += " due to failed negotiation with error ";
-                warning_message += std::to_string(res);
-                LoaderLogger::LogWarningMessage(openxr_command, warning_message);
-                LoaderPlatformLibraryClose(layer_library);
-                continue;
-            }
-
-            std::string info_message = "ApiLayerInterface::LoadApiLayers succeeded loading layer ";
-            info_message += manifest_file->LayerName();
-            info_message += " using interface version ";
-            info_message += std::to_string(api_layer_info.layerInterfaceVersion);
-            info_message += " and OpenXR API version ";
-            info_message += std::to_string(XR_VERSION_MAJOR(api_layer_info.layerXrVersion));
-            info_message += ".";
-            info_message += std::to_string(XR_VERSION_MINOR(api_layer_info.layerXrVersion));
-            LoaderLogger::LogInfoMessage(openxr_command, info_message);
-
-            // Grab the list of extensions this layer supports for easy filtering after the
-            // xrCreateInstance call
-            std::vector<std::string> supported_extensions;
-            std::vector<XrExtensionProperties> extension_properties;
-            manifest_file->GetInstanceExtensionProperties(extension_properties);
-            for (XrExtensionProperties& ext_prop : extension_properties) {
-                supported_extensions.push_back(ext_prop.extensionName);
-            }
-
-            // Add this runtime to the vector
-            api_layer_interfaces.emplace_back(new ApiLayerInterface(manifest_file->LayerName(), layer_library, supported_extensions,
-                                                                    api_layer_info.getInstanceProcAddr,
-                                                                    api_layer_info.createApiLayerInstance));
-
-            // If we load one, clear all errors.
-            any_loaded = true;
-            last_error = XR_SUCCESS;
-        }
-
-        // If even one of the layers wasn't found, we want to return an error
-        for (uint32_t layer = 0; layer < layer_found.size(); ++layer) {
-            if (!layer_found[layer]) {
-                std::string error_message = "ApiLayerInterface::LoadApiLayers - failed to find layer ";
-                error_message += enabled_api_layers[layer];
-                LoaderLogger::LogErrorMessage(openxr_command, error_message);
-                last_error = XR_ERROR_API_LAYER_NOT_PRESENT;
-            }
-        }
-
-        // Always clear the manifest file list.  Either we use them or we don't.
-        layer_manifest_files.clear();
-    } catch (std::bad_alloc&) {
-        LoaderLogger::LogErrorMessage(openxr_command, "ApiLayerInterface::LoadApiLayers - failed to allocate memory");
-        last_error = XR_ERROR_OUT_OF_MEMORY;
-    } catch (...) {
-        LoaderLogger::LogErrorMessage(openxr_command, "ApiLayerInterface::LoadApiLayers - unknown error");
-        last_error = XR_ERROR_FILE_ACCESS_ERROR;
+    // Find any implicit layers which we may need to report information for.
+    XrResult result = ApiLayerManifestFile::FindManifestFiles(MANIFEST_TYPE_IMPLICIT_API_LAYER, layer_manifest_files);
+    if (XR_SUCCESS == result) {
+        // Find any explicit layers which we may need to report information for.
+        result = ApiLayerManifestFile::FindManifestFiles(MANIFEST_TYPE_EXPLICIT_API_LAYER, layer_manifest_files);
     }
 
-    // If we failed catastrophically for some reason, clean up everything.
-    if (XR_SUCCESS != last_error) {
-        api_layer_interfaces.clear();
+    // Put all the enabled layers into a string vector
+    std::vector<std::string> enabled_api_layers = {};
+    AddEnvironmentApiLayers(openxr_command, enabled_api_layers);
+    if (enabled_api_layer_count > 0) {
+        if (nullptr == enabled_api_layer_names) {
+            LoaderLogger::LogErrorMessage(
+                "xrCreateInstance",
+                "VUID-XrInstanceCreateInfo-enabledApiLayerNames-parameter: enabledApiLayerCount is non-0 but array is NULL");
+            LoaderLogger::LogErrorMessage(
+                "xrCreateInstance", "VUID-xrCreateInstance-info-parameter: something wrong with XrInstanceCreateInfo contents");
+            return XR_ERROR_VALIDATION_FAILURE;
+        }
+        uint32_t num_env_api_layers = static_cast<uint32_t>(enabled_api_layers.size());
+        uint32_t total_api_layers = num_env_api_layers + enabled_api_layer_count;
+        enabled_api_layers.resize(total_api_layers);
+        for (uint32_t layer = 0; layer < enabled_api_layer_count; ++layer) {
+            enabled_api_layers[num_env_api_layers + layer] = enabled_api_layer_names[layer];
+        }
     }
+
+    // Initialize the layer found vector to false
+    layer_found.resize(enabled_api_layers.size());
+    for (uint32_t layer = 0; layer < layer_found.size(); ++layer) {
+        layer_found[layer] = false;
+    }
+
+    for (std::unique_ptr<ApiLayerManifestFile>& manifest_file : layer_manifest_files) {
+        bool enabled = false;
+
+        // Always add implicit layers.  They would only be in this list if they were enabled
+        // (i.e. the disable environment variable is not set).
+        if (manifest_file->Type() == MANIFEST_TYPE_IMPLICIT_API_LAYER) {
+            enabled = true;
+        } else {
+            // Only add explicit layers if they are called out by the application
+            for (uint32_t layer = 0; layer < enabled_api_layers.size(); ++layer) {
+                if (enabled_api_layers[layer] == manifest_file->LayerName()) {
+                    layer_found[layer] = true;
+                    enabled = true;
+                    break;
+                }
+            }
+        }
+
+        // If this layer isn't enabled, skip it.
+        if (!enabled) {
+            continue;
+        }
+
+        LoaderPlatformLibraryHandle layer_library = LoaderPlatformLibraryOpen(manifest_file->LibraryPath());
+        if (nullptr == layer_library) {
+            if (!any_loaded) {
+                last_error = XR_ERROR_FILE_ACCESS_ERROR;
+            }
+            std::string library_message = LoaderPlatformLibraryOpenError(manifest_file->LibraryPath());
+            std::string warning_message = "ApiLayerInterface::LoadApiLayers skipping layer ";
+            warning_message += manifest_file->LayerName();
+            warning_message += ", failed to load with message \"";
+            warning_message += library_message;
+            warning_message += "\"";
+            LoaderLogger::LogWarningMessage(openxr_command, warning_message);
+            continue;
+        }
+
+        // Get and settle on an layer interface version (using any provided name if required).
+        std::string function_name = manifest_file->GetFunctionName("xrNegotiateLoaderApiLayerInterface");
+        PFN_xrNegotiateLoaderApiLayerInterface negotiate = reinterpret_cast<PFN_xrNegotiateLoaderApiLayerInterface>(
+            LoaderPlatformLibraryGetProcAddr(layer_library, function_name));
+
+        // Loader info for negotiation
+        XrNegotiateLoaderInfo loader_info = {};
+        loader_info.structType = XR_LOADER_INTERFACE_STRUCT_LOADER_INFO;
+        loader_info.structVersion = XR_LOADER_INFO_STRUCT_VERSION;
+        loader_info.structSize = sizeof(XrNegotiateLoaderInfo);
+        loader_info.minInterfaceVersion = 1;
+        loader_info.maxInterfaceVersion = XR_CURRENT_LOADER_API_LAYER_VERSION;
+        loader_info.minXrVersion = XR_MAKE_VERSION(0, 1, 0);
+        loader_info.maxXrVersion = XR_MAKE_VERSION(1, 0, 0);
+
+        // Set up the layer return structure
+        XrNegotiateApiLayerRequest api_layer_info = {};
+        api_layer_info.structType = XR_LOADER_INTERFACE_STRUCT_API_LAYER_REQUEST;
+        api_layer_info.structVersion = XR_API_LAYER_INFO_STRUCT_VERSION;
+        api_layer_info.structSize = sizeof(XrNegotiateApiLayerRequest);
+
+        XrResult res = negotiate(&loader_info, manifest_file->LayerName().c_str(), &api_layer_info);
+        // If we supposedly succeeded, but got a nullptr for getInstanceProcAddr
+        // then something still went wrong, so return with an error.
+        if (XR_SUCCESS == res && nullptr == api_layer_info.getInstanceProcAddr) {
+            std::string warning_message = "ApiLayerInterface::LoadApiLayers skipping layer ";
+            warning_message += manifest_file->LayerName();
+            warning_message += ", negotiation did not return a valid getInstanceProcAddr";
+            LoaderLogger::LogWarningMessage(openxr_command, warning_message);
+            res = XR_ERROR_FILE_CONTENTS_INVALID;
+        }
+        if (XR_SUCCESS != res) {
+            if (!any_loaded) {
+                last_error = res;
+            }
+            std::string warning_message = "ApiLayerInterface::LoadApiLayers skipping layer ";
+            warning_message += manifest_file->LayerName();
+            warning_message += " due to failed negotiation with error ";
+            warning_message += std::to_string(res);
+            LoaderLogger::LogWarningMessage(openxr_command, warning_message);
+            LoaderPlatformLibraryClose(layer_library);
+            continue;
+        }
+
+        std::string info_message = "ApiLayerInterface::LoadApiLayers succeeded loading layer ";
+        info_message += manifest_file->LayerName();
+        info_message += " using interface version ";
+        info_message += std::to_string(api_layer_info.layerInterfaceVersion);
+        info_message += " and OpenXR API version ";
+        info_message += std::to_string(XR_VERSION_MAJOR(api_layer_info.layerXrVersion));
+        info_message += ".";
+        info_message += std::to_string(XR_VERSION_MINOR(api_layer_info.layerXrVersion));
+        LoaderLogger::LogInfoMessage(openxr_command, info_message);
+
+        // Grab the list of extensions this layer supports for easy filtering after the
+        // xrCreateInstance call
+        std::vector<std::string> supported_extensions;
+        std::vector<XrExtensionProperties> extension_properties;
+        manifest_file->GetInstanceExtensionProperties(extension_properties);
+        for (XrExtensionProperties& ext_prop : extension_properties) {
+            supported_extensions.push_back(ext_prop.extensionName);
+        }
+
+        // Add this runtime to the vector
+        api_layer_interfaces.emplace_back(new ApiLayerInterface(manifest_file->LayerName(), layer_library, supported_extensions,
+                                                                api_layer_info.getInstanceProcAddr,
+                                                                api_layer_info.createApiLayerInstance));
+
+        // If we load one, clear all errors.
+        any_loaded = true;
+        last_error = XR_SUCCESS;
+    }
+
+    // If even one of the layers wasn't found, we want to return an error
+    for (uint32_t layer = 0; layer < layer_found.size(); ++layer) {
+        if (!layer_found[layer]) {
+            std::string error_message = "ApiLayerInterface::LoadApiLayers - failed to find layer ";
+            error_message += enabled_api_layers[layer];
+            LoaderLogger::LogErrorMessage(openxr_command, error_message);
+            last_error = XR_ERROR_API_LAYER_NOT_PRESENT;
+        }
+    }
+
+    // Always clear the manifest file list.  Either we use them or we don't.
+    layer_manifest_files.clear();
 
     return last_error;
 }
@@ -398,14 +370,11 @@ ApiLayerInterface::~ApiLayerInterface() {
 
 bool ApiLayerInterface::SupportsExtension(const std::string& extension_name) {
     bool found_prop = false;
-    try {
-        for (std::string supported_extension : _supported_extensions) {
-            if (supported_extension == extension_name) {
-                found_prop = true;
-                break;
-            }
+    for (std::string supported_extension : _supported_extensions) {
+        if (supported_extension == extension_name) {
+            found_prop = true;
+            break;
         }
-    } catch (...) {
     }
     return found_prop;
 }

--- a/src/loader/loader_core.cpp
+++ b/src/loader/loader_core.cpp
@@ -62,291 +62,261 @@ extern "C" {
 LOADER_EXPORT XRAPI_ATTR XrResult XRAPI_CALL xrEnumerateApiLayerProperties(uint32_t propertyCapacityInput,
                                                                            uint32_t *propertyCountOutput,
                                                                            XrApiLayerProperties *properties) {
-    try {
-        LoaderLogger::LogVerboseMessage("xrEnumerateApiLayerProperties", "Entering loader trampoline");
+    LoaderLogger::LogVerboseMessage("xrEnumerateApiLayerProperties", "Entering loader trampoline");
 
-        // Make sure only one thread is attempting to read the JSON files at a time.
-        std::unique_lock<std::mutex> json_lock(g_loader_json_mutex);
+    // Make sure only one thread is attempting to read the JSON files at a time.
+    std::unique_lock<std::mutex> json_lock(g_loader_json_mutex);
 
-        XrResult result = ApiLayerInterface::GetApiLayerProperties("xrEnumerateApiLayerProperties", propertyCapacityInput,
-                                                                   propertyCountOutput, properties);
-        if (XR_SUCCESS != result) {
-            LoaderLogger::LogErrorMessage("xrEnumerateApiLayerProperties", "Failed ApiLayerInterface::GetApiLayerProperties");
-        }
-
-        return result;
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("xrEnumerateApiLayerProperties", "Unknown error occurred");
-        return XR_ERROR_VALIDATION_FAILURE;
+    XrResult result = ApiLayerInterface::GetApiLayerProperties("xrEnumerateApiLayerProperties", propertyCapacityInput,
+                                                               propertyCountOutput, properties);
+    if (XR_SUCCESS != result) {
+        LoaderLogger::LogErrorMessage("xrEnumerateApiLayerProperties", "Failed ApiLayerInterface::GetApiLayerProperties");
     }
 
-    return XR_SUCCESS;
+    return result;
 }
 
 LOADER_EXPORT XRAPI_ATTR XrResult XRAPI_CALL xrEnumerateInstanceExtensionProperties(const char *layerName,
                                                                                     uint32_t propertyCapacityInput,
                                                                                     uint32_t *propertyCountOutput,
                                                                                     XrExtensionProperties *properties) {
-    try {
-        bool just_layer_properties = false;
-        LoaderLogger::LogVerboseMessage("xrEnumerateInstanceExtensionProperties", "Entering loader trampoline");
+    bool just_layer_properties = false;
+    LoaderLogger::LogVerboseMessage("xrEnumerateInstanceExtensionProperties", "Entering loader trampoline");
 
-        if (nullptr != layerName && 0 != strlen(layerName)) {
-            // Application is only interested in layer's properties, not all of them.
-            just_layer_properties = true;
-        }
-
-        std::vector<XrExtensionProperties> extension_properties = {};
-        XrResult result;
-
-        {
-            // Make sure only one thread is attempting to read the JSON files at a time.
-            std::unique_lock<std::mutex> json_lock(g_loader_json_mutex);
-
-            // Get the layer extension properties
-            result = ApiLayerInterface::GetInstanceExtensionProperties("xrEnumerateInstanceExtensionProperties", layerName,
-                                                                       extension_properties);
-            if (XR_SUCCESS == result && !just_layer_properties) {
-                // If not specific to a layer, get the runtime extension properties
-                result = RuntimeInterface::LoadRuntime("xrEnumerateInstanceExtensionProperties");
-                if (XR_SUCCESS == result) {
-                    RuntimeInterface::GetRuntime().GetInstanceExtensionProperties(extension_properties);
-                    RuntimeInterface::UnloadRuntime("xrEnumerateInstanceExtensionProperties");
-                } else {
-                    LoaderLogger::LogErrorMessage("xrEnumerateInstanceExtensionProperties",
-                                                  "Failed to find default runtime with RuntimeInterface::LoadRuntime()");
-                }
-            }
-        }
-
-        if (XR_SUCCESS != result) {
-            LoaderLogger::LogErrorMessage("xrEnumerateInstanceExtensionProperties", "Failed querying extension properties");
-            return result;
-        }
-
-        // If this is not in reference to a specific layer, then add the loader-specific extension properties as well.
-        // These are extensions that the loader directly supports.
-        if (!just_layer_properties) {
-            auto loader_extension_props = LoaderInstance::LoaderSpecificExtensions();
-            for (XrExtensionProperties &loader_prop : loader_extension_props) {
-                bool found_prop = false;
-                for (XrExtensionProperties &existing_prop : extension_properties) {
-                    if (0 == strcmp(existing_prop.extensionName, loader_prop.extensionName)) {
-                        found_prop = true;
-                        // Use the loader version if it is newer
-                        if (existing_prop.specVersion < loader_prop.specVersion) {
-                            existing_prop.specVersion = loader_prop.specVersion;
-                        }
-                        break;
-                    }
-                }
-                // Only add extensions not supported by the loader
-                if (!found_prop) {
-                    extension_properties.push_back(loader_prop);
-                }
-            }
-        }
-
-        uint32_t num_extension_properties = static_cast<uint32_t>(extension_properties.size());
-        if (propertyCapacityInput == 0) {
-            *propertyCountOutput = num_extension_properties;
-        } else if (nullptr != properties) {
-            if (propertyCapacityInput < num_extension_properties) {
-                *propertyCountOutput = num_extension_properties;
-                LoaderLogger::LogErrorMessage(
-                    "xrEnumerateInstanceExtensionProperties",
-                    "VUID-xrEnumerateInstanceExtensionProperties-propertyCountOutput-parameter: insufficient space in array");
-                return XR_ERROR_SIZE_INSUFFICIENT;
-            }
-
-            uint32_t num_to_copy = num_extension_properties;
-            // Determine how many extension properties we can copy over
-            if (propertyCapacityInput < num_to_copy) {
-                num_to_copy = propertyCapacityInput;
-            }
-            bool properties_valid = true;
-            for (uint32_t prop = 0; prop < propertyCapacityInput && prop < extension_properties.size(); ++prop) {
-                if (XR_TYPE_EXTENSION_PROPERTIES != properties[prop].type) {
-                    properties_valid = false;
-                    LoaderLogger::LogErrorMessage("xrEnumerateInstanceExtensionProperties",
-                                                  "VUID-XrExtensionProperties-type-type: unknown type in properties");
-                }
-                if (nullptr != properties[prop].next) {
-                    LoaderLogger::LogErrorMessage("xrEnumerateInstanceExtensionProperties",
-                                                  "VUID-XrExtensionProperties-next-next: expected NULL");
-                    properties_valid = false;
-                }
-                if (properties_valid) {
-                    properties[prop] = extension_properties[prop];
-                }
-            }
-            if (!properties_valid) {
-                LoaderLogger::LogErrorMessage(
-                    "xrEnumerateInstanceExtensionProperties",
-                    "VUID-xrEnumerateInstanceExtensionProperties-properties-parameter: invalid properties");
-                return XR_ERROR_VALIDATION_FAILURE;
-            } else if (nullptr != propertyCountOutput) {
-                *propertyCountOutput = num_to_copy;
-            }
-        }
-        LoaderLogger::LogVerboseMessage("xrEnumerateInstanceExtensionProperties", "Completed loader trampoline");
-        return XR_SUCCESS;
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("xrEnumerateInstanceExtensionProperties", "Unknown error occurred");
-        return XR_ERROR_INITIALIZATION_FAILED;
+    if (nullptr != layerName && 0 != strlen(layerName)) {
+        // Application is only interested in layer's properties, not all of them.
+        just_layer_properties = true;
     }
+
+    std::vector<XrExtensionProperties> extension_properties = {};
+    XrResult result;
+
+    {
+        // Make sure only one thread is attempting to read the JSON files at a time.
+        std::unique_lock<std::mutex> json_lock(g_loader_json_mutex);
+
+        // Get the layer extension properties
+        result = ApiLayerInterface::GetInstanceExtensionProperties("xrEnumerateInstanceExtensionProperties", layerName,
+                                                                   extension_properties);
+        if (XR_SUCCESS == result && !just_layer_properties) {
+            // If not specific to a layer, get the runtime extension properties
+            result = RuntimeInterface::LoadRuntime("xrEnumerateInstanceExtensionProperties");
+            if (XR_SUCCESS == result) {
+                RuntimeInterface::GetRuntime().GetInstanceExtensionProperties(extension_properties);
+                RuntimeInterface::UnloadRuntime("xrEnumerateInstanceExtensionProperties");
+            } else {
+                LoaderLogger::LogErrorMessage("xrEnumerateInstanceExtensionProperties",
+                                              "Failed to find default runtime with RuntimeInterface::LoadRuntime()");
+            }
+        }
+    }
+
+    if (XR_SUCCESS != result) {
+        LoaderLogger::LogErrorMessage("xrEnumerateInstanceExtensionProperties", "Failed querying extension properties");
+        return result;
+    }
+
+    // If this is not in reference to a specific layer, then add the loader-specific extension properties as well.
+    // These are extensions that the loader directly supports.
+    if (!just_layer_properties) {
+        auto loader_extension_props = LoaderInstance::LoaderSpecificExtensions();
+        for (XrExtensionProperties &loader_prop : loader_extension_props) {
+            bool found_prop = false;
+            for (XrExtensionProperties &existing_prop : extension_properties) {
+                if (0 == strcmp(existing_prop.extensionName, loader_prop.extensionName)) {
+                    found_prop = true;
+                    // Use the loader version if it is newer
+                    if (existing_prop.specVersion < loader_prop.specVersion) {
+                        existing_prop.specVersion = loader_prop.specVersion;
+                    }
+                    break;
+                }
+            }
+            // Only add extensions not supported by the loader
+            if (!found_prop) {
+                extension_properties.push_back(loader_prop);
+            }
+        }
+    }
+
+    uint32_t num_extension_properties = static_cast<uint32_t>(extension_properties.size());
+    if (propertyCapacityInput == 0) {
+        *propertyCountOutput = num_extension_properties;
+    } else if (nullptr != properties) {
+        if (propertyCapacityInput < num_extension_properties) {
+            *propertyCountOutput = num_extension_properties;
+            LoaderLogger::LogErrorMessage(
+                "xrEnumerateInstanceExtensionProperties",
+                "VUID-xrEnumerateInstanceExtensionProperties-propertyCountOutput-parameter: insufficient space in array");
+            return XR_ERROR_SIZE_INSUFFICIENT;
+        }
+
+        uint32_t num_to_copy = num_extension_properties;
+        // Determine how many extension properties we can copy over
+        if (propertyCapacityInput < num_to_copy) {
+            num_to_copy = propertyCapacityInput;
+        }
+        bool properties_valid = true;
+        for (uint32_t prop = 0; prop < propertyCapacityInput && prop < extension_properties.size(); ++prop) {
+            if (XR_TYPE_EXTENSION_PROPERTIES != properties[prop].type) {
+                properties_valid = false;
+                LoaderLogger::LogErrorMessage("xrEnumerateInstanceExtensionProperties",
+                                              "VUID-XrExtensionProperties-type-type: unknown type in properties");
+            }
+            if (nullptr != properties[prop].next) {
+                LoaderLogger::LogErrorMessage("xrEnumerateInstanceExtensionProperties",
+                                              "VUID-XrExtensionProperties-next-next: expected NULL");
+                properties_valid = false;
+            }
+            if (properties_valid) {
+                properties[prop] = extension_properties[prop];
+            }
+        }
+        if (!properties_valid) {
+            LoaderLogger::LogErrorMessage(
+                "xrEnumerateInstanceExtensionProperties",
+                "VUID-xrEnumerateInstanceExtensionProperties-properties-parameter: invalid properties");
+            return XR_ERROR_VALIDATION_FAILURE;
+        } else if (nullptr != propertyCountOutput) {
+            *propertyCountOutput = num_to_copy;
+        }
+    }
+    LoaderLogger::LogVerboseMessage("xrEnumerateInstanceExtensionProperties", "Completed loader trampoline");
+    return XR_SUCCESS;
 }
 
 LOADER_EXPORT XRAPI_ATTR XrResult XRAPI_CALL xrCreateInstance(const XrInstanceCreateInfo *info, XrInstance *instance) {
     bool runtime_loaded = false;
 
-    try {
-        LoaderLogger::LogVerboseMessage("xrCreateInstance", "Entering loader trampoline");
-        if (nullptr == info) {
-            LoaderLogger::LogErrorMessage("xrCreateInstance", "VUID-xrCreateInstance-info-parameter: must be non-NULL");
-            return XR_ERROR_VALIDATION_FAILURE;
-        } else {
-            // If application requested OpenXR API version is higher than the loader version, then we need to throw
-            // an error.
-            uint16_t app_major = XR_VERSION_MAJOR(info->applicationInfo.apiVersion);
-            uint16_t app_minor = XR_VERSION_MINOR(info->applicationInfo.apiVersion);
-            uint16_t loader_major = XR_VERSION_MAJOR(XR_CURRENT_API_VERSION);
-            uint16_t loader_minor = XR_VERSION_MINOR(XR_CURRENT_API_VERSION);
-            if (app_major > loader_major || (app_major == loader_major && app_minor > loader_minor)) {
-                std::string error_message = "xrCreateInstance called with invalid API version ";
-                error_message += std::to_string(app_major);
-                error_message += ".";
-                error_message += std::to_string(app_minor);
-                error_message += ".  Max supported version is ";
-                error_message += std::to_string(loader_major);
-                error_message += ".";
-                error_message += std::to_string(loader_minor);
-                LoaderLogger::LogErrorMessage("xrCreateInstance", error_message);
-                return XR_ERROR_DRIVER_INCOMPATIBLE;
-            }
+    LoaderLogger::LogVerboseMessage("xrCreateInstance", "Entering loader trampoline");
+    if (nullptr == info) {
+        LoaderLogger::LogErrorMessage("xrCreateInstance", "VUID-xrCreateInstance-info-parameter: must be non-NULL");
+        return XR_ERROR_VALIDATION_FAILURE;
+    } else {
+        // If application requested OpenXR API version is higher than the loader version, then we need to throw
+        // an error.
+        uint16_t app_major = XR_VERSION_MAJOR(info->applicationInfo.apiVersion);
+        uint16_t app_minor = XR_VERSION_MINOR(info->applicationInfo.apiVersion);
+        uint16_t loader_major = XR_VERSION_MAJOR(XR_CURRENT_API_VERSION);
+        uint16_t loader_minor = XR_VERSION_MINOR(XR_CURRENT_API_VERSION);
+        if (app_major > loader_major || (app_major == loader_major && app_minor > loader_minor)) {
+            std::string error_message = "xrCreateInstance called with invalid API version ";
+            error_message += std::to_string(app_major);
+            error_message += ".";
+            error_message += std::to_string(app_minor);
+            error_message += ".  Max supported version is ";
+            error_message += std::to_string(loader_major);
+            error_message += ".";
+            error_message += std::to_string(loader_minor);
+            LoaderLogger::LogErrorMessage("xrCreateInstance", error_message);
+            return XR_ERROR_DRIVER_INCOMPATIBLE;
         }
-        if (nullptr == instance) {
-            LoaderLogger::LogErrorMessage("xrCreateInstance", "VUID-xrCreateInstance-instance-parameter: must be non-NULL");
-            return XR_ERROR_HANDLE_INVALID;
-        }
-
-        std::vector<std::unique_ptr<ApiLayerInterface>> api_layer_interfaces;
-
-        // Make sure only one thread is attempting to read the JSON files and use the instance.
-        XrResult result;
-        {
-            std::unique_lock<std::mutex> json_lock(g_loader_json_mutex);
-            // Load the available runtime
-            result = RuntimeInterface::LoadRuntime("xrCreateInstance");
-            if (XR_SUCCESS != result) {
-                LoaderLogger::LogErrorMessage("xrCreateInstance", "Failed loading runtime information");
-            } else {
-                runtime_loaded = true;
-                // Load the appropriate layers
-                result = ApiLayerInterface::LoadApiLayers("xrCreateInstance", info->enabledApiLayerCount,
-                                                          info->enabledApiLayerNames, api_layer_interfaces);
-                if (XR_SUCCESS != result) {
-                    LoaderLogger::LogErrorMessage("xrCreateInstance", "Failed loading layer information");
-                }
-            }
-        }
-
-        if (XR_FAILED(result)) {
-            if (runtime_loaded) {
-                RuntimeInterface::UnloadRuntime("xrCreateInstance");
-            }
-            return result;
-        }
-
-        std::unique_lock<std::mutex> instance_lock(g_loader_instance_mutex);
-
-        // Create the loader instance (only send down first runtime interface)
-        XrInstance created_instance = XR_NULL_HANDLE;
-        result = LoaderInstance::CreateInstance(api_layer_interfaces, info, &created_instance);
-
-        if (XR_SUCCEEDED(result)) {
-            *instance = created_instance;
-
-            LoaderInstance *loader_instance = nullptr;
-            {
-                std::unique_lock<std::mutex> lock(g_instance_mutex);
-                // Unguarded RHS bracket operator ok here - we know it was just successfully found or inserted above
-                loader_instance = g_instance_map[created_instance];
-            }
-
-            // Create a debug utils messenger if the create structure is in the "next" chain
-            const XrBaseInStructure *next_header = reinterpret_cast<const XrBaseInStructure *>(info->next);
-            const XrDebugUtilsMessengerCreateInfoEXT *dbg_utils_create_info = nullptr;
-            while (next_header != nullptr) {
-                if (next_header->type == XR_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT) {
-                    LoaderLogger::LogInfoMessage("xrCreateInstance", "Found XrDebugUtilsMessengerCreateInfoEXT in \'next\' chain.");
-                    dbg_utils_create_info = reinterpret_cast<const XrDebugUtilsMessengerCreateInfoEXT *>(next_header);
-                    XrDebugUtilsMessengerEXT messenger;
-                    result = xrCreateDebugUtilsMessengerEXT(*instance, dbg_utils_create_info, &messenger);
-                    if (XR_SUCCESS != result) {
-                        return XR_ERROR_VALIDATION_FAILURE;
-                    }
-                    loader_instance->SetDefaultDebugUtilsMessenger(messenger);
-                    break;
-                }
-                next_header = reinterpret_cast<const XrBaseInStructure *>(next_header->next);
-            }
-        }
-
-        LoaderLogger::LogVerboseMessage("xrCreateInstance", "Completed loader trampoline");
-        return result;
-    } catch (std::bad_alloc &) {
-        if (runtime_loaded) {
-            RuntimeInterface::UnloadRuntime("xrCreateInstance");
-        }
-        LoaderLogger::LogErrorMessage("xrCreateInstance", "Failed to allocate memory");
-        return XR_ERROR_OUT_OF_MEMORY;
-    } catch (...) {
-        if (runtime_loaded) {
-            RuntimeInterface::UnloadRuntime("xrCreateInstance");
-        }
-        LoaderLogger::LogErrorMessage("xrCreateInstance", "Unknown error occurred");
-        return XR_ERROR_INITIALIZATION_FAILED;
     }
+    if (nullptr == instance) {
+        LoaderLogger::LogErrorMessage("xrCreateInstance", "VUID-xrCreateInstance-instance-parameter: must be non-NULL");
+        return XR_ERROR_HANDLE_INVALID;
+    }
+
+    std::vector<std::unique_ptr<ApiLayerInterface>> api_layer_interfaces;
+
+    // Make sure only one thread is attempting to read the JSON files and use the instance.
+    XrResult result;
+    {
+        std::unique_lock<std::mutex> json_lock(g_loader_json_mutex);
+        // Load the available runtime
+        result = RuntimeInterface::LoadRuntime("xrCreateInstance");
+        if (XR_SUCCESS != result) {
+            LoaderLogger::LogErrorMessage("xrCreateInstance", "Failed loading runtime information");
+        } else {
+            runtime_loaded = true;
+            // Load the appropriate layers
+            result = ApiLayerInterface::LoadApiLayers("xrCreateInstance", info->enabledApiLayerCount,
+                                                      info->enabledApiLayerNames, api_layer_interfaces);
+            if (XR_SUCCESS != result) {
+                LoaderLogger::LogErrorMessage("xrCreateInstance", "Failed loading layer information");
+            }
+        }
+    }
+
+    if (XR_FAILED(result)) {
+        if (runtime_loaded) {
+            RuntimeInterface::UnloadRuntime("xrCreateInstance");
+        }
+        return result;
+    }
+
+    std::unique_lock<std::mutex> instance_lock(g_loader_instance_mutex);
+
+    // Create the loader instance (only send down first runtime interface)
+    XrInstance created_instance = XR_NULL_HANDLE;
+    result = LoaderInstance::CreateInstance(api_layer_interfaces, info, &created_instance);
+
+    if (XR_SUCCEEDED(result)) {
+        *instance = created_instance;
+
+        LoaderInstance *loader_instance = nullptr;
+        {
+            std::unique_lock<std::mutex> lock(g_instance_mutex);
+            // Unguarded RHS bracket operator ok here - we know it was just successfully found or inserted above
+            loader_instance = g_instance_map[created_instance];
+        }
+
+        // Create a debug utils messenger if the create structure is in the "next" chain
+        const XrBaseInStructure *next_header = reinterpret_cast<const XrBaseInStructure *>(info->next);
+        const XrDebugUtilsMessengerCreateInfoEXT *dbg_utils_create_info = nullptr;
+        while (next_header != nullptr) {
+            if (next_header->type == XR_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT) {
+                LoaderLogger::LogInfoMessage("xrCreateInstance", "Found XrDebugUtilsMessengerCreateInfoEXT in \'next\' chain.");
+                dbg_utils_create_info = reinterpret_cast<const XrDebugUtilsMessengerCreateInfoEXT *>(next_header);
+                XrDebugUtilsMessengerEXT messenger;
+                result = xrCreateDebugUtilsMessengerEXT(*instance, dbg_utils_create_info, &messenger);
+                if (XR_SUCCESS != result) {
+                    return XR_ERROR_VALIDATION_FAILURE;
+                }
+                loader_instance->SetDefaultDebugUtilsMessenger(messenger);
+                break;
+            }
+            next_header = reinterpret_cast<const XrBaseInStructure *>(next_header->next);
+        }
+    }
+
+    LoaderLogger::LogVerboseMessage("xrCreateInstance", "Completed loader trampoline");
+    return result;
 }
 
 LOADER_EXPORT XRAPI_ATTR XrResult XRAPI_CALL xrDestroyInstance(XrInstance instance) {
-    try {
-        LoaderLogger::LogVerboseMessage("xrDestroyInstance", "Entering loader trampoline");
-        // XR_NULL_HANDLE is ignored, but valid, in a delete operation.
-        if (XR_NULL_HANDLE == instance) {
-            return XR_SUCCESS;
-        }
-
-        LoaderInstance *const loader_instance = TryLookupLoaderInstance(instance);
-        if (loader_instance == nullptr) {
-            LoaderLogger::LogErrorMessage("xrDestroyInstance", "VUID-xrDestroyInstance-instance-parameter: invalid instance");
-            return XR_ERROR_HANDLE_INVALID;
-        }
-
-        const std::unique_ptr<XrGeneratedDispatchTable> &dispatch_table = loader_instance->DispatchTable();
-
-        // If we allocated a default debug utils messenger, free it
-        XrDebugUtilsMessengerEXT messenger = loader_instance->DefaultDebugUtilsMessenger();
-        if (messenger != XR_NULL_HANDLE) {
-            xrDestroyDebugUtilsMessengerEXT(messenger);
-        }
-
-        // Now destroy the instance
-        if (XR_SUCCESS != dispatch_table->DestroyInstance(instance)) {
-            LoaderLogger::LogErrorMessage("xrDestroyInstance", "Unknown error occurred calling down chain");
-        }
-
-        // Cleanup any map entries that may still be using this instance
-        LoaderCleanUpMapsForInstance(loader_instance);
-
-        // Lock the instance create/destroy mutex
-        std::unique_lock<std::mutex> loader_instance_lock(g_loader_instance_mutex);
-        delete loader_instance;
-        LoaderLogger::LogVerboseMessage("xrDestroyInstance", "Completed loader trampoline");
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("xrDestroyInstance", "Unknown error occurred");
+    LoaderLogger::LogVerboseMessage("xrDestroyInstance", "Entering loader trampoline");
+    // XR_NULL_HANDLE is ignored, but valid, in a delete operation.
+    if (XR_NULL_HANDLE == instance) {
+        return XR_SUCCESS;
     }
+
+    LoaderInstance *const loader_instance = TryLookupLoaderInstance(instance);
+    if (loader_instance == nullptr) {
+        LoaderLogger::LogErrorMessage("xrDestroyInstance", "VUID-xrDestroyInstance-instance-parameter: invalid instance");
+        return XR_ERROR_HANDLE_INVALID;
+    }
+
+    const std::unique_ptr<XrGeneratedDispatchTable> &dispatch_table = loader_instance->DispatchTable();
+
+    // If we allocated a default debug utils messenger, free it
+    XrDebugUtilsMessengerEXT messenger = loader_instance->DefaultDebugUtilsMessenger();
+    if (messenger != XR_NULL_HANDLE) {
+        xrDestroyDebugUtilsMessengerEXT(messenger);
+    }
+
+    // Now destroy the instance
+    if (XR_SUCCESS != dispatch_table->DestroyInstance(instance)) {
+        LoaderLogger::LogErrorMessage("xrDestroyInstance", "Unknown error occurred calling down chain");
+    }
+
+    // Cleanup any map entries that may still be using this instance
+    LoaderCleanUpMapsForInstance(loader_instance);
+
+    // Lock the instance create/destroy mutex
+    std::unique_lock<std::mutex> loader_instance_lock(g_loader_instance_mutex);
+    delete loader_instance;
+    LoaderLogger::LogVerboseMessage("xrDestroyInstance", "Completed loader trampoline");
 
     // Finally, unload the runtime if necessary
     RuntimeInterface::UnloadRuntime("xrDestroyInstance");
@@ -433,99 +403,79 @@ XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermDestroyInstance(XrInstance instance) 
 XRAPI_ATTR XrResult XRAPI_CALL xrCreateDebugUtilsMessengerEXT(XrInstance instance,
                                                               const XrDebugUtilsMessengerCreateInfoEXT *createInfo,
                                                               XrDebugUtilsMessengerEXT *messenger) {
-    try {
-        LoaderLogger::LogVerboseMessage("xrCreateDebugUtilsMessengerEXT", "Entering loader trampoline");
 
-        LoaderInstance *loader_instance = nullptr;
-        {
-            std::unique_lock<std::mutex> lock(g_instance_mutex);
-            auto map_iter = g_instance_map.find(instance);
-            if (map_iter == g_instance_map.end()) {
-                return XR_ERROR_VALIDATION_FAILURE;
-            }
-            loader_instance = map_iter->second;
-        }
+    LoaderLogger::LogVerboseMessage("xrCreateDebugUtilsMessengerEXT", "Entering loader trampoline");
 
-        if (!loader_instance->ExtensionIsEnabled(XR_EXT_DEBUG_UTILS_EXTENSION_NAME)) {
-            std::string error_str = "The ";
-            error_str += XR_EXT_DEBUG_UTILS_EXTENSION_NAME;
-            error_str += " extension has not been enabled prior to calling xrCreateDebugUtilsMessengerEXT";
-            LoaderLogger::LogValidationErrorMessage("VUID-xrCreateDebugUtilsMessengerEXT-extension-notenabled",
-                                                    "xrCreateDebugUtilsMessengerEXT", error_str);
-            return XR_ERROR_FUNCTION_UNSUPPORTED;
+    LoaderInstance *loader_instance = nullptr;
+    {
+        std::unique_lock<std::mutex> lock(g_instance_mutex);
+        auto map_iter = g_instance_map.find(instance);
+        if (map_iter == g_instance_map.end()) {
+            return XR_ERROR_VALIDATION_FAILURE;
         }
-
-        const std::unique_ptr<XrGeneratedDispatchTable> &dispatch_table = loader_instance->DispatchTable();
-        XrResult result = XR_SUCCESS;
-        result = dispatch_table->CreateDebugUtilsMessengerEXT(instance, createInfo, messenger);
-        if (XR_SUCCESS == result && nullptr != messenger) {
-            auto exists = g_debugutilsmessengerext_map.find(*messenger);
-            if (exists == g_debugutilsmessengerext_map.end()) {
-                std::unique_lock<std::mutex> debugutilsmessengerlock(g_debugutilsmessengerext_mutex);
-                g_debugutilsmessengerext_map[*messenger] = loader_instance;
-            }
-        }
-        LoaderLogger::LogVerboseMessage("xrCreateDebugUtilsMessengerEXT", "Completed loader trampoline");
-        return result;
-    } catch (std::bad_alloc &) {
-        LoaderLogger::LogErrorMessage("xrCreateDebugUtilsMessengerEXT",
-                                      "xrCreateDebugUtilsMessengerEXT trampoline failed allocating memory");
-        return XR_ERROR_OUT_OF_MEMORY;
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("xrCreateDebugUtilsMessengerEXT",
-                                      "xrCreateDebugUtilsMessengerEXT trampoline encountered an unknown error");
-        return XR_ERROR_INITIALIZATION_FAILED;
+        loader_instance = map_iter->second;
     }
+
+    if (!loader_instance->ExtensionIsEnabled(XR_EXT_DEBUG_UTILS_EXTENSION_NAME)) {
+        std::string error_str = "The ";
+        error_str += XR_EXT_DEBUG_UTILS_EXTENSION_NAME;
+        error_str += " extension has not been enabled prior to calling xrCreateDebugUtilsMessengerEXT";
+        LoaderLogger::LogValidationErrorMessage("VUID-xrCreateDebugUtilsMessengerEXT-extension-notenabled",
+                                                "xrCreateDebugUtilsMessengerEXT", error_str);
+        return XR_ERROR_FUNCTION_UNSUPPORTED;
+    }
+
+    const std::unique_ptr<XrGeneratedDispatchTable> &dispatch_table = loader_instance->DispatchTable();
+    XrResult result = XR_SUCCESS;
+    result = dispatch_table->CreateDebugUtilsMessengerEXT(instance, createInfo, messenger);
+    if (XR_SUCCESS == result && nullptr != messenger) {
+        auto exists = g_debugutilsmessengerext_map.find(*messenger);
+        if (exists == g_debugutilsmessengerext_map.end()) {
+            std::unique_lock<std::mutex> debugutilsmessengerlock(g_debugutilsmessengerext_mutex);
+            g_debugutilsmessengerext_map[*messenger] = loader_instance;
+        }
+    }
+    LoaderLogger::LogVerboseMessage("xrCreateDebugUtilsMessengerEXT", "Completed loader trampoline");
+    return result;
 }
 
 XRAPI_ATTR XrResult XRAPI_CALL xrDestroyDebugUtilsMessengerEXT(XrDebugUtilsMessengerEXT messenger) {
     // TODO: get instance from messenger in loader
     // Also, is the loader really doing all this every call?
-    try {
-        LoaderLogger::LogVerboseMessage("xrDestroyDebugUtilsMessengerEXT", "Entering loader trampoline");
+    LoaderLogger::LogVerboseMessage("xrDestroyDebugUtilsMessengerEXT", "Entering loader trampoline");
 
-        if (XR_NULL_HANDLE == messenger) {
-            return XR_SUCCESS;
-        }
-
-        auto exists = g_debugutilsmessengerext_map.find(messenger);
-        if (exists == g_debugutilsmessengerext_map.end()) {
-            return XR_ERROR_DEBUG_UTILS_MESSENGER_INVALID_EXT;
-        }
-
-        LoaderInstance *loader_instance = nullptr;
-        {
-            std::unique_lock<std::mutex> lock(g_debugutilsmessengerext_mutex);
-            auto map_iter = g_debugutilsmessengerext_map.find(messenger);
-            if (map_iter == g_debugutilsmessengerext_map.end()) {
-                return XR_ERROR_VALIDATION_FAILURE;
-            }
-            loader_instance = map_iter->second;
-        }
-
-        if (!loader_instance->ExtensionIsEnabled(XR_EXT_DEBUG_UTILS_EXTENSION_NAME)) {
-            std::string error_str = "The ";
-            error_str += XR_EXT_DEBUG_UTILS_EXTENSION_NAME;
-            error_str += " extension has not been enabled prior to calling xrDestroyDebugUtilsMessengerEXT";
-            LoaderLogger::LogValidationErrorMessage("VUID-xrDestroyDebugUtilsMessengerEXT-extension-notenabled",
-                                                    "xrDestroyDebugUtilsMessengerEXT", error_str);
-            return XR_ERROR_FUNCTION_UNSUPPORTED;
-        }
-
-        const std::unique_ptr<XrGeneratedDispatchTable> &dispatch_table = loader_instance->DispatchTable();
-        XrResult result = dispatch_table->DestroyDebugUtilsMessengerEXT(messenger);
-        LoaderLogger::LogVerboseMessage("xrDestroyDebugUtilsMessengerEXT", "Completed loader trampoline");
-        return result;
-    } catch (...) {
-        std::string error_message =
-            "xrDestroyDebugUtilsMessengerEXT trampoline encountered an unknown error.  Likely XrDebugUtilsMessengerEXT 0x";
-        std::ostringstream oss;
-        oss << std::hex << reinterpret_cast<const void *>(messenger);
-        error_message += oss.str();
-        error_message += " is invalid";
-        LoaderLogger::LogErrorMessage("xrDestroyDebugUtilsMessengerEXT", error_message);
-        return XR_ERROR_HANDLE_INVALID;
+    if (XR_NULL_HANDLE == messenger) {
+        return XR_SUCCESS;
     }
+
+    auto exists = g_debugutilsmessengerext_map.find(messenger);
+    if (exists == g_debugutilsmessengerext_map.end()) {
+        return XR_ERROR_DEBUG_UTILS_MESSENGER_INVALID_EXT;
+    }
+
+    LoaderInstance *loader_instance = nullptr;
+    {
+        std::unique_lock<std::mutex> lock(g_debugutilsmessengerext_mutex);
+        auto map_iter = g_debugutilsmessengerext_map.find(messenger);
+        if (map_iter == g_debugutilsmessengerext_map.end()) {
+            return XR_ERROR_VALIDATION_FAILURE;
+        }
+        loader_instance = map_iter->second;
+    }
+
+    if (!loader_instance->ExtensionIsEnabled(XR_EXT_DEBUG_UTILS_EXTENSION_NAME)) {
+        std::string error_str = "The ";
+        error_str += XR_EXT_DEBUG_UTILS_EXTENSION_NAME;
+        error_str += " extension has not been enabled prior to calling xrDestroyDebugUtilsMessengerEXT";
+        LoaderLogger::LogValidationErrorMessage("VUID-xrDestroyDebugUtilsMessengerEXT-extension-notenabled",
+                                                "xrDestroyDebugUtilsMessengerEXT", error_str);
+        return XR_ERROR_FUNCTION_UNSUPPORTED;
+    }
+
+    const std::unique_ptr<XrGeneratedDispatchTable> &dispatch_table = loader_instance->DispatchTable();
+    XrResult result = dispatch_table->DestroyDebugUtilsMessengerEXT(messenger);
+    LoaderLogger::LogVerboseMessage("xrDestroyDebugUtilsMessengerEXT", "Completed loader trampoline");
+    return result;
 }
 
 // ---- Extension manual loader terminator functions
@@ -533,248 +483,192 @@ XRAPI_ATTR XrResult XRAPI_CALL xrDestroyDebugUtilsMessengerEXT(XrDebugUtilsMesse
 XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermCreateDebugUtilsMessengerEXT(XrInstance instance,
                                                                         const XrDebugUtilsMessengerCreateInfoEXT *createInfo,
                                                                         XrDebugUtilsMessengerEXT *messenger) {
-    try {
-        LoaderLogger::LogVerboseMessage("xrCreateDebugUtilsMessengerEXT", "Entering loader terminator");
-        if (nullptr == messenger) {
-            return XR_ERROR_VALIDATION_FAILURE;
-        }
-        const XrGeneratedDispatchTable *dispatch_table = RuntimeInterface::GetRuntime().GetDispatchTable(instance);
-        XrResult result = XR_SUCCESS;
-        // This extension is supported entirely by the loader which means the runtime may or may not support it.
-        if (nullptr != dispatch_table->CreateDebugUtilsMessengerEXT) {
-            result = dispatch_table->CreateDebugUtilsMessengerEXT(instance, createInfo, messenger);
-        } else {
-            // Just allocate a character so we have a unique value
-            char *temp_mess_ptr = new char;
-            *messenger = reinterpret_cast<XrDebugUtilsMessengerEXT>(temp_mess_ptr);
-        }
-        if (XR_SUCCESS == result) {
-            std::unique_ptr<LoaderLogRecorder> base_recorder(new DebugUtilsLogRecorder(createInfo, *messenger));
-            LoaderLogger::GetInstance().AddLogRecorder(base_recorder);
-            RuntimeInterface::GetRuntime().TrackDebugMessenger(instance, *messenger);
-        }
-        LoaderLogger::LogVerboseMessage("xrCreateDebugUtilsMessengerEXT", "Completed loader terminator");
-        return result;
-    } catch (std::bad_alloc &) {
-        LoaderLogger::LogErrorMessage("xrCreateDebugUtilsMessengerEXT", "Terminator failed allocating memory");
-        return XR_ERROR_OUT_OF_MEMORY;
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("xrCreateDebugUtilsMessengerEXT", "Terminator encountered an unknown error");
-        return XR_ERROR_INITIALIZATION_FAILED;
+    LoaderLogger::LogVerboseMessage("xrCreateDebugUtilsMessengerEXT", "Entering loader terminator");
+    if (nullptr == messenger) {
+        return XR_ERROR_VALIDATION_FAILURE;
     }
+    const XrGeneratedDispatchTable *dispatch_table = RuntimeInterface::GetRuntime().GetDispatchTable(instance);
+    XrResult result = XR_SUCCESS;
+    // This extension is supported entirely by the loader which means the runtime may or may not support it.
+    if (nullptr != dispatch_table->CreateDebugUtilsMessengerEXT) {
+        result = dispatch_table->CreateDebugUtilsMessengerEXT(instance, createInfo, messenger);
+    } else {
+        // Just allocate a character so we have a unique value
+        char *temp_mess_ptr = new char;
+        *messenger = reinterpret_cast<XrDebugUtilsMessengerEXT>(temp_mess_ptr);
+    }
+    if (XR_SUCCESS == result) {
+        std::unique_ptr<LoaderLogRecorder> base_recorder(new DebugUtilsLogRecorder(createInfo, *messenger));
+        LoaderLogger::GetInstance().AddLogRecorder(base_recorder);
+        RuntimeInterface::GetRuntime().TrackDebugMessenger(instance, *messenger);
+    }
+    LoaderLogger::LogVerboseMessage("xrCreateDebugUtilsMessengerEXT", "Completed loader terminator");
+    return result;
 }
 
 XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermDestroyDebugUtilsMessengerEXT(XrDebugUtilsMessengerEXT messenger) {
-    try {
-        LoaderLogger::LogVerboseMessage("xrDestroyDebugUtilsMessengerEXT", "Entering loader terminator");
-        const XrGeneratedDispatchTable *dispatch_table =
-            RuntimeInterface::GetRuntime().GetDebugUtilsMessengerDispatchTable(messenger);
-        XrResult result = XR_SUCCESS;
-        // This extension is supported entirely by the loader which means the runtime may or may not support it.
-        if (nullptr != dispatch_table->DestroyDebugUtilsMessengerEXT) {
-            result = dispatch_table->DestroyDebugUtilsMessengerEXT(messenger);
-        } else {
-            // Delete the character we would've created
-            delete (reinterpret_cast<char *>(reinterpret_cast<uint64_t &>(messenger)));
-        }
-        LoaderLogger::LogVerboseMessage("xrDestroyDebugUtilsMessengerEXT", "Completed loader terminator");
-        LoaderLogger::GetInstance().RemoveLogRecorder(reinterpret_cast<uint64_t &>(messenger));
-        RuntimeInterface::GetRuntime().ForgetDebugMessenger(messenger);
-        return result;
-    } catch (...) {
-        std::string error_message = "Terminator encountered an unknown error.  Likely XrDebugUtilsMessengerEXT 0x";
-        std::ostringstream oss;
-        oss << std::hex << reinterpret_cast<const void *>(messenger);
-        error_message += oss.str();
-        error_message += " is invalid";
-        LoaderLogger::LogErrorMessage("xrDestroyDebugUtilsMessengerEXT", error_message);
-        return XR_ERROR_DEBUG_UTILS_MESSENGER_INVALID_EXT;
+    LoaderLogger::LogVerboseMessage("xrDestroyDebugUtilsMessengerEXT", "Entering loader terminator");
+    const XrGeneratedDispatchTable *dispatch_table =
+        RuntimeInterface::GetRuntime().GetDebugUtilsMessengerDispatchTable(messenger);
+    XrResult result = XR_SUCCESS;
+    // This extension is supported entirely by the loader which means the runtime may or may not support it.
+    if (nullptr != dispatch_table->DestroyDebugUtilsMessengerEXT) {
+        result = dispatch_table->DestroyDebugUtilsMessengerEXT(messenger);
+    } else {
+        // Delete the character we would've created
+        delete (reinterpret_cast<char *>(reinterpret_cast<uint64_t &>(messenger)));
     }
+    LoaderLogger::LogVerboseMessage("xrDestroyDebugUtilsMessengerEXT", "Completed loader terminator");
+    LoaderLogger::GetInstance().RemoveLogRecorder(reinterpret_cast<uint64_t &>(messenger));
+    RuntimeInterface::GetRuntime().ForgetDebugMessenger(messenger);
+    return result;
 }
 
 XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermSubmitDebugUtilsMessageEXT(XrInstance instance,
                                                                       XrDebugUtilsMessageSeverityFlagsEXT messageSeverity,
                                                                       XrDebugUtilsMessageTypeFlagsEXT messageTypes,
                                                                       const XrDebugUtilsMessengerCallbackDataEXT *callbackData) {
-    try {
-        LoaderLogger::LogVerboseMessage("xrSubmitDebugUtilsMessageEXT", "Entering loader terminator");
-        const XrGeneratedDispatchTable *dispatch_table = RuntimeInterface::GetRuntime().GetDispatchTable(instance);
-        XrResult result = XR_SUCCESS;
-        if (nullptr != dispatch_table->SubmitDebugUtilsMessageEXT) {
-            result = dispatch_table->SubmitDebugUtilsMessageEXT(instance, messageSeverity, messageTypes, callbackData);
-        } else {
-            // Only log the message from the loader if the runtime doesn't support this extension.  If we did,
-            // then the user would receive multiple instances of the same message.
-            LoaderLogger::GetInstance().LogDebugUtilsMessage(messageSeverity, messageTypes, callbackData);
-        }
-        LoaderLogger::LogVerboseMessage("xrSubmitDebugUtilsMessageEXT", "Completed loader terminator");
-        return result;
-    } catch (...) {
-        std::string error_message = "xrSubmitDebugUtilsMessageEXT terminator encountered an unknown error.  Likely XrInstance 0x";
-        std::ostringstream oss;
-        oss << std::hex << reinterpret_cast<const void *>(instance);
-        error_message += oss.str();
-        error_message += " is invalid";
-        LoaderLogger::LogErrorMessage("xrSubmitDebugUtilsMessageEXT", error_message);
-        return XR_ERROR_HANDLE_INVALID;
+    LoaderLogger::LogVerboseMessage("xrSubmitDebugUtilsMessageEXT", "Entering loader terminator");
+    const XrGeneratedDispatchTable *dispatch_table = RuntimeInterface::GetRuntime().GetDispatchTable(instance);
+    XrResult result = XR_SUCCESS;
+    if (nullptr != dispatch_table->SubmitDebugUtilsMessageEXT) {
+        result = dispatch_table->SubmitDebugUtilsMessageEXT(instance, messageSeverity, messageTypes, callbackData);
+    } else {
+        // Only log the message from the loader if the runtime doesn't support this extension.  If we did,
+        // then the user would receive multiple instances of the same message.
+        LoaderLogger::GetInstance().LogDebugUtilsMessage(messageSeverity, messageTypes, callbackData);
     }
+    LoaderLogger::LogVerboseMessage("xrSubmitDebugUtilsMessageEXT", "Completed loader terminator");
+    return result;
 }
 
 XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermSetDebugUtilsObjectNameEXT(XrInstance instance,
                                                                       const XrDebugUtilsObjectNameInfoEXT *nameInfo) {
-    try {
-        LoaderLogger::LogVerboseMessage("xrSetDebugUtilsObjectNameEXT", "Entering loader terminator");
-        const XrGeneratedDispatchTable *dispatch_table = RuntimeInterface::GetRuntime().GetDispatchTable(instance);
-        XrResult result = XR_SUCCESS;
-        if (nullptr != dispatch_table->SetDebugUtilsObjectNameEXT) {
-            result = dispatch_table->SetDebugUtilsObjectNameEXT(instance, nameInfo);
-        }
-        LoaderLogger::GetInstance().AddObjectName(nameInfo->objectHandle, nameInfo->objectType, nameInfo->objectName);
-        LoaderLogger::LogVerboseMessage("xrSetDebugUtilsObjectNameEXT", "Completed loader terminator");
-        return result;
-    } catch (...) {
-        std::string error_message = "xrSetDebugUtilsObjectNameEXT terminator encountered an unknown error.  Likely XrInstance 0x";
-        std::ostringstream oss;
-        oss << std::hex << reinterpret_cast<const void *>(instance);
-        error_message += oss.str();
-        error_message += " is invalid";
-        LoaderLogger::LogErrorMessage("xrSetDebugUtilsObjectNameEXT", error_message);
-        return XR_ERROR_HANDLE_INVALID;
+    LoaderLogger::LogVerboseMessage("xrSetDebugUtilsObjectNameEXT", "Entering loader terminator");
+    const XrGeneratedDispatchTable *dispatch_table = RuntimeInterface::GetRuntime().GetDispatchTable(instance);
+    XrResult result = XR_SUCCESS;
+    if (nullptr != dispatch_table->SetDebugUtilsObjectNameEXT) {
+        result = dispatch_table->SetDebugUtilsObjectNameEXT(instance, nameInfo);
     }
+    LoaderLogger::GetInstance().AddObjectName(nameInfo->objectHandle, nameInfo->objectType, nameInfo->objectName);
+    LoaderLogger::LogVerboseMessage("xrSetDebugUtilsObjectNameEXT", "Completed loader terminator");
+    return result;
 }
 
 XRAPI_ATTR XrResult XRAPI_CALL xrSessionBeginDebugUtilsLabelRegionEXT(XrSession session, const XrDebugUtilsLabelEXT *labelInfo) {
-    try {
-        LoaderInstance *loader_instance = nullptr;
-        {
-            std::unique_lock<std::mutex> lock(g_session_mutex);
-            auto map_iter = g_session_map.find(session);
-            if (map_iter == g_session_map.end()) {
-                return XR_ERROR_VALIDATION_FAILURE;
-            }
-            loader_instance = map_iter->second;
-        }
-
-        std::vector<XrLoaderLogObjectInfo> loader_objects;
-        XrLoaderLogObjectInfo object_info = {};
-        object_info.type = XR_OBJECT_TYPE_SESSION;
-        object_info.handle = reinterpret_cast<uint64_t &>(session);
-        loader_objects.push_back(object_info);
-        if (nullptr == loader_instance) {
-            LoaderLogger::LogValidationErrorMessage("VUID-xrSessionBeginDebugUtilsLabelRegionEXT-session-parameter",
-                                                    "xrSessionBeginDebugUtilsLabelRegionEXT", "session is not a valid XrSession",
-                                                    loader_objects);
-            return XR_ERROR_HANDLE_INVALID;
-        }
-        if (!loader_instance->ExtensionIsEnabled(XR_EXT_DEBUG_UTILS_EXTENSION_NAME)) {
-            LoaderLogger::LogValidationErrorMessage("TBD", "xrSessionBeginDebugUtilsLabelRegionEXT",
-                                                    "Extension entrypoint called without enabling appropriate extension",
-                                                    loader_objects);
-            return XR_ERROR_FUNCTION_UNSUPPORTED;
-        } else if (nullptr == labelInfo) {
-            LoaderLogger::LogValidationErrorMessage("VUID-xrSessionBeginDebugUtilsLabelRegionEXT-labelInfo-parameter",
-                                                    "xrSessionBeginDebugUtilsLabelRegionEXT", "labelInfo must be non-NULL",
-                                                    loader_objects);
+    LoaderInstance *loader_instance = nullptr;
+    {
+        std::unique_lock<std::mutex> lock(g_session_mutex);
+        auto map_iter = g_session_map.find(session);
+        if (map_iter == g_session_map.end()) {
             return XR_ERROR_VALIDATION_FAILURE;
         }
+        loader_instance = map_iter->second;
+    }
 
-        LoaderLogger::GetInstance().BeginLabelRegion(session, labelInfo);
-        const std::unique_ptr<XrGeneratedDispatchTable> &dispatch_table = loader_instance->DispatchTable();
-        if (nullptr != dispatch_table->SessionBeginDebugUtilsLabelRegionEXT) {
-            return dispatch_table->SessionBeginDebugUtilsLabelRegionEXT(session, labelInfo);
-        }
-        return XR_SUCCESS;
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("xrSessionBeginDebugUtilsLabelRegionEXT",
-                                      "xrSessionBeginDebugUtilsLabelRegionEXT trampoline encountered an unknown error");
+    std::vector<XrLoaderLogObjectInfo> loader_objects;
+    XrLoaderLogObjectInfo object_info = {};
+    object_info.type = XR_OBJECT_TYPE_SESSION;
+    object_info.handle = reinterpret_cast<uint64_t &>(session);
+    loader_objects.push_back(object_info);
+    if (nullptr == loader_instance) {
+        LoaderLogger::LogValidationErrorMessage("VUID-xrSessionBeginDebugUtilsLabelRegionEXT-session-parameter",
+                                                "xrSessionBeginDebugUtilsLabelRegionEXT", "session is not a valid XrSession",
+                                                loader_objects);
+        return XR_ERROR_HANDLE_INVALID;
+    }
+    if (!loader_instance->ExtensionIsEnabled(XR_EXT_DEBUG_UTILS_EXTENSION_NAME)) {
+        LoaderLogger::LogValidationErrorMessage("TBD", "xrSessionBeginDebugUtilsLabelRegionEXT",
+                                                "Extension entrypoint called without enabling appropriate extension",
+                                                loader_objects);
+        return XR_ERROR_FUNCTION_UNSUPPORTED;
+    } else if (nullptr == labelInfo) {
+        LoaderLogger::LogValidationErrorMessage("VUID-xrSessionBeginDebugUtilsLabelRegionEXT-labelInfo-parameter",
+                                                "xrSessionBeginDebugUtilsLabelRegionEXT", "labelInfo must be non-NULL",
+                                                loader_objects);
         return XR_ERROR_VALIDATION_FAILURE;
     }
+
+    LoaderLogger::GetInstance().BeginLabelRegion(session, labelInfo);
+    const std::unique_ptr<XrGeneratedDispatchTable> &dispatch_table = loader_instance->DispatchTable();
+    if (nullptr != dispatch_table->SessionBeginDebugUtilsLabelRegionEXT) {
+        return dispatch_table->SessionBeginDebugUtilsLabelRegionEXT(session, labelInfo);
+    }
+    return XR_SUCCESS;
 }
 
 XRAPI_ATTR XrResult XRAPI_CALL xrSessionEndDebugUtilsLabelRegionEXT(XrSession session) {
-    try {
-        LoaderInstance *loader_instance = nullptr;
-        {
-            std::unique_lock<std::mutex> lock(g_session_mutex);
-            auto map_iter = g_session_map.find(session);
-            if (map_iter == g_session_map.end()) {
-                return XR_ERROR_VALIDATION_FAILURE;
-            }
-            loader_instance = map_iter->second;
+    LoaderInstance *loader_instance = nullptr;
+    {
+        std::unique_lock<std::mutex> lock(g_session_mutex);
+        auto map_iter = g_session_map.find(session);
+        if (map_iter == g_session_map.end()) {
+            return XR_ERROR_VALIDATION_FAILURE;
         }
-
-        if (nullptr == loader_instance) {
-            XrLoaderLogObjectInfo bad_object = {};
-            bad_object.type = XR_OBJECT_TYPE_SESSION;
-            bad_object.handle = reinterpret_cast<uint64_t &>(session);
-            std::vector<XrLoaderLogObjectInfo> loader_objects;
-            loader_objects.push_back(bad_object);
-            LoaderLogger::LogValidationErrorMessage("VUID-xrSessionEndDebugUtilsLabelRegionEXT-session-parameter",
-                                                    "xrSessionEndDebugUtilsLabelRegionEXT", "session is not a valid XrSession",
-                                                    loader_objects);
-            return XR_ERROR_HANDLE_INVALID;
-        } else if (!loader_instance->ExtensionIsEnabled(XR_EXT_DEBUG_UTILS_EXTENSION_NAME)) {
-            return XR_ERROR_FUNCTION_UNSUPPORTED;
-        }
-        LoaderLogger::GetInstance().EndLabelRegion(session);
-        const std::unique_ptr<XrGeneratedDispatchTable> &dispatch_table = loader_instance->DispatchTable();
-        if (nullptr != dispatch_table->SessionBeginDebugUtilsLabelRegionEXT) {
-            return dispatch_table->SessionEndDebugUtilsLabelRegionEXT(session);
-        }
-        return XR_SUCCESS;
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("xrSessionEndDebugUtilsLabelRegionEXT",
-                                      "xrSessionEndDebugUtilsLabelRegionEXT trampoline encountered an unknown error");
-        return XR_ERROR_VALIDATION_FAILURE;
+        loader_instance = map_iter->second;
     }
+
+    if (nullptr == loader_instance) {
+        XrLoaderLogObjectInfo bad_object = {};
+        bad_object.type = XR_OBJECT_TYPE_SESSION;
+        bad_object.handle = reinterpret_cast<uint64_t &>(session);
+        std::vector<XrLoaderLogObjectInfo> loader_objects;
+        loader_objects.push_back(bad_object);
+        LoaderLogger::LogValidationErrorMessage("VUID-xrSessionEndDebugUtilsLabelRegionEXT-session-parameter",
+                                                "xrSessionEndDebugUtilsLabelRegionEXT", "session is not a valid XrSession",
+                                                loader_objects);
+        return XR_ERROR_HANDLE_INVALID;
+    } else if (!loader_instance->ExtensionIsEnabled(XR_EXT_DEBUG_UTILS_EXTENSION_NAME)) {
+        return XR_ERROR_FUNCTION_UNSUPPORTED;
+    }
+    LoaderLogger::GetInstance().EndLabelRegion(session);
+    const std::unique_ptr<XrGeneratedDispatchTable> &dispatch_table = loader_instance->DispatchTable();
+    if (nullptr != dispatch_table->SessionBeginDebugUtilsLabelRegionEXT) {
+        return dispatch_table->SessionEndDebugUtilsLabelRegionEXT(session);
+    }
+    return XR_SUCCESS;
 }
 
 XRAPI_ATTR XrResult XRAPI_CALL xrSessionInsertDebugUtilsLabelEXT(XrSession session, const XrDebugUtilsLabelEXT *labelInfo) {
-    try {
-        LoaderInstance *loader_instance = nullptr;
-        {
-            std::unique_lock<std::mutex> lock(g_session_mutex);
-            auto map_iter = g_session_map.find(session);
-            if (map_iter == g_session_map.end()) {
-                return XR_ERROR_VALIDATION_FAILURE;
-            }
-            loader_instance = map_iter->second;
-        }
-
-        XrLoaderLogObjectInfo object_info = {};
-        object_info.type = XR_OBJECT_TYPE_SESSION;
-        object_info.handle = reinterpret_cast<uint64_t &>(session);
-        std::vector<XrLoaderLogObjectInfo> loader_objects;
-        loader_objects.push_back(object_info);
-        if (nullptr == loader_instance) {
-            LoaderLogger::LogValidationErrorMessage("VUID-xrSessionInsertDebugUtilsLabelEXT-session-parameter",
-                                                    "xrSessionInsertDebugUtilsLabelEXT", "session is not a valid XrSession",
-                                                    loader_objects);
-            return XR_ERROR_HANDLE_INVALID;
-        }
-        if (!loader_instance->ExtensionIsEnabled(XR_EXT_DEBUG_UTILS_EXTENSION_NAME)) {
-            LoaderLogger::LogValidationErrorMessage("TBD", "xrSessionInsertDebugUtilsLabelEXT",
-                                                    "Extension entrypoint called without enabling appropriate extension",
-                                                    loader_objects);
-            return XR_ERROR_FUNCTION_UNSUPPORTED;
-        } else if (nullptr == labelInfo) {
-            LoaderLogger::LogValidationErrorMessage("VUID-xrSessionInsertDebugUtilsLabelEXT-labelInfo-parameter",
-                                                    "xrSessionInsertDebugUtilsLabelEXT", "labelInfo must be non-NULL",
-                                                    loader_objects);
+    LoaderInstance *loader_instance = nullptr;
+    {
+        std::unique_lock<std::mutex> lock(g_session_mutex);
+        auto map_iter = g_session_map.find(session);
+        if (map_iter == g_session_map.end()) {
             return XR_ERROR_VALIDATION_FAILURE;
         }
+        loader_instance = map_iter->second;
+    }
 
-        LoaderLogger::GetInstance().InsertLabel(session, labelInfo);
-        const std::unique_ptr<XrGeneratedDispatchTable> &dispatch_table = loader_instance->DispatchTable();
-        if (nullptr != dispatch_table->SessionInsertDebugUtilsLabelEXT) {
-            return dispatch_table->SessionInsertDebugUtilsLabelEXT(session, labelInfo);
-        }
-        return XR_SUCCESS;
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("xrSessionInsertDebugUtilsLabelEXT",
-                                      "xrSessionInsertDebugUtilsLabelEXT trampoline encountered an unknown error");
+    XrLoaderLogObjectInfo object_info = {};
+    object_info.type = XR_OBJECT_TYPE_SESSION;
+    object_info.handle = reinterpret_cast<uint64_t &>(session);
+    std::vector<XrLoaderLogObjectInfo> loader_objects;
+    loader_objects.push_back(object_info);
+    if (nullptr == loader_instance) {
+        LoaderLogger::LogValidationErrorMessage("VUID-xrSessionInsertDebugUtilsLabelEXT-session-parameter",
+                                                "xrSessionInsertDebugUtilsLabelEXT", "session is not a valid XrSession",
+                                                loader_objects);
+        return XR_ERROR_HANDLE_INVALID;
+    }
+    if (!loader_instance->ExtensionIsEnabled(XR_EXT_DEBUG_UTILS_EXTENSION_NAME)) {
+        LoaderLogger::LogValidationErrorMessage("TBD", "xrSessionInsertDebugUtilsLabelEXT",
+                                                "Extension entrypoint called without enabling appropriate extension",
+                                                loader_objects);
+        return XR_ERROR_FUNCTION_UNSUPPORTED;
+    } else if (nullptr == labelInfo) {
+        LoaderLogger::LogValidationErrorMessage("VUID-xrSessionInsertDebugUtilsLabelEXT-labelInfo-parameter",
+                                                "xrSessionInsertDebugUtilsLabelEXT", "labelInfo must be non-NULL",
+                                                loader_objects);
         return XR_ERROR_VALIDATION_FAILURE;
     }
+
+    LoaderLogger::GetInstance().InsertLabel(session, labelInfo);
+    const std::unique_ptr<XrGeneratedDispatchTable> &dispatch_table = loader_instance->DispatchTable();
+    if (nullptr != dispatch_table->SessionInsertDebugUtilsLabelEXT) {
+        return dispatch_table->SessionInsertDebugUtilsLabelEXT(session, labelInfo);
+    }
+    return XR_SUCCESS;
 }
 
 }  // extern "C"

--- a/src/loader/loader_instance.cpp
+++ b/src/loader/loader_instance.cpp
@@ -45,149 +45,141 @@ const std::vector<XrExtensionProperties> LoaderInstance::_loader_supported_exten
 XrResult LoaderInstance::CreateInstance(std::vector<std::unique_ptr<ApiLayerInterface>>& api_layer_interfaces,
                                         const XrInstanceCreateInfo* info, XrInstance* instance) {
     XrResult last_error = XR_SUCCESS;
-    try {
-        LoaderLogger::LogVerboseMessage("xrCreateInstance", "Entering LoaderInstance::CreateInstance");
-        LoaderInstance* loader_instance;
+    LoaderLogger::LogVerboseMessage("xrCreateInstance", "Entering LoaderInstance::CreateInstance");
+    LoaderInstance* loader_instance;
 
-        // Topmost means "closest to the application"
-        PFN_xrCreateInstance topmost_ci_fp = LoaderXrTermCreateInstance;
-        PFN_xrCreateApiLayerInstance topmost_cali_fp = LoaderXrTermCreateApiLayerInstance;
+    // Topmost means "closest to the application"
+    PFN_xrCreateInstance topmost_ci_fp = LoaderXrTermCreateInstance;
+    PFN_xrCreateApiLayerInstance topmost_cali_fp = LoaderXrTermCreateApiLayerInstance;
 
-        // Create the loader instance
-        loader_instance = new LoaderInstance(api_layer_interfaces);
-        *instance = reinterpret_cast<XrInstance>(loader_instance);
+    // Create the loader instance
+    loader_instance = new LoaderInstance(api_layer_interfaces);
+    *instance = reinterpret_cast<XrInstance>(loader_instance);
 
-        // Only start the xrCreateApiLayerInstance stack if we have layers.
-        std::vector<std::unique_ptr<ApiLayerInterface>>& layer_interfaces = loader_instance->LayerInterfaces();
-        if (layer_interfaces.size() > 0) {
-            // Initialize an array of ApiLayerNextInfo structs
-            XrApiLayerNextInfo* next_info_list = new XrApiLayerNextInfo[layer_interfaces.size()];
-            uint32_t ni_index = static_cast<uint32_t>(layer_interfaces.size() - 1);
-            for (uint32_t i = 0; i <= ni_index; i++) {
-                next_info_list[i].structType = XR_LOADER_INTERFACE_STRUCT_API_LAYER_NEXT_INFO;
-                next_info_list[i].structVersion = XR_API_LAYER_NEXT_INFO_STRUCT_VERSION;
-                next_info_list[i].structSize = sizeof(XrApiLayerNextInfo);
-            }
-
-            // Go through all layers, and override the instance pointers with the layer version.  However,
-            // go backwards through the layer list so we replace in reverse order so the layers can call their next function
-            // appropriately.
-            XrApiLayerNextInfo* prev_nextinfo = nullptr;
-            PFN_xrGetInstanceProcAddr prev_gipa_fp = LoaderXrTermGetInstanceProcAddr;
-            PFN_xrCreateApiLayerInstance prev_cali_fp = LoaderXrTermCreateApiLayerInstance;
-            for (auto layer_interface = layer_interfaces.rbegin(); layer_interface != layer_interfaces.rend(); ++layer_interface) {
-                // Collect current layer's function pointers
-                PFN_xrGetInstanceProcAddr cur_gipa_fp = (*layer_interface)->GetInstanceProcAddrFuncPointer();
-                PFN_xrCreateApiLayerInstance cur_cali_fp = (*layer_interface)->GetCreateApiLayerInstanceFuncPointer();
-                // Update topmosts
-                cur_gipa_fp(XR_NULL_HANDLE, "xrCreateInstance", reinterpret_cast<PFN_xrVoidFunction*>(&topmost_ci_fp));
-                topmost_cali_fp = cur_cali_fp;
-
-                // Fill in layer info and link previous (lower) layer fxn pointers
-                strncpy(next_info_list[ni_index].layerName, (*layer_interface)->LayerName().c_str(),
-                        XR_MAX_API_LAYER_NAME_SIZE - 1);
-                next_info_list[ni_index].layerName[XR_MAX_API_LAYER_NAME_SIZE - 1] = '\0';
-                next_info_list[ni_index].next = prev_nextinfo;
-                next_info_list[ni_index].nextGetInstanceProcAddr = prev_gipa_fp;
-                next_info_list[ni_index].nextCreateApiLayerInstance = prev_cali_fp;
-
-                // Update saved pointers for next iteration
-                prev_nextinfo = &next_info_list[ni_index];
-                prev_gipa_fp = cur_gipa_fp;
-                prev_cali_fp = cur_cali_fp;
-                ni_index--;
-            }
-
-            // Populate the ApiLayerCreateInfo struct and pass to topmost CreateApiLayerInstance()
-            XrApiLayerCreateInfo api_layer_ci = {};
-            api_layer_ci.structType = XR_LOADER_INTERFACE_STRUCT_API_LAYER_CREATE_INFO;
-            api_layer_ci.structVersion = XR_API_LAYER_CREATE_INFO_STRUCT_VERSION;
-            api_layer_ci.structSize = sizeof(XrApiLayerCreateInfo);
-            api_layer_ci.loaderInstance = reinterpret_cast<void*>(loader_instance);
-            api_layer_ci.settings_file_location[0] = '\0';
-            api_layer_ci.nextInfo = next_info_list;
-            last_error = topmost_cali_fp(info, &api_layer_ci, instance);
-
-            delete[] next_info_list;
-        } else {
-            last_error = topmost_ci_fp(info, instance);
+    // Only start the xrCreateApiLayerInstance stack if we have layers.
+    std::vector<std::unique_ptr<ApiLayerInterface>>& layer_interfaces = loader_instance->LayerInterfaces();
+    if (layer_interfaces.size() > 0) {
+        // Initialize an array of ApiLayerNextInfo structs
+        XrApiLayerNextInfo* next_info_list = new XrApiLayerNextInfo[layer_interfaces.size()];
+        uint32_t ni_index = static_cast<uint32_t>(layer_interfaces.size() - 1);
+        for (uint32_t i = 0; i <= ni_index; i++) {
+            next_info_list[i].structType = XR_LOADER_INTERFACE_STRUCT_API_LAYER_NEXT_INFO;
+            next_info_list[i].structVersion = XR_API_LAYER_NEXT_INFO_STRUCT_VERSION;
+            next_info_list[i].structSize = sizeof(XrApiLayerNextInfo);
         }
 
-        if (XR_SUCCEEDED(last_error)) {
-            // Check the list of enabled extensions to make sure something supports them, and, if we do,
-            // add it to the list of enabled extensions
-            for (uint32_t ext = 0; ext < info->enabledExtensionCount; ++ext) {
-                bool found = false;
-                // First check the runtime
-                if (RuntimeInterface::GetRuntime().SupportsExtension(info->enabledExtensionNames[ext])) {
-                    found = true;
-                }
-                // Next check the loader
-                if (!found) {
-                    for (auto loader_extension : LoaderInstance::_loader_supported_extensions) {
-                        if (!strcmp(loader_extension.extensionName, info->enabledExtensionNames[ext])) {
-                            found = true;
-                            break;
-                        }
+        // Go through all layers, and override the instance pointers with the layer version.  However,
+        // go backwards through the layer list so we replace in reverse order so the layers can call their next function
+        // appropriately.
+        XrApiLayerNextInfo* prev_nextinfo = nullptr;
+        PFN_xrGetInstanceProcAddr prev_gipa_fp = LoaderXrTermGetInstanceProcAddr;
+        PFN_xrCreateApiLayerInstance prev_cali_fp = LoaderXrTermCreateApiLayerInstance;
+        for (auto layer_interface = layer_interfaces.rbegin(); layer_interface != layer_interfaces.rend(); ++layer_interface) {
+            // Collect current layer's function pointers
+            PFN_xrGetInstanceProcAddr cur_gipa_fp = (*layer_interface)->GetInstanceProcAddrFuncPointer();
+            PFN_xrCreateApiLayerInstance cur_cali_fp = (*layer_interface)->GetCreateApiLayerInstanceFuncPointer();
+            // Update topmosts
+            cur_gipa_fp(XR_NULL_HANDLE, "xrCreateInstance", reinterpret_cast<PFN_xrVoidFunction*>(&topmost_ci_fp));
+            topmost_cali_fp = cur_cali_fp;
+
+            // Fill in layer info and link previous (lower) layer fxn pointers
+            strncpy(next_info_list[ni_index].layerName, (*layer_interface)->LayerName().c_str(),
+                    XR_MAX_API_LAYER_NAME_SIZE - 1);
+            next_info_list[ni_index].layerName[XR_MAX_API_LAYER_NAME_SIZE - 1] = '\0';
+            next_info_list[ni_index].next = prev_nextinfo;
+            next_info_list[ni_index].nextGetInstanceProcAddr = prev_gipa_fp;
+            next_info_list[ni_index].nextCreateApiLayerInstance = prev_cali_fp;
+
+            // Update saved pointers for next iteration
+            prev_nextinfo = &next_info_list[ni_index];
+            prev_gipa_fp = cur_gipa_fp;
+            prev_cali_fp = cur_cali_fp;
+            ni_index--;
+        }
+
+        // Populate the ApiLayerCreateInfo struct and pass to topmost CreateApiLayerInstance()
+        XrApiLayerCreateInfo api_layer_ci = {};
+        api_layer_ci.structType = XR_LOADER_INTERFACE_STRUCT_API_LAYER_CREATE_INFO;
+        api_layer_ci.structVersion = XR_API_LAYER_CREATE_INFO_STRUCT_VERSION;
+        api_layer_ci.structSize = sizeof(XrApiLayerCreateInfo);
+        api_layer_ci.loaderInstance = reinterpret_cast<void*>(loader_instance);
+        api_layer_ci.settings_file_location[0] = '\0';
+        api_layer_ci.nextInfo = next_info_list;
+        last_error = topmost_cali_fp(info, &api_layer_ci, instance);
+
+        delete[] next_info_list;
+    } else {
+        last_error = topmost_ci_fp(info, instance);
+    }
+
+    if (XR_SUCCEEDED(last_error)) {
+        // Check the list of enabled extensions to make sure something supports them, and, if we do,
+        // add it to the list of enabled extensions
+        for (uint32_t ext = 0; ext < info->enabledExtensionCount; ++ext) {
+            bool found = false;
+            // First check the runtime
+            if (RuntimeInterface::GetRuntime().SupportsExtension(info->enabledExtensionNames[ext])) {
+                found = true;
+            }
+            // Next check the loader
+            if (!found) {
+                for (auto loader_extension : LoaderInstance::_loader_supported_extensions) {
+                    if (!strcmp(loader_extension.extensionName, info->enabledExtensionNames[ext])) {
+                        found = true;
+                        break;
                     }
                 }
-                // Finally, check the enabled layers
-                if (!found) {
-                    for (auto layer_interface = layer_interfaces.begin(); layer_interface != layer_interfaces.end();
-                         ++layer_interface) {
-                        if ((*layer_interface)->SupportsExtension(info->enabledExtensionNames[ext])) {
-                            found = true;
-                            break;
-                        }
+            }
+            // Finally, check the enabled layers
+            if (!found) {
+                for (auto layer_interface = layer_interfaces.begin(); layer_interface != layer_interfaces.end();
+                     ++layer_interface) {
+                    if ((*layer_interface)->SupportsExtension(info->enabledExtensionNames[ext])) {
+                        found = true;
+                        break;
                     }
                 }
-                if (!found) {
-                    std::string msg = "LoaderInstance::CreateInstance, no support found for requested extension: ";
-                    msg += info->enabledExtensionNames[ext];
-                    LoaderLogger::LogErrorMessage("xrCreateInstance", msg);
-                    last_error = XR_ERROR_EXTENSION_NOT_PRESENT;
-                    break;
-                }
-                loader_instance->AddEnabledExtension(info->enabledExtensionNames[ext]);
             }
-        } else {
-            LoaderLogger::LogErrorMessage("xrCreateInstance", "LoaderInstance::CreateInstance chained CreateInstance call failed");
-        }
-
-        if (XR_SUCCEEDED(last_error)) {
-            // Create the top-level dispatch table for the instance.  This will contain the function pointers to the
-            // first instantiation of every command, whether that is in a layer, or a runtime.
-            last_error = loader_instance->CreateDispatchTable(*instance);
-            if (XR_FAILED(last_error)) {
-                LoaderLogger::LogErrorMessage("xrCreateInstance",
-                                              "LoaderInstance::CreateInstance failed creating top-level dispatch table");
-            } else {
-                std::unique_lock<std::mutex> lock(g_instance_mutex);
-                auto exists = g_instance_map.find(*instance);
-                if (exists == g_instance_map.end()) {
-                    g_instance_map[*instance] = loader_instance;
-                }
+            if (!found) {
+                std::string msg = "LoaderInstance::CreateInstance, no support found for requested extension: ";
+                msg += info->enabledExtensionNames[ext];
+                LoaderLogger::LogErrorMessage("xrCreateInstance", msg);
+                last_error = XR_ERROR_EXTENSION_NOT_PRESENT;
+                break;
             }
+            loader_instance->AddEnabledExtension(info->enabledExtensionNames[ext]);
         }
+    } else {
+        LoaderLogger::LogErrorMessage("xrCreateInstance", "LoaderInstance::CreateInstance chained CreateInstance call failed");
+    }
 
+    if (XR_SUCCEEDED(last_error)) {
+        // Create the top-level dispatch table for the instance.  This will contain the function pointers to the
+        // first instantiation of every command, whether that is in a layer, or a runtime.
+        last_error = loader_instance->CreateDispatchTable(*instance);
         if (XR_FAILED(last_error)) {
-            delete loader_instance;
-            loader_instance = nullptr;
+            LoaderLogger::LogErrorMessage("xrCreateInstance",
+                                          "LoaderInstance::CreateInstance failed creating top-level dispatch table");
         } else {
-            std::string info_message = "LoaderInstance::CreateInstance succeeded with ";
-            info_message += std::to_string(loader_instance->LayerInterfaces().size());
-            info_message += " layers enabled and runtime interface - created instance = 0x";
-            std::ostringstream oss;
-            oss << std::hex << reinterpret_cast<uintptr_t>(loader_instance);
-            info_message += oss.str();
-            LoaderLogger::LogInfoMessage("xrCreateInstance", info_message);
+            std::unique_lock<std::mutex> lock(g_instance_mutex);
+            auto exists = g_instance_map.find(*instance);
+            if (exists == g_instance_map.end()) {
+                g_instance_map[*instance] = loader_instance;
+            }
         }
-    } catch (std::bad_alloc&) {
-        LoaderLogger::LogErrorMessage("xrCreateInstance", "LoaderInstance::CreateInstance - failed to allocate memory");
-        last_error = XR_ERROR_OUT_OF_MEMORY;
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("xrCreateInstance", "LoaderInstance::CreateInstance - unknown error occurred");
-        last_error = XR_ERROR_INITIALIZATION_FAILED;
+    }
+
+    if (XR_FAILED(last_error)) {
+        delete loader_instance;
+        loader_instance = nullptr;
+    } else {
+        std::string info_message = "LoaderInstance::CreateInstance succeeded with ";
+        info_message += std::to_string(loader_instance->LayerInterfaces().size());
+        info_message += " layers enabled and runtime interface - created instance = 0x";
+        std::ostringstream oss;
+        oss << std::hex << reinterpret_cast<uintptr_t>(loader_instance);
+        info_message += oss.str();
+        LoaderLogger::LogInfoMessage("xrCreateInstance", info_message);
     }
 
     // Always clear the input lists.  Either we use them or we don't.
@@ -198,15 +190,10 @@ XrResult LoaderInstance::CreateInstance(std::vector<std::unique_ptr<ApiLayerInte
 
 LoaderInstance::LoaderInstance(std::vector<std::unique_ptr<ApiLayerInterface>>& api_layer_interfaces)
     : _unique_id(0xDECAFBAD), _api_version(XR_CURRENT_API_VERSION), _dispatch_valid(false), _messenger(XR_NULL_HANDLE) {
-    try {
-        for (auto l_iter = api_layer_interfaces.begin(); api_layer_interfaces.size() > 0 && l_iter != api_layer_interfaces.end();
-             /* No iterate */) {
-            _api_layer_interfaces.push_back(std::move(*l_iter));
-            api_layer_interfaces.erase(l_iter);
-        }
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("xrCreateInstance", "LoaderInstance::LoaderInstance - Unknown error occurred");
-        throw;
+    for (auto l_iter = api_layer_interfaces.begin(); api_layer_interfaces.size() > 0 && l_iter != api_layer_interfaces.end();
+         /* No iterate */) {
+        _api_layer_interfaces.push_back(std::move(*l_iter));
+        api_layer_interfaces.erase(l_iter);
     }
 }
 
@@ -220,30 +207,22 @@ LoaderInstance::~LoaderInstance() {
 
 XrResult LoaderInstance::CreateDispatchTable(XrInstance instance) {
     XrResult res = XR_SUCCESS;
-    try {
-        // Create the top-level dispatch table.  First, we want to start with a dispatch table generated
-        // using the commands from the runtime, with the exception of commands that we need a terminator
-        // for.  The loaderGenInitInstanceDispatchTable utility function handles that automatically for us.
-        std::unique_ptr<XrGeneratedDispatchTable> new_instance_dispatch_table(new XrGeneratedDispatchTable());
-        LoaderGenInitInstanceDispatchTable(_runtime_instance, new_instance_dispatch_table);
+    // Create the top-level dispatch table.  First, we want to start with a dispatch table generated
+    // using the commands from the runtime, with the exception of commands that we need a terminator
+    // for.  The loaderGenInitInstanceDispatchTable utility function handles that automatically for us.
+    std::unique_ptr<XrGeneratedDispatchTable> new_instance_dispatch_table(new XrGeneratedDispatchTable());
+    LoaderGenInitInstanceDispatchTable(_runtime_instance, new_instance_dispatch_table);
 
-        // Go through all layers, and override the instance pointers with the layer version.  However,
-        // go backwards through the layer list so we replace in reverse order so the layers can call their next function
-        // appropriately.
-        if (_api_layer_interfaces.size() > 0) {
-            (*_api_layer_interfaces.begin())->GenUpdateInstanceDispatchTable(instance, new_instance_dispatch_table);
-        }
-
-        // Set the top-level instance dispatch table to the top-most commands now that we've figured them out.
-        _dispatch_table = std::move(new_instance_dispatch_table);
-        _dispatch_valid = true;
-    } catch (std::bad_alloc&) {
-        LoaderLogger::LogErrorMessage("xrCreateInstance", "LoaderInstance::CreateDispatchTable - failed to allocate memory");
-        res = XR_ERROR_OUT_OF_MEMORY;
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("xrCreateInstance", "LoaderInstance::CreateDispatchTable - unknown error occurred");
-        res = XR_ERROR_INITIALIZATION_FAILED;
+    // Go through all layers, and override the instance pointers with the layer version.  However,
+    // go backwards through the layer list so we replace in reverse order so the layers can call their next function
+    // appropriately.
+    if (_api_layer_interfaces.size() > 0) {
+        (*_api_layer_interfaces.begin())->GenUpdateInstanceDispatchTable(instance, new_instance_dispatch_table);
     }
+
+    // Set the top-level instance dispatch table to the top-most commands now that we've figured them out.
+    _dispatch_table = std::move(new_instance_dispatch_table);
+    _dispatch_valid = true;
     return res;
 }
 

--- a/src/loader/manifest_file.cpp
+++ b/src/loader/manifest_file.cpp
@@ -60,15 +60,10 @@ static inline bool StringEndsWith(std::string const &value, std::string const &e
 
 // If the file found is a manifest file name, add it to the out_files manifest list.
 static void AddIfJson(ManifestFileType type, const std::string &full_file, std::vector<std::string> &manifest_files) {
-    try {
-        if (0 == full_file.size() || !StringEndsWith(full_file, ".json")) {
-            return;
-        }
-        manifest_files.push_back(full_file);
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("", "AddIfJson - unknown error occurred");
-        throw;
+    if (0 == full_file.size() || !StringEndsWith(full_file, ".json")) {
+        return;
     }
+    manifest_files.push_back(full_file);
 }
 
 // Check the current path for any manifest files.  If the provided search_path is a directory, look for
@@ -76,32 +71,27 @@ static void AddIfJson(ManifestFileType type, const std::string &full_file, std::
 // be a single filename.
 static void CheckAllFilesInThePath(ManifestFileType type, const std::string &search_path, bool is_directory_list,
                                    std::vector<std::string> &manifest_files) {
-    try {
-        if (FileSysUtilsPathExists(search_path)) {
-            std::string absolute_path;
-            if (!is_directory_list) {
-                // If the file exists, try to add it
-                if (FileSysUtilsIsRegularFile(search_path)) {
-                    FileSysUtilsGetAbsolutePath(search_path, absolute_path);
-                    AddIfJson(type, absolute_path, manifest_files);
-                }
-            } else {
-                std::vector<std::string> files;
-                if (FileSysUtilsFindFilesInPath(search_path, files)) {
-                    for (std::string &cur_file : files) {
-                        std::string relative_path;
-                        FileSysUtilsCombinePaths(search_path, cur_file, relative_path);
-                        if (!FileSysUtilsGetAbsolutePath(relative_path, absolute_path)) {
-                            continue;
-                        }
-                        AddIfJson(type, absolute_path, manifest_files);
+    if (FileSysUtilsPathExists(search_path)) {
+        std::string absolute_path;
+        if (!is_directory_list) {
+            // If the file exists, try to add it
+            if (FileSysUtilsIsRegularFile(search_path)) {
+                FileSysUtilsGetAbsolutePath(search_path, absolute_path);
+                AddIfJson(type, absolute_path, manifest_files);
+            }
+        } else {
+            std::vector<std::string> files;
+            if (FileSysUtilsFindFilesInPath(search_path, files)) {
+                for (std::string &cur_file : files) {
+                    std::string relative_path;
+                    FileSysUtilsCombinePaths(search_path, cur_file, relative_path);
+                    if (!FileSysUtilsGetAbsolutePath(relative_path, absolute_path)) {
+                        continue;
                     }
+                    AddIfJson(type, absolute_path, manifest_files);
                 }
             }
         }
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("", "CheckAllFilesInThePath - unknown error occurred");
-        throw;
     }
 }
 
@@ -114,31 +104,26 @@ static void AddFilesInPath(ManifestFileType type, const std::string &search_path
     std::size_t found = search_path.find_first_of(PATH_SEPARATOR);
     std::string cur_search;
 
-    try {
-        // Handle any path listings in the string (separated by the appropriate path separator)
-        while (found != std::string::npos) {
-            // substr takes a start index and length.
-            std::size_t length = found - last_found;
-            cur_search = search_path.substr(last_found, length);
+    // Handle any path listings in the string (separated by the appropriate path separator)
+    while (found != std::string::npos) {
+        // substr takes a start index and length.
+        std::size_t length = found - last_found;
+        cur_search = search_path.substr(last_found, length);
 
-            CheckAllFilesInThePath(type, cur_search, is_directory_list, manifest_files);
+        CheckAllFilesInThePath(type, cur_search, is_directory_list, manifest_files);
 
-            // This works around issue if multiple path separator follow each other directly.
-            last_found = found;
-            while (found == last_found) {
-                last_found = found + 1;
-                found = search_path.find_first_of(PATH_SEPARATOR, last_found);
-            }
+        // This works around issue if multiple path separator follow each other directly.
+        last_found = found;
+        while (found == last_found) {
+            last_found = found + 1;
+            found = search_path.find_first_of(PATH_SEPARATOR, last_found);
         }
+    }
 
-        // If there's something remaining in the string, copy it over
-        if (last_found < search_path.size()) {
-            cur_search = search_path.substr(last_found);
-            CheckAllFilesInThePath(type, cur_search, is_directory_list, manifest_files);
-        }
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("", "AddFilesInPath - unknown error occurred");
-        throw;
+    // If there's something remaining in the string, copy it over
+    if (last_found < search_path.size()) {
+        cur_search = search_path.substr(last_found);
+        CheckAllFilesInThePath(type, cur_search, is_directory_list, manifest_files);
     }
 }
 
@@ -149,34 +134,29 @@ static void CopyIncludedPaths(bool is_directory_list, const std::string &cur_pat
         std::size_t last_found = 0;
         std::size_t found = cur_path.find_first_of(PATH_SEPARATOR);
 
-        try {
-            // Handle any path listings in the string (separated by the appropriate path separator)
-            while (found != std::string::npos) {
-                std::size_t length = found - last_found;
-                output_path += cur_path.substr(last_found, length);
-                if (is_directory_list && (cur_path[found - 1] != '\\' && cur_path[found - 1] != '/')) {
-                    output_path += DIRECTORY_SYMBOL;
-                }
-                output_path += relative_path;
-                output_path += PATH_SEPARATOR;
-
-                last_found = found;
-                found = cur_path.find_first_of(PATH_SEPARATOR, found + 1);
+        // Handle any path listings in the string (separated by the appropriate path separator)
+        while (found != std::string::npos) {
+            std::size_t length = found - last_found;
+            output_path += cur_path.substr(last_found, length);
+            if (is_directory_list && (cur_path[found - 1] != '\\' && cur_path[found - 1] != '/')) {
+                output_path += DIRECTORY_SYMBOL;
             }
+            output_path += relative_path;
+            output_path += PATH_SEPARATOR;
 
-            // If there's something remaining in the string, copy it over
-            size_t last_char = cur_path.size() - 1;
-            if (last_found != last_char) {
-                output_path += cur_path.substr(last_found);
-                if (is_directory_list && (cur_path[last_char] != '\\' && cur_path[last_char] != '/')) {
-                    output_path += DIRECTORY_SYMBOL;
-                }
-                output_path += relative_path;
-                output_path += PATH_SEPARATOR;
+            last_found = found;
+            found = cur_path.find_first_of(PATH_SEPARATOR, found + 1);
+        }
+
+        // If there's something remaining in the string, copy it over
+        size_t last_char = cur_path.size() - 1;
+        if (last_found != last_char) {
+            output_path += cur_path.substr(last_found);
+            if (is_directory_list && (cur_path[last_char] != '\\' && cur_path[last_char] != '/')) {
+                output_path += DIRECTORY_SYMBOL;
             }
-        } catch (...) {
-            LoaderLogger::LogErrorMessage("", "CopyIncludedPaths - unknown error occurred");
-            throw;
+            output_path += relative_path;
+            output_path += PATH_SEPARATOR;
         }
     }
 }
@@ -190,97 +170,92 @@ static void ReadDataFilesInSearchPaths(ManifestFileType type, const std::string 
     std::string override_path = "";
     std::string search_path = "";
 
-    try {
-        if (override_env_var.size() != 0) {
+    if (override_env_var.size() != 0) {
 #ifndef XR_OS_WINDOWS
-            if (geteuid() != getuid() || getegid() != getgid()) {
-                // Don't allow setuid apps to use the env var:
-                override_env = nullptr;
-            } else
+        if (geteuid() != getuid() || getegid() != getgid()) {
+            // Don't allow setuid apps to use the env var:
+            override_env = nullptr;
+        } else
 #endif
-            {
-                override_env = PlatformUtilsGetSecureEnv(override_env_var.c_str());
-                if (nullptr != override_env) {
-                    // The runtime override is actually a specific list of filenames, not directories
-                    if (is_runtime) {
-                        is_directory_list = false;
-                    }
-                    override_path = override_env;
+        {
+            override_env = PlatformUtilsGetSecureEnv(override_env_var.c_str());
+            if (nullptr != override_env) {
+                // The runtime override is actually a specific list of filenames, not directories
+                if (is_runtime) {
+                    is_directory_list = false;
                 }
+                override_path = override_env;
             }
         }
-
-        if (nullptr != override_env && override_path.size() != 0) {
-            CopyIncludedPaths(is_directory_list, override_path, "", search_path);
-            PlatformUtilsFreeEnv(override_env);
-            override_active = true;
-        } else {
-            override_active = false;
-#ifndef XR_OS_WINDOWS
-            bool xdg_conf_dirs_alloc = true;
-            bool xdg_data_dirs_alloc = true;
-            const char home_additional[] = ".local/share/";
-
-            // Determine how much space is needed to generate the full search path
-            // for the current manifest files.
-            char *xdg_conf_dirs = PlatformUtilsGetSecureEnv("XDG_CONFIG_DIRS");
-            char *xdg_data_dirs = PlatformUtilsGetSecureEnv("XDG_DATA_DIRS");
-            char *xdg_data_home = PlatformUtilsGetSecureEnv("XDG_DATA_HOME");
-            char *home = PlatformUtilsGetSecureEnv("HOME");
-
-            if (nullptr == xdg_conf_dirs) {
-                xdg_conf_dirs_alloc = false;
-            }
-            if (nullptr == xdg_data_dirs) {
-                xdg_data_dirs_alloc = false;
-            }
-
-            if (nullptr == xdg_conf_dirs || xdg_conf_dirs[0] == '\0') {
-                CopyIncludedPaths(true, FALLBACK_CONFIG_DIRS, relative_path, search_path);
-            } else {
-                CopyIncludedPaths(true, xdg_conf_dirs, relative_path, search_path);
-            }
-
-            CopyIncludedPaths(true, SYSCONFDIR, relative_path, search_path);
-#if defined(EXTRASYSCONFDIR)
-            CopyIncludedPaths(true, EXTRASYSCONFDIR, relative_path, search_path);
-#endif
-
-            if (xdg_data_dirs == nullptr || xdg_data_dirs[0] == '\0') {
-                CopyIncludedPaths(true, FALLBACK_DATA_DIRS, relative_path, search_path);
-            } else {
-                CopyIncludedPaths(true, xdg_data_dirs, relative_path, search_path);
-            }
-
-            if (nullptr != xdg_data_home) {
-                CopyIncludedPaths(true, xdg_data_home, relative_path, search_path);
-            } else if (nullptr != home) {
-                std::string relative_home_path = home_additional;
-                relative_home_path += relative_path;
-                CopyIncludedPaths(true, home, relative_home_path, search_path);
-            }
-
-            if (xdg_conf_dirs_alloc) {
-                PlatformUtilsFreeEnv(xdg_conf_dirs);
-            }
-            if (xdg_data_dirs_alloc) {
-                PlatformUtilsFreeEnv(xdg_data_dirs);
-            }
-            if (nullptr != xdg_data_home) {
-                PlatformUtilsFreeEnv(xdg_data_home);
-            }
-            if (nullptr != home) {
-                PlatformUtilsFreeEnv(home);
-            }
-#endif
-        }
-
-        // Now, parse the paths and add any manifest files found in them.
-        AddFilesInPath(type, search_path, is_directory_list, manifest_files);
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("", "ReadDataFilesInSearchPaths - unknown error occurred");
-        throw;
     }
+
+    if (nullptr != override_env && override_path.size() != 0) {
+        CopyIncludedPaths(is_directory_list, override_path, "", search_path);
+        PlatformUtilsFreeEnv(override_env);
+        override_active = true;
+    } else {
+        override_active = false;
+#ifndef XR_OS_WINDOWS
+        bool xdg_conf_dirs_alloc = true;
+        bool xdg_data_dirs_alloc = true;
+        const char home_additional[] = ".local/share/";
+
+        // Determine how much space is needed to generate the full search path
+        // for the current manifest files.
+        char *xdg_conf_dirs = PlatformUtilsGetSecureEnv("XDG_CONFIG_DIRS");
+        char *xdg_data_dirs = PlatformUtilsGetSecureEnv("XDG_DATA_DIRS");
+        char *xdg_data_home = PlatformUtilsGetSecureEnv("XDG_DATA_HOME");
+        char *home = PlatformUtilsGetSecureEnv("HOME");
+
+        if (nullptr == xdg_conf_dirs) {
+            xdg_conf_dirs_alloc = false;
+        }
+        if (nullptr == xdg_data_dirs) {
+            xdg_data_dirs_alloc = false;
+        }
+
+        if (nullptr == xdg_conf_dirs || xdg_conf_dirs[0] == '\0') {
+            CopyIncludedPaths(true, FALLBACK_CONFIG_DIRS, relative_path, search_path);
+        } else {
+            CopyIncludedPaths(true, xdg_conf_dirs, relative_path, search_path);
+        }
+
+        CopyIncludedPaths(true, SYSCONFDIR, relative_path, search_path);
+#if defined(EXTRASYSCONFDIR)
+        CopyIncludedPaths(true, EXTRASYSCONFDIR, relative_path, search_path);
+#endif
+
+        if (xdg_data_dirs == nullptr || xdg_data_dirs[0] == '\0') {
+            CopyIncludedPaths(true, FALLBACK_DATA_DIRS, relative_path, search_path);
+        } else {
+            CopyIncludedPaths(true, xdg_data_dirs, relative_path, search_path);
+        }
+
+        if (nullptr != xdg_data_home) {
+            CopyIncludedPaths(true, xdg_data_home, relative_path, search_path);
+        } else if (nullptr != home) {
+            std::string relative_home_path = home_additional;
+            relative_home_path += relative_path;
+            CopyIncludedPaths(true, home, relative_home_path, search_path);
+        }
+
+        if (xdg_conf_dirs_alloc) {
+            PlatformUtilsFreeEnv(xdg_conf_dirs);
+        }
+        if (xdg_data_dirs_alloc) {
+            PlatformUtilsFreeEnv(xdg_data_dirs);
+        }
+        if (nullptr != xdg_data_home) {
+            PlatformUtilsFreeEnv(xdg_data_home);
+        }
+        if (nullptr != home) {
+            PlatformUtilsFreeEnv(home);
+        }
+#endif
+    }
+
+    // Now, parse the paths and add any manifest files found in them.
+    AddFilesInPath(type, search_path, is_directory_list, manifest_files);
 }
 
 #ifdef XR_OS_LINUX
@@ -363,33 +338,28 @@ static bool FindXDGConfigFile(const std::string &relative_path, std::string &out
 static void ReadRuntimeDataFilesInRegistry(ManifestFileType type, const std::string &runtime_registry_location,
                                            const std::string &default_runtime_value_name,
                                            std::vector<std::string> &manifest_files) {
-    try {
-        HKEY hkey;
-        DWORD access_flags;
-        char value[1024];
-        DWORD value_size = 1023;
+    HKEY hkey;
+    DWORD access_flags;
+    char value[1024];
+    DWORD value_size = 1023;
 
-        // Generate the full registry location for the registry information
-        std::string full_registry_location = OPENXR_REGISTRY_LOCATION;
-        full_registry_location += std::to_string(XR_VERSION_MAJOR(XR_CURRENT_API_VERSION));
-        full_registry_location += runtime_registry_location;
+    // Generate the full registry location for the registry information
+    std::string full_registry_location = OPENXR_REGISTRY_LOCATION;
+    full_registry_location += std::to_string(XR_VERSION_MAJOR(XR_CURRENT_API_VERSION));
+    full_registry_location += runtime_registry_location;
 
-        // Use 64 bit regkey for 64bit application, and use 32 bit regkey in WOW for 32bit application.
-        access_flags = KEY_QUERY_VALUE;
-        LONG open_value = RegOpenKeyExA(HKEY_LOCAL_MACHINE, full_registry_location.c_str(), 0, access_flags, &hkey);
+    // Use 64 bit regkey for 64bit application, and use 32 bit regkey in WOW for 32bit application.
+    access_flags = KEY_QUERY_VALUE;
+    LONG open_value = RegOpenKeyExA(HKEY_LOCAL_MACHINE, full_registry_location.c_str(), 0, access_flags, &hkey);
 
-        if (ERROR_SUCCESS != open_value) {
-            std::string warning_message = "ReadLayerDataFilesInRegistry - failed to read registry location ";
-            warning_message += full_registry_location;
-            LoaderLogger::LogWarningMessage("", warning_message);
-        } else if (ERROR_SUCCESS == RegQueryValueExA(hkey, default_runtime_value_name.c_str(), NULL, NULL,
-                                                     reinterpret_cast<LPBYTE>(&value), &value_size) &&
-                   value_size < 1024) {
-            AddFilesInPath(type, value, false, manifest_files);
-        }
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("", "ReadLayerDataFilesInRegistry - unknown error occurred");
-        throw;
+    if (ERROR_SUCCESS != open_value) {
+        std::string warning_message = "ReadLayerDataFilesInRegistry - failed to read registry location ";
+        warning_message += full_registry_location;
+        LoaderLogger::LogWarningMessage("", warning_message);
+    } else if (ERROR_SUCCESS == RegQueryValueExA(hkey, default_runtime_value_name.c_str(), NULL, NULL,
+                                                 reinterpret_cast<LPBYTE>(&value), &value_size) &&
+               value_size < 1024) {
+        AddFilesInPath(type, value, false, manifest_files);
     }
 }
 
@@ -397,48 +367,43 @@ static void ReadRuntimeDataFilesInRegistry(ManifestFileType type, const std::str
 // if we should use that instead.
 static void ReadLayerDataFilesInRegistry(ManifestFileType type, const std::string &registry_location,
                                          std::vector<std::string> &manifest_files) {
-    try {
-        HKEY hive[2] = {HKEY_LOCAL_MACHINE, HKEY_CURRENT_USER};
-        bool found[2] = {false, false};
-        HKEY hkey;
-        DWORD access_flags;
-        LONG rtn_value;
-        char name[1024];
-        DWORD value;
-        DWORD name_size = 1023;
-        DWORD value_size = sizeof(value);
+    HKEY hive[2] = {HKEY_LOCAL_MACHINE, HKEY_CURRENT_USER};
+    bool found[2] = {false, false};
+    HKEY hkey;
+    DWORD access_flags;
+    LONG rtn_value;
+    char name[1024];
+    DWORD value;
+    DWORD name_size = 1023;
+    DWORD value_size = sizeof(value);
 
-        for (uint8_t hive_index = 0; hive_index < 2; ++hive_index) {
-            DWORD key_index = 0;
-            std::string full_registry_location = OPENXR_REGISTRY_LOCATION;
-            full_registry_location += std::to_string(XR_VERSION_MAJOR(XR_CURRENT_API_VERSION));
-            full_registry_location += registry_location;
+    for (uint8_t hive_index = 0; hive_index < 2; ++hive_index) {
+        DWORD key_index = 0;
+        std::string full_registry_location = OPENXR_REGISTRY_LOCATION;
+        full_registry_location += std::to_string(XR_VERSION_MAJOR(XR_CURRENT_API_VERSION));
+        full_registry_location += registry_location;
 
-            access_flags = KEY_QUERY_VALUE;
-            LONG open_value = RegOpenKeyExA(hive[hive_index], full_registry_location.c_str(), 0, access_flags, &hkey);
-            if (ERROR_SUCCESS != open_value) {
-                if (hive_index == 1 && !found[0]) {
-                    std::string warning_message = "ReadLayerDataFilesInRegistry - failed to read registry location ";
-                    warning_message += registry_location;
-                    warning_message += " in either HKEY_LOCAL_MACHINE or KHEY_CURRENT_USER";
-                    LoaderLogger::LogWarningMessage("", warning_message);
-                }
-                continue;
+        access_flags = KEY_QUERY_VALUE;
+        LONG open_value = RegOpenKeyExA(hive[hive_index], full_registry_location.c_str(), 0, access_flags, &hkey);
+        if (ERROR_SUCCESS != open_value) {
+            if (hive_index == 1 && !found[0]) {
+                std::string warning_message = "ReadLayerDataFilesInRegistry - failed to read registry location ";
+                warning_message += registry_location;
+                warning_message += " in either HKEY_LOCAL_MACHINE or KHEY_CURRENT_USER";
+                LoaderLogger::LogWarningMessage("", warning_message);
             }
-            found[hive_index] = true;
-            while (ERROR_SUCCESS ==
-                   (rtn_value = RegEnumValueA(hkey, key_index++, name, &name_size, NULL, NULL, (LPBYTE)&value, &value_size))) {
-                if (value_size == sizeof(value) && value == 0) {
-                    std::string filename = name;
-                    AddFilesInPath(type, filename, false, manifest_files);
-                }
-                // Reset some items for the next loop
-                name_size = 1023;
-            }
+            continue;
         }
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("", "ReadLayerDataFilesInRegistry - unknown error occurred");
-        throw;
+        found[hive_index] = true;
+        while (ERROR_SUCCESS ==
+               (rtn_value = RegEnumValueA(hkey, key_index++, name, &name_size, NULL, NULL, (LPBYTE)&value, &value_size))) {
+            if (value_size == sizeof(value) && value == 0) {
+                std::string filename = name;
+                AddFilesInPath(type, filename, false, manifest_files);
+            }
+            // Reset some items for the next loop
+            name_size = 1023;
+        }
     }
 }
 
@@ -450,30 +415,25 @@ ManifestFile::ManifestFile(ManifestFileType type, const std::string &filename, c
 ManifestFile::~ManifestFile() {}
 
 bool ManifestFile::IsValidJson(Json::Value &root_node, JsonVersion &version) {
-    try {
-        if (root_node["file_format_version"].isNull() || !root_node["file_format_version"].isString()) {
-            LoaderLogger::LogErrorMessage("", "ManifestFile::IsValidJson - JSON file missing \"file_format_version\"");
-            return false;
-        }
-        std::string file_format = root_node["file_format_version"].asString();
-        sscanf(file_format.c_str(), "%d.%d.%d", &version.major, &version.minor, &version.patch);
+    if (root_node["file_format_version"].isNull() || !root_node["file_format_version"].isString()) {
+        LoaderLogger::LogErrorMessage("", "ManifestFile::IsValidJson - JSON file missing \"file_format_version\"");
+        return false;
+    }
+    std::string file_format = root_node["file_format_version"].asString();
+    sscanf(file_format.c_str(), "%d.%d.%d", &version.major, &version.minor, &version.patch);
 
-        // Only version 1.0.0 is defined currently.  Eventually we may have more version, but
-        // some of the versions may only be valid for layers or runtimes specifically.
-        if (version.major != 1 || version.minor != 0 || version.patch != 0) {
-            std::string error_message = "ManifestFile::IsValidJson - JSON \"file_format_version\" ";
-            error_message += std::to_string(version.major);
-            error_message += ".";
-            error_message += std::to_string(version.minor);
-            error_message += ".";
-            error_message += std::to_string(version.patch);
-            error_message += " is not supported";
-            LoaderLogger::LogErrorMessage("", error_message);
-            return false;
-        }
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("", "ManifestFile::IsValidJson - unknown error occurred");
-        throw;
+    // Only version 1.0.0 is defined currently.  Eventually we may have more version, but
+    // some of the versions may only be valid for layers or runtimes specifically.
+    if (version.major != 1 || version.minor != 0 || version.patch != 0) {
+        std::string error_message = "ManifestFile::IsValidJson - JSON \"file_format_version\" ";
+        error_message += std::to_string(version.major);
+        error_message += ".";
+        error_message += std::to_string(version.minor);
+        error_message += ".";
+        error_message += std::to_string(version.patch);
+        error_message += " is not supported";
+        LoaderLogger::LogErrorMessage("", error_message);
+        return false;
     }
 
     return true;
@@ -482,80 +442,65 @@ bool ManifestFile::IsValidJson(Json::Value &root_node, JsonVersion &version) {
 // Return any instance extensions found in the manifest files in the proper form for
 // OpenXR (XrExtensionProperties).
 void ManifestFile::GetInstanceExtensionProperties(std::vector<XrExtensionProperties> &props) {
-    try {
-        size_t ext_count = _instance_extensions.size();
-        size_t props_count = props.size();
-        bool found = false;
-        for (size_t ext = 0; ext < ext_count; ++ext) {
-            for (size_t prop = 0; prop < props_count; ++prop) {
-                if (!strcmp(props[prop].extensionName, _instance_extensions[ext].name.c_str())) {
-                    if (props[prop].specVersion < _instance_extensions[ext].spec_version) {
-                        props[prop].specVersion = _instance_extensions[ext].spec_version;
-                        found = true;
-                        break;
-                    }
+    size_t ext_count = _instance_extensions.size();
+    size_t props_count = props.size();
+    bool found = false;
+    for (size_t ext = 0; ext < ext_count; ++ext) {
+        for (size_t prop = 0; prop < props_count; ++prop) {
+            if (!strcmp(props[prop].extensionName, _instance_extensions[ext].name.c_str())) {
+                if (props[prop].specVersion < _instance_extensions[ext].spec_version) {
+                    props[prop].specVersion = _instance_extensions[ext].spec_version;
+                    found = true;
+                    break;
                 }
             }
-            if (!found) {
-                XrExtensionProperties prop = {};
-                prop.type = XR_TYPE_EXTENSION_PROPERTIES;
-                prop.next = nullptr;
-                strncpy(prop.extensionName, _instance_extensions[ext].name.c_str(), XR_MAX_EXTENSION_NAME_SIZE - 1);
-                prop.extensionName[XR_MAX_EXTENSION_NAME_SIZE - 1] = '\0';
-                prop.specVersion = _instance_extensions[ext].spec_version;
-                props.push_back(prop);
-            }
         }
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("", "ManifestFile::GetInstanceExtensionProperties - unknown error occurred");
-        throw;
+        if (!found) {
+            XrExtensionProperties prop = {};
+            prop.type = XR_TYPE_EXTENSION_PROPERTIES;
+            prop.next = nullptr;
+            strncpy(prop.extensionName, _instance_extensions[ext].name.c_str(), XR_MAX_EXTENSION_NAME_SIZE - 1);
+            prop.extensionName[XR_MAX_EXTENSION_NAME_SIZE - 1] = '\0';
+            prop.specVersion = _instance_extensions[ext].spec_version;
+            props.push_back(prop);
+        }
     }
 }
 
 // Return any device extensions found in the manifest files in the proper form for
 // OpenXR (XrExtensionProperties).
 void ManifestFile::GetDeviceExtensionProperties(std::vector<XrExtensionProperties> &props) {
-    try {
-        size_t ext_count = _device_extensions.size();
-        size_t props_count = props.size();
-        bool found = false;
-        for (size_t ext = 0; ext < ext_count; ++ext) {
-            for (size_t prop = 0; prop < props_count; ++prop) {
-                if (!strcmp(props[prop].extensionName, _device_extensions[ext].name.c_str())) {
-                    if (props[prop].specVersion < _device_extensions[ext].spec_version) {
-                        props[prop].specVersion = _device_extensions[ext].spec_version;
-                        found = true;
-                        break;
-                    }
+    size_t ext_count = _device_extensions.size();
+    size_t props_count = props.size();
+    bool found = false;
+    for (size_t ext = 0; ext < ext_count; ++ext) {
+        for (size_t prop = 0; prop < props_count; ++prop) {
+            if (!strcmp(props[prop].extensionName, _device_extensions[ext].name.c_str())) {
+                if (props[prop].specVersion < _device_extensions[ext].spec_version) {
+                    props[prop].specVersion = _device_extensions[ext].spec_version;
+                    found = true;
+                    break;
                 }
             }
-            if (!found) {
-                XrExtensionProperties prop = {};
-                prop.type = XR_TYPE_EXTENSION_PROPERTIES;
-                prop.next = nullptr;
-                strncpy(prop.extensionName, _device_extensions[ext].name.c_str(), XR_MAX_EXTENSION_NAME_SIZE - 1);
-                prop.extensionName[XR_MAX_EXTENSION_NAME_SIZE - 1] = '\0';
-                prop.specVersion = _device_extensions[ext].spec_version;
-                props.push_back(prop);
-            }
         }
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("", "ManifestFile::GetDeviceExtensionProperties - unknown error occurred");
-        throw;
+        if (!found) {
+            XrExtensionProperties prop = {};
+            prop.type = XR_TYPE_EXTENSION_PROPERTIES;
+            prop.next = nullptr;
+            strncpy(prop.extensionName, _device_extensions[ext].name.c_str(), XR_MAX_EXTENSION_NAME_SIZE - 1);
+            prop.extensionName[XR_MAX_EXTENSION_NAME_SIZE - 1] = '\0';
+            prop.specVersion = _device_extensions[ext].spec_version;
+            props.push_back(prop);
+        }
     }
 }
 
 const std::string &ManifestFile::GetFunctionName(const std::string &func_name) {
-    try {
-        if (_functions_renamed.size() > 0) {
-            auto found = _functions_renamed.find(func_name);
-            if (found != _functions_renamed.end()) {
-                return found->second;
-            }
+    if (_functions_renamed.size() > 0) {
+        auto found = _functions_renamed.find(func_name);
+        if (found != _functions_renamed.end()) {
+            return found->second;
         }
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("", "ManifestFile::GetFunctionName - unknown error occurred");
-        throw;
     }
     return func_name;
 }
@@ -566,141 +511,136 @@ RuntimeManifestFile::RuntimeManifestFile(const std::string &filename, const std:
 RuntimeManifestFile::~RuntimeManifestFile() {}
 
 void RuntimeManifestFile::CreateIfValid(std::string filename, std::vector<std::unique_ptr<RuntimeManifestFile>> &manifest_files) {
-    try {
-        std::ifstream json_stream = std::ifstream(filename, std::ifstream::in);
-        if (!json_stream.is_open()) {
-            std::string error_message = "RuntimeManifestFile::createIfValid failed to open ";
-            error_message += filename;
-            error_message += ".  Does it exist?";
-            LoaderLogger::LogErrorMessage("", error_message);
-            return;
-        }
-        Json::Reader reader;
-        Json::Value root_node = Json::nullValue;
-        Json::Value runtime_root_node = Json::nullValue;
-        JsonVersion file_version = {};
-        if (!reader.parse(json_stream, root_node, false) || root_node.isNull()) {
-            std::string error_message = "RuntimeManifestFile::CreateIfValid failed to parse ";
-            error_message += filename;
-            error_message += ".  Is it a valid runtime manifest file?";
-            LoaderLogger::LogErrorMessage("", error_message);
-            return;
-        }
-        if (!ManifestFile::IsValidJson(root_node, file_version)) {
-            std::string error_message = "RuntimeManifestFile::CreateIfValid isValidJson indicates ";
-            error_message += filename;
-            error_message += " is not a valid manifest file.";
-            LoaderLogger::LogErrorMessage("", error_message);
-            return;
-        }
-        runtime_root_node = root_node["runtime"];
-        // The Runtime manifest file needs the "runtime" root as well as sub-nodes for "api_version" and
-        // "library_path".  If any of those aren't there, fail.
-        if (runtime_root_node.isNull() || runtime_root_node["library_path"].isNull() ||
-            !runtime_root_node["library_path"].isString()) {
-            std::string error_message = "RuntimeManifestFile::CreateIfValid ";
-            error_message += filename;
-            error_message += " is missing required fields.  Verify all proper fields exist.";
-            LoaderLogger::LogErrorMessage("", error_message);
-            return;
-        }
+    std::ifstream json_stream = std::ifstream(filename, std::ifstream::in);
+    if (!json_stream.is_open()) {
+        std::string error_message = "RuntimeManifestFile::createIfValid failed to open ";
+        error_message += filename;
+        error_message += ".  Does it exist?";
+        LoaderLogger::LogErrorMessage("", error_message);
+        return;
+    }
+    Json::Reader reader;
+    Json::Value root_node = Json::nullValue;
+    Json::Value runtime_root_node = Json::nullValue;
+    JsonVersion file_version = {};
+    if (!reader.parse(json_stream, root_node, false) || root_node.isNull()) {
+        std::string error_message = "RuntimeManifestFile::CreateIfValid failed to parse ";
+        error_message += filename;
+        error_message += ".  Is it a valid runtime manifest file?";
+        LoaderLogger::LogErrorMessage("", error_message);
+        return;
+    }
+    if (!ManifestFile::IsValidJson(root_node, file_version)) {
+        std::string error_message = "RuntimeManifestFile::CreateIfValid isValidJson indicates ";
+        error_message += filename;
+        error_message += " is not a valid manifest file.";
+        LoaderLogger::LogErrorMessage("", error_message);
+        return;
+    }
+    runtime_root_node = root_node["runtime"];
+    // The Runtime manifest file needs the "runtime" root as well as sub-nodes for "api_version" and
+    // "library_path".  If any of those aren't there, fail.
+    if (runtime_root_node.isNull() || runtime_root_node["library_path"].isNull() ||
+        !runtime_root_node["library_path"].isString()) {
+        std::string error_message = "RuntimeManifestFile::CreateIfValid ";
+        error_message += filename;
+        error_message += " is missing required fields.  Verify all proper fields exist.";
+        LoaderLogger::LogErrorMessage("", error_message);
+        return;
+    }
 
-        std::string lib_path = runtime_root_node["library_path"].asString();
+    std::string lib_path = runtime_root_node["library_path"].asString();
 
-        // If the library_path variable has no directory symbol, it's just a file name and should be accessible on the
-        // global library path.
-        if (lib_path.find("\\") != lib_path.npos || lib_path.find("/") != lib_path.npos) {
-            // If the library_path is an absolute path, just use that if it exists
-            if (FileSysUtilsIsAbsolutePath(lib_path)) {
-                if (!FileSysUtilsPathExists(lib_path)) {
-                    std::string error_message = "RuntimeManifestFile::CreateIfValid ";
-                    error_message += filename;
-                    error_message += " library ";
-                    error_message += lib_path;
-                    error_message += " does not appear to exist";
-                    LoaderLogger::LogErrorMessage("", error_message);
-                    return;
-                }
-                lib_path = lib_path;
-            } else {
-                // Otherwise, treat the library path as a relative path based on the JSON file.
-                std::string combined_path;
-                std::string file_parent;
-                if (!FileSysUtilsGetParentPath(filename, file_parent) ||
-                    !FileSysUtilsCombinePaths(file_parent, lib_path, combined_path) || !FileSysUtilsPathExists(combined_path)) {
-                    std::string error_message = "RuntimeManifestFile::CreateIfValid ";
-                    error_message += filename;
-                    error_message += " library ";
-                    error_message += combined_path;
-                    error_message += " does not appear to exist";
-                    LoaderLogger::LogErrorMessage("", error_message);
-                    return;
-                }
-                lib_path = combined_path;
+    // If the library_path variable has no directory symbol, it's just a file name and should be accessible on the
+    // global library path.
+    if (lib_path.find("\\") != lib_path.npos || lib_path.find("/") != lib_path.npos) {
+        // If the library_path is an absolute path, just use that if it exists
+        if (FileSysUtilsIsAbsolutePath(lib_path)) {
+            if (!FileSysUtilsPathExists(lib_path)) {
+                std::string error_message = "RuntimeManifestFile::CreateIfValid ";
+                error_message += filename;
+                error_message += " library ";
+                error_message += lib_path;
+                error_message += " does not appear to exist";
+                LoaderLogger::LogErrorMessage("", error_message);
+                return;
             }
+            lib_path = lib_path;
+        } else {
+            // Otherwise, treat the library path as a relative path based on the JSON file.
+            std::string combined_path;
+            std::string file_parent;
+            if (!FileSysUtilsGetParentPath(filename, file_parent) ||
+                !FileSysUtilsCombinePaths(file_parent, lib_path, combined_path) || !FileSysUtilsPathExists(combined_path)) {
+                std::string error_message = "RuntimeManifestFile::CreateIfValid ";
+                error_message += filename;
+                error_message += " library ";
+                error_message += combined_path;
+                error_message += " does not appear to exist";
+                LoaderLogger::LogErrorMessage("", error_message);
+                return;
+            }
+            lib_path = combined_path;
         }
+    }
 
-        // Add this runtime manifest file
-        manifest_files.emplace_back(new RuntimeManifestFile(filename, lib_path));
+    // Add this runtime manifest file
+    manifest_files.emplace_back(new RuntimeManifestFile(filename, lib_path));
 
-        // Add any extensions to it after the fact.
-        Json::Value dev_exts = runtime_root_node["device_extensions"];
-        if (!dev_exts.isNull() && dev_exts.isArray()) {
-            for (Json::ValueIterator dev_ext_it = dev_exts.begin(); dev_ext_it != dev_exts.end(); ++dev_ext_it) {
-                Json::Value dev_ext = (*dev_ext_it);
-                Json::Value dev_ext_name = dev_ext["name"];
-                Json::Value dev_ext_version = dev_ext["spec_version"];
-                Json::Value dev_ext_entries = dev_ext["entrypoints"];
-                if (!dev_ext_name.isNull() && dev_ext_name.isString() && !dev_ext_version.isNull() && dev_ext_version.isUInt() &&
-                    !dev_ext_entries.isNull() && dev_ext_entries.isArray()) {
-                    ExtensionListing ext = {};
-                    ext.name = dev_ext_name.asString();
-                    ext.spec_version = dev_ext_version.asUInt();
-                    for (Json::ValueIterator entry_it = dev_ext_entries.begin(); entry_it != dev_ext_entries.end(); ++entry_it) {
-                        Json::Value entry = (*entry_it);
-                        if (!entry.isNull() && entry.isString()) {
-                            ext.entrypoints.push_back(entry.asString());
-                        }
+    // Add any extensions to it after the fact.
+    Json::Value dev_exts = runtime_root_node["device_extensions"];
+    if (!dev_exts.isNull() && dev_exts.isArray()) {
+        for (Json::ValueIterator dev_ext_it = dev_exts.begin(); dev_ext_it != dev_exts.end(); ++dev_ext_it) {
+            Json::Value dev_ext = (*dev_ext_it);
+            Json::Value dev_ext_name = dev_ext["name"];
+            Json::Value dev_ext_version = dev_ext["spec_version"];
+            Json::Value dev_ext_entries = dev_ext["entrypoints"];
+            if (!dev_ext_name.isNull() && dev_ext_name.isString() && !dev_ext_version.isNull() && dev_ext_version.isUInt() &&
+                !dev_ext_entries.isNull() && dev_ext_entries.isArray()) {
+                ExtensionListing ext = {};
+                ext.name = dev_ext_name.asString();
+                ext.spec_version = dev_ext_version.asUInt();
+                for (Json::ValueIterator entry_it = dev_ext_entries.begin(); entry_it != dev_ext_entries.end(); ++entry_it) {
+                    Json::Value entry = (*entry_it);
+                    if (!entry.isNull() && entry.isString()) {
+                        ext.entrypoints.push_back(entry.asString());
                     }
-                    manifest_files.back()->_device_extensions.push_back(ext);
                 }
+                manifest_files.back()->_device_extensions.push_back(ext);
             }
         }
+    }
 
-        Json::Value inst_exts = runtime_root_node["instance_extensions"];
-        if (!inst_exts.isNull() && inst_exts.isArray()) {
-            for (Json::ValueIterator inst_ext_it = inst_exts.begin(); inst_ext_it != inst_exts.end(); ++inst_ext_it) {
-                Json::Value inst_ext = (*inst_ext_it);
-                Json::Value inst_ext_name = inst_ext["name"];
-                Json::Value inst_ext_version = inst_ext["spec_version"];
-                if (!inst_ext_name.isNull() && inst_ext_name.isString() && !inst_ext_version.isNull() &&
-                    inst_ext_version.isUInt()) {
-                    ExtensionListing ext = {};
-                    ext.name = inst_ext_name.asString();
-                    ext.spec_version = inst_ext_version.asUInt();
-                    manifest_files.back()->_instance_extensions.push_back(ext);
-                }
+    Json::Value inst_exts = runtime_root_node["instance_extensions"];
+    if (!inst_exts.isNull() && inst_exts.isArray()) {
+        for (Json::ValueIterator inst_ext_it = inst_exts.begin(); inst_ext_it != inst_exts.end(); ++inst_ext_it) {
+            Json::Value inst_ext = (*inst_ext_it);
+            Json::Value inst_ext_name = inst_ext["name"];
+            Json::Value inst_ext_version = inst_ext["spec_version"];
+            if (!inst_ext_name.isNull() && inst_ext_name.isString() && !inst_ext_version.isNull() &&
+                inst_ext_version.isUInt()) {
+                ExtensionListing ext = {};
+                ext.name = inst_ext_name.asString();
+                ext.spec_version = inst_ext_version.asUInt();
+                manifest_files.back()->_instance_extensions.push_back(ext);
             }
         }
+    }
 
-        Json::Value funcs_renamed = runtime_root_node["functions"];
-        if (!funcs_renamed.isNull() && funcs_renamed.size() > 0) {
-            for (Json::ValueIterator func_it = funcs_renamed.begin(); func_it != funcs_renamed.end(); ++func_it) {
-                if (!(*func_it).isString()) {
-                    std::string warning_message = "RuntimeManifestFile::CreateIfValid ";
-                    warning_message += filename;
-                    warning_message += " \"functions\" section contains non-string values.";
-                    LoaderLogger::LogWarningMessage("", warning_message);
-                    continue;
-                }
-                std::string original_name = func_it.key().asString();
-                std::string new_name = (*func_it).asString();
-                manifest_files.back()->_functions_renamed.insert(std::make_pair(original_name, new_name));
+    Json::Value funcs_renamed = runtime_root_node["functions"];
+    if (!funcs_renamed.isNull() && funcs_renamed.size() > 0) {
+        for (Json::ValueIterator func_it = funcs_renamed.begin(); func_it != funcs_renamed.end(); ++func_it) {
+            if (!(*func_it).isString()) {
+                std::string warning_message = "RuntimeManifestFile::CreateIfValid ";
+                warning_message += filename;
+                warning_message += " \"functions\" section contains non-string values.";
+                LoaderLogger::LogWarningMessage("", warning_message);
+                continue;
             }
+            std::string original_name = func_it.key().asString();
+            std::string new_name = (*func_it).asString();
+            manifest_files.back()->_functions_renamed.insert(std::make_pair(original_name, new_name));
         }
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("", "RuntimeManifestFile::CreateIfValid - unknown error occurred");
-        throw;
     }
 }
 
@@ -708,64 +648,56 @@ void RuntimeManifestFile::CreateIfValid(std::string filename, std::vector<std::u
 XrResult RuntimeManifestFile::FindManifestFiles(ManifestFileType type,
                                                 std::vector<std::unique_ptr<RuntimeManifestFile>> &manifest_files) {
     XrResult result = XR_SUCCESS;
-    try {
-        if (MANIFEST_TYPE_RUNTIME != type) {
-            LoaderLogger::LogErrorMessage("", "RuntimeManifestFile::FindManifestFiles - unknown manifest file requested");
-            throw std::runtime_error("invalid manifest type");
-        }
-        std::string filename;
-        char *override_path = PlatformUtilsGetSecureEnv(OPENXR_RUNTIME_JSON_ENV_VAR);
-        if (override_path != nullptr && *override_path != '\0') {
-            filename = override_path;
-            PlatformUtilsFreeEnv(override_path);
-            std::string info_message = "RuntimeManifestFile::FindManifestFiles - using environment variable override runtime file ";
-            info_message += filename;
-            LoaderLogger::LogInfoMessage("", info_message);
-        } else {
-            PlatformUtilsFreeEnv(override_path);
-#ifdef XR_OS_WINDOWS
-            std::vector<std::string> filenames;
-            ReadRuntimeDataFilesInRegistry(type, "", "ActiveRuntime", filenames);
-            if (filenames.size() == 0) {
-                LoaderLogger::LogErrorMessage(
-                    "", "RuntimeManifestFile::FindManifestFiles - failed to find active runtime file in registry");
-                return XR_ERROR_FILE_ACCESS_ERROR;
-            }
-            if (filenames.size() > 1) {
-                LoaderLogger::LogWarningMessage(
-                    "", "RuntimeManifestFile::FindManifestFiles - found too many default runtime files in registry");
-            }
-            filename = filenames[0];
-#elif defined(XR_OS_LINUX)
-            const std::string relative_path = "openxr/"
-                + std::to_string(XR_VERSION_MAJOR(XR_CURRENT_API_VERSION))
-                + "/active_runtime.json";
-            if (!FindXDGConfigFile(relative_path, filename)) {
-                LoaderLogger::LogErrorMessage(
-                    "",
-                    "RuntimeManifestFile::FindManifestFiles - failed to determine active runtime file path for this environment");
-                return XR_ERROR_FILE_ACCESS_ERROR;
-            }
-#else
-            if (!PlatformGetGlobalRuntimeFileName(XR_VERSION_MAJOR(XR_CURRENT_API_VERSION), filename)) {
-                LoaderLogger::LogErrorMessage(
-                    "",
-                    "RuntimeManifestFile::FindManifestFiles - failed to determine active runtime file path for this environment");
-                return XR_ERROR_FILE_ACCESS_ERROR;
-            }
-#endif
-            std::string info_message = "RuntimeManifestFile::FindManifestFiles - using global runtime file ";
-            info_message += filename;
-            LoaderLogger::LogInfoMessage("", info_message);
-        }
-        RuntimeManifestFile::CreateIfValid(filename, manifest_files);
-    } catch (std::bad_alloc &) {
-        LoaderLogger::LogErrorMessage("", "RuntimeManifestFile::FindManifestFiles - failed to allocate memory");
-        return XR_ERROR_OUT_OF_MEMORY;
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("", "RuntimeManifestFile::FindManifestFiles - unknown error occurred");
+    if (MANIFEST_TYPE_RUNTIME != type) {
+        LoaderLogger::LogErrorMessage("", "RuntimeManifestFile::FindManifestFiles - unknown manifest file requested");
         return XR_ERROR_FILE_ACCESS_ERROR;
     }
+    std::string filename;
+    char *override_path = PlatformUtilsGetSecureEnv(OPENXR_RUNTIME_JSON_ENV_VAR);
+    if (override_path != nullptr && *override_path != '\0') {
+        filename = override_path;
+        PlatformUtilsFreeEnv(override_path);
+        std::string info_message = "RuntimeManifestFile::FindManifestFiles - using environment variable override runtime file ";
+        info_message += filename;
+        LoaderLogger::LogInfoMessage("", info_message);
+    } else {
+        PlatformUtilsFreeEnv(override_path);
+#ifdef XR_OS_WINDOWS
+        std::vector<std::string> filenames;
+        ReadRuntimeDataFilesInRegistry(type, "", "ActiveRuntime", filenames);
+        if (filenames.size() == 0) {
+            LoaderLogger::LogErrorMessage(
+                "", "RuntimeManifestFile::FindManifestFiles - failed to find active runtime file in registry");
+            return XR_ERROR_FILE_ACCESS_ERROR;
+        }
+        if (filenames.size() > 1) {
+            LoaderLogger::LogWarningMessage(
+                "", "RuntimeManifestFile::FindManifestFiles - found too many default runtime files in registry");
+        }
+        filename = filenames[0];
+#elif defined(XR_OS_LINUX)
+        const std::string relative_path = "openxr/"
+            + std::to_string(XR_VERSION_MAJOR(XR_CURRENT_API_VERSION))
+            + "/active_runtime.json";
+        if (!FindXDGConfigFile(relative_path, filename)) {
+            LoaderLogger::LogErrorMessage(
+                "",
+                "RuntimeManifestFile::FindManifestFiles - failed to determine active runtime file path for this environment");
+            return XR_ERROR_FILE_ACCESS_ERROR;
+        }
+#else
+        if (!PlatformGetGlobalRuntimeFileName(XR_VERSION_MAJOR(XR_CURRENT_API_VERSION), filename)) {
+            LoaderLogger::LogErrorMessage(
+                "",
+                "RuntimeManifestFile::FindManifestFiles - failed to determine active runtime file path for this environment");
+            return XR_ERROR_FILE_ACCESS_ERROR;
+        }
+#endif
+        std::string info_message = "RuntimeManifestFile::FindManifestFiles - using global runtime file ";
+        info_message += filename;
+        LoaderLogger::LogInfoMessage("", info_message);
+    }
+    RuntimeManifestFile::CreateIfValid(filename, manifest_files);
     return result;
 }
 
@@ -782,281 +714,263 @@ ApiLayerManifestFile::~ApiLayerManifestFile() {}
 
 void ApiLayerManifestFile::CreateIfValid(ManifestFileType type, std::string filename,
                                          std::vector<std::unique_ptr<ApiLayerManifestFile>> &manifest_files) {
-    try {
-        std::ifstream json_stream = std::ifstream(filename, std::ifstream::in);
-        Json::Reader reader;
-        Json::Value root_node = Json::nullValue;
-        JsonVersion file_version = {};
-        JsonVersion api_version = {};
-        std::string layer_name = "";
-        std::string library_path = "";
-        std::string description = "";
-        if (!reader.parse(json_stream, root_node, false) || root_node.isNull()) {
-            std::string error_message = "ApiLayerManifestFile::CreateIfValid failed to parse ";
-            error_message += filename;
-            error_message += ".  Is it a valid layer manifest file?";
-            LoaderLogger::LogErrorMessage("", error_message);
-            return;
-        }
-        if (!ManifestFile::IsValidJson(root_node, file_version)) {
-            std::string error_message = "ApiLayerManifestFile::CreateIfValid isValidJson indicates ";
-            error_message += filename;
-            error_message += " is not a valid manifest file.";
-            LoaderLogger::LogErrorMessage("", error_message);
-            return;
-        }
+    std::ifstream json_stream = std::ifstream(filename, std::ifstream::in);
+    Json::Reader reader;
+    Json::Value root_node = Json::nullValue;
+    JsonVersion file_version = {};
+    JsonVersion api_version = {};
+    std::string layer_name = "";
+    std::string library_path = "";
+    std::string description = "";
+    if (!reader.parse(json_stream, root_node, false) || root_node.isNull()) {
+        std::string error_message = "ApiLayerManifestFile::CreateIfValid failed to parse ";
+        error_message += filename;
+        error_message += ".  Is it a valid layer manifest file?";
+        LoaderLogger::LogErrorMessage("", error_message);
+        return;
+    }
+    if (!ManifestFile::IsValidJson(root_node, file_version)) {
+        std::string error_message = "ApiLayerManifestFile::CreateIfValid isValidJson indicates ";
+        error_message += filename;
+        error_message += " is not a valid manifest file.";
+        LoaderLogger::LogErrorMessage("", error_message);
+        return;
+    }
 
-        Json::Value layer_root_node = root_node["api_layer"];
+    Json::Value layer_root_node = root_node["api_layer"];
 
-        // The API Layer manifest file needs the "api_layer" root as well as other sub-nodes.
-        // If any of those aren't there, fail.
-        if (layer_root_node.isNull() || layer_root_node["name"].isNull() || !layer_root_node["name"].isString() ||
-            layer_root_node["api_version"].isNull() || !layer_root_node["api_version"].isString() ||
-            layer_root_node["library_path"].isNull() || !layer_root_node["library_path"].isString() ||
-            layer_root_node["implementation_version"].isNull() || !layer_root_node["implementation_version"].isString()) {
-            std::string error_message = "ApiLayerManifestFile::CreateIfValid ";
+    // The API Layer manifest file needs the "api_layer" root as well as other sub-nodes.
+    // If any of those aren't there, fail.
+    if (layer_root_node.isNull() || layer_root_node["name"].isNull() || !layer_root_node["name"].isString() ||
+        layer_root_node["api_version"].isNull() || !layer_root_node["api_version"].isString() ||
+        layer_root_node["library_path"].isNull() || !layer_root_node["library_path"].isString() ||
+        layer_root_node["implementation_version"].isNull() || !layer_root_node["implementation_version"].isString()) {
+        std::string error_message = "ApiLayerManifestFile::CreateIfValid ";
+        error_message += filename;
+        error_message += " is missing required fields.  Verify all proper fields exist.";
+        LoaderLogger::LogErrorMessage("", error_message);
+        return;
+    }
+    if (MANIFEST_TYPE_IMPLICIT_API_LAYER == type) {
+        bool enabled = true;
+        // Implicit layers require the disable environment variable.
+        if (layer_root_node["disable_environment"].isNull() || !layer_root_node["disable_environment"].isString()) {
+            std::string error_message = "ApiLayerManifestFile::CreateIfValid Implicit layer ";
             error_message += filename;
-            error_message += " is missing required fields.  Verify all proper fields exist.";
+            error_message += " is missing \"disable_environment\"";
             LoaderLogger::LogErrorMessage("", error_message);
             return;
         }
-        if (MANIFEST_TYPE_IMPLICIT_API_LAYER == type) {
-            bool enabled = true;
-            // Implicit layers require the disable environment variable.
-            if (layer_root_node["disable_environment"].isNull() || !layer_root_node["disable_environment"].isString()) {
-                std::string error_message = "ApiLayerManifestFile::CreateIfValid Implicit layer ";
+        // Check if there's an enable environment variable provided
+        if (!layer_root_node["enable_environment"].isNull() && layer_root_node["enable_environment"].isString()) {
+            char *enable_val = PlatformUtilsGetEnv(layer_root_node["enable_environment"].asString().c_str());
+            // If it's not set in the environment, disable the layer
+            if (NULL == enable_val) {
+                enabled = false;
+            }
+            PlatformUtilsFreeEnv(enable_val);
+        }
+        // Check for the disable environment variable, which must be provided in the JSON
+        char *disable_val = PlatformUtilsGetEnv(layer_root_node["disable_environment"].asString().c_str());
+        // If the envar is set, disable the layer. Disable envar overrides enable above
+        if (NULL != disable_val) {
+            enabled = false;
+        }
+        PlatformUtilsFreeEnv(disable_val);
+
+        // Not enabled, so pretend like it isn't even there.
+        if (!enabled) {
+            std::string info_message = "ApiLayerManifestFile::CreateIfValid Implicit layer ";
+            info_message += filename;
+            info_message += " is disabled";
+            LoaderLogger::LogInfoMessage("", info_message);
+            return;
+        }
+    }
+    layer_name = layer_root_node["name"].asString();
+    std::string api_version_string = layer_root_node["api_version"].asString();
+    sscanf(api_version_string.c_str(), "%d.%d", &api_version.major, &api_version.minor);
+    api_version.patch = 0;
+
+    if ((api_version.major == 0 && api_version.minor == 0) || api_version.major > XR_VERSION_MAJOR(XR_CURRENT_API_VERSION)) {
+        std::string warning_message = "ApiLayerManifestFile::CreateIfValid layer ";
+        warning_message += filename;
+        warning_message += " has invalid API Version.  Skipping layer.";
+        LoaderLogger::LogWarningMessage("", warning_message);
+        return;
+    }
+
+    uint32_t implementation_version = atoi(layer_root_node["implementation_version"].asString().c_str());
+    library_path = layer_root_node["library_path"].asString();
+
+    // If the library_path variable has no directory symbol, it's just a file name and should be accessible on the
+    // global library path.
+    if (library_path.find("\\") != library_path.npos || library_path.find("/") != library_path.npos) {
+        // If the library_path is an absolute path, just use that if it exists
+        if (FileSysUtilsIsAbsolutePath(library_path)) {
+            if (!FileSysUtilsPathExists(library_path)) {
+                std::string error_message = "ApiLayerManifestFile::CreateIfValid ";
                 error_message += filename;
-                error_message += " is missing \"disable_environment\"";
+                error_message += " library ";
+                error_message += library_path;
+                error_message += " does not appear to exist";
                 LoaderLogger::LogErrorMessage("", error_message);
                 return;
             }
-            // Check if there's an enable environment variable provided
-            if (!layer_root_node["enable_environment"].isNull() && layer_root_node["enable_environment"].isString()) {
-                char *enable_val = PlatformUtilsGetEnv(layer_root_node["enable_environment"].asString().c_str());
-                // If it's not set in the environment, disable the layer
-                if (NULL == enable_val) {
-                    enabled = false;
-                }
-                PlatformUtilsFreeEnv(enable_val);
-            }
-            // Check for the disable environment variable, which must be provided in the JSON
-            char *disable_val = PlatformUtilsGetEnv(layer_root_node["disable_environment"].asString().c_str());
-            // If the envar is set, disable the layer. Disable envar overrides enable above
-            if (NULL != disable_val) {
-                enabled = false;
-            }
-            PlatformUtilsFreeEnv(disable_val);
-
-            // Not enabled, so pretend like it isn't even there.
-            if (!enabled) {
-                std::string info_message = "ApiLayerManifestFile::CreateIfValid Implicit layer ";
-                info_message += filename;
-                info_message += " is disabled";
-                LoaderLogger::LogInfoMessage("", info_message);
+            library_path = library_path;
+        } else {
+            // Otherwise, treat the library path as a relative path based on the JSON file.
+            std::string combined_path;
+            std::string file_parent;
+            if (!FileSysUtilsGetParentPath(filename, file_parent) ||
+                !FileSysUtilsCombinePaths(file_parent, library_path, combined_path) || !FileSysUtilsPathExists(combined_path)) {
+                std::string error_message = "ApiLayerManifestFile::CreateIfValid ";
+                error_message += filename;
+                error_message += " library ";
+                error_message += combined_path;
+                error_message += " does not appear to exist";
+                LoaderLogger::LogErrorMessage("", error_message);
                 return;
             }
+            library_path = combined_path;
         }
-        layer_name = layer_root_node["name"].asString();
-        std::string api_version_string = layer_root_node["api_version"].asString();
-        sscanf(api_version_string.c_str(), "%d.%d", &api_version.major, &api_version.minor);
-        api_version.patch = 0;
+    }
 
-        if ((api_version.major == 0 && api_version.minor == 0) || api_version.major > XR_VERSION_MAJOR(XR_CURRENT_API_VERSION)) {
-            std::string warning_message = "ApiLayerManifestFile::CreateIfValid layer ";
-            warning_message += filename;
-            warning_message += " has invalid API Version.  Skipping layer.";
-            LoaderLogger::LogWarningMessage("", warning_message);
-            return;
-        }
+    if (!layer_root_node["description"].isNull() && layer_root_node["description"].isString()) {
+        description = layer_root_node["description"].asString();
+    }
 
-        uint32_t implementation_version = atoi(layer_root_node["implementation_version"].asString().c_str());
-        library_path = layer_root_node["library_path"].asString();
+    // Add this layer manifest file
+    manifest_files.emplace_back(
+        new ApiLayerManifestFile(type, filename, layer_name, description, api_version, implementation_version, library_path));
 
-        // If the library_path variable has no directory symbol, it's just a file name and should be accessible on the
-        // global library path.
-        if (library_path.find("\\") != library_path.npos || library_path.find("/") != library_path.npos) {
-            // If the library_path is an absolute path, just use that if it exists
-            if (FileSysUtilsIsAbsolutePath(library_path)) {
-                if (!FileSysUtilsPathExists(library_path)) {
-                    std::string error_message = "ApiLayerManifestFile::CreateIfValid ";
-                    error_message += filename;
-                    error_message += " library ";
-                    error_message += library_path;
-                    error_message += " does not appear to exist";
-                    LoaderLogger::LogErrorMessage("", error_message);
-                    return;
-                }
-                library_path = library_path;
-            } else {
-                // Otherwise, treat the library path as a relative path based on the JSON file.
-                std::string combined_path;
-                std::string file_parent;
-                if (!FileSysUtilsGetParentPath(filename, file_parent) ||
-                    !FileSysUtilsCombinePaths(file_parent, library_path, combined_path) || !FileSysUtilsPathExists(combined_path)) {
-                    std::string error_message = "ApiLayerManifestFile::CreateIfValid ";
-                    error_message += filename;
-                    error_message += " library ";
-                    error_message += combined_path;
-                    error_message += " does not appear to exist";
-                    LoaderLogger::LogErrorMessage("", error_message);
-                    return;
-                }
-                library_path = combined_path;
-            }
-        }
-
-        if (!layer_root_node["description"].isNull() && layer_root_node["description"].isString()) {
-            description = layer_root_node["description"].asString();
-        }
-
-        // Add this layer manifest file
-        manifest_files.emplace_back(
-            new ApiLayerManifestFile(type, filename, layer_name, description, api_version, implementation_version, library_path));
-
-        // Add any extensions to it after the fact.
-        Json::Value dev_exts = layer_root_node["device_extensions"];
-        if (!dev_exts.isNull() && dev_exts.isArray()) {
-            for (Json::ValueIterator dev_ext_it = dev_exts.begin(); dev_ext_it != dev_exts.end(); ++dev_ext_it) {
-                Json::Value dev_ext = (*dev_ext_it);
-                Json::Value dev_ext_name = dev_ext["name"];
-                Json::Value dev_ext_version = dev_ext["spec_version"];
-                Json::Value dev_ext_entries = dev_ext["entrypoints"];
-                if (!dev_ext_name.isNull() && dev_ext_name.isString() && !dev_ext_version.isNull() && dev_ext_version.isString() &&
-                    !dev_ext_entries.isNull() && dev_ext_entries.isArray()) {
-                    ExtensionListing ext = {};
-                    ext.name = dev_ext_name.asString();
-                    ext.spec_version = atoi(dev_ext_version.asString().c_str());
-                    for (Json::ValueIterator entry_it = dev_ext_entries.begin(); entry_it != dev_ext_entries.end(); ++entry_it) {
-                        Json::Value entry = (*entry_it);
-                        if (!entry.isNull() && entry.isString()) {
-                            ext.entrypoints.push_back(entry.asString());
-                        }
+    // Add any extensions to it after the fact.
+    Json::Value dev_exts = layer_root_node["device_extensions"];
+    if (!dev_exts.isNull() && dev_exts.isArray()) {
+        for (Json::ValueIterator dev_ext_it = dev_exts.begin(); dev_ext_it != dev_exts.end(); ++dev_ext_it) {
+            Json::Value dev_ext = (*dev_ext_it);
+            Json::Value dev_ext_name = dev_ext["name"];
+            Json::Value dev_ext_version = dev_ext["spec_version"];
+            Json::Value dev_ext_entries = dev_ext["entrypoints"];
+            if (!dev_ext_name.isNull() && dev_ext_name.isString() && !dev_ext_version.isNull() && dev_ext_version.isString() &&
+                !dev_ext_entries.isNull() && dev_ext_entries.isArray()) {
+                ExtensionListing ext = {};
+                ext.name = dev_ext_name.asString();
+                ext.spec_version = atoi(dev_ext_version.asString().c_str());
+                for (Json::ValueIterator entry_it = dev_ext_entries.begin(); entry_it != dev_ext_entries.end(); ++entry_it) {
+                    Json::Value entry = (*entry_it);
+                    if (!entry.isNull() && entry.isString()) {
+                        ext.entrypoints.push_back(entry.asString());
                     }
-                    manifest_files.back()->_device_extensions.push_back(ext);
                 }
+                manifest_files.back()->_device_extensions.push_back(ext);
             }
         }
+    }
 
-        Json::Value inst_exts = layer_root_node["instance_extensions"];
-        if (!inst_exts.isNull() && inst_exts.isArray()) {
-            for (Json::ValueIterator inst_ext_it = inst_exts.begin(); inst_ext_it != inst_exts.end(); ++inst_ext_it) {
-                Json::Value inst_ext = (*inst_ext_it);
-                Json::Value inst_ext_name = inst_ext["name"];
-                Json::Value inst_ext_version = inst_ext["spec_version"];
-                if (!inst_ext_name.isNull() && inst_ext_name.isString() && !inst_ext_version.isNull() &&
-                    inst_ext_version.isString()) {
-                    ExtensionListing ext = {};
-                    ext.name = inst_ext_name.asString();
-                    ext.spec_version = atoi(inst_ext_version.asString().c_str());
-                    manifest_files.back()->_instance_extensions.push_back(ext);
-                }
+    Json::Value inst_exts = layer_root_node["instance_extensions"];
+    if (!inst_exts.isNull() && inst_exts.isArray()) {
+        for (Json::ValueIterator inst_ext_it = inst_exts.begin(); inst_ext_it != inst_exts.end(); ++inst_ext_it) {
+            Json::Value inst_ext = (*inst_ext_it);
+            Json::Value inst_ext_name = inst_ext["name"];
+            Json::Value inst_ext_version = inst_ext["spec_version"];
+            if (!inst_ext_name.isNull() && inst_ext_name.isString() && !inst_ext_version.isNull() &&
+                inst_ext_version.isString()) {
+                ExtensionListing ext = {};
+                ext.name = inst_ext_name.asString();
+                ext.spec_version = atoi(inst_ext_version.asString().c_str());
+                manifest_files.back()->_instance_extensions.push_back(ext);
             }
         }
+    }
 
-        Json::Value funcs_renamed = layer_root_node["functions"];
-        if (!funcs_renamed.isNull() && funcs_renamed.size() > 0) {
-            for (Json::ValueIterator func_it = funcs_renamed.begin(); func_it != funcs_renamed.end(); ++func_it) {
-                if (!(*func_it).isString()) {
-                    std::string warning_message = "ApiLayerManifestFile::CreateIfValid ";
-                    warning_message += filename;
-                    warning_message += " \"functions\" section contains non-string values.";
-                    LoaderLogger::LogWarningMessage("", warning_message);
-                    continue;
-                }
-                std::string original_name = func_it.key().asString();
-                std::string new_name = (*func_it).asString();
-                manifest_files.back()->_functions_renamed.insert(std::make_pair(original_name, new_name));
+    Json::Value funcs_renamed = layer_root_node["functions"];
+    if (!funcs_renamed.isNull() && funcs_renamed.size() > 0) {
+        for (Json::ValueIterator func_it = funcs_renamed.begin(); func_it != funcs_renamed.end(); ++func_it) {
+            if (!(*func_it).isString()) {
+                std::string warning_message = "ApiLayerManifestFile::CreateIfValid ";
+                warning_message += filename;
+                warning_message += " \"functions\" section contains non-string values.";
+                LoaderLogger::LogWarningMessage("", warning_message);
+                continue;
             }
+            std::string original_name = func_it.key().asString();
+            std::string new_name = (*func_it).asString();
+            manifest_files.back()->_functions_renamed.insert(std::make_pair(original_name, new_name));
         }
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("", "ApiLayerManifestFile::CreateIfValid - unknown error occurred");
-        throw;
     }
 }
 
 XrApiLayerProperties ApiLayerManifestFile::GetApiLayerProperties() {
-    try {
-        XrApiLayerProperties props = {};
-        props.type = XR_TYPE_API_LAYER_PROPERTIES;
-        props.next = nullptr;
-        props.implementationVersion = _implementation_version;
-        props.specVersion = XR_MAKE_VERSION(_api_version.major, _api_version.minor, _api_version.patch);
-        strncpy(props.layerName, _layer_name.c_str(), XR_MAX_API_LAYER_NAME_SIZE - 1);
-        if (_layer_name.size() >= XR_MAX_API_LAYER_NAME_SIZE - 1) {
-            props.layerName[XR_MAX_API_LAYER_NAME_SIZE - 1] = '\0';
-        }
-        strncpy(props.description, _description.c_str(), XR_MAX_API_LAYER_DESCRIPTION_SIZE - 1);
-        if (_description.size() >= XR_MAX_API_LAYER_DESCRIPTION_SIZE - 1) {
-            props.description[XR_MAX_API_LAYER_DESCRIPTION_SIZE - 1] = '\0';
-        }
-        return props;
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("", "ApiLayerManifestFile::GetApiLayerProperties - unknown error occurred");
-        throw;
+    XrApiLayerProperties props = {};
+    props.type = XR_TYPE_API_LAYER_PROPERTIES;
+    props.next = nullptr;
+    props.implementationVersion = _implementation_version;
+    props.specVersion = XR_MAKE_VERSION(_api_version.major, _api_version.minor, _api_version.patch);
+    strncpy(props.layerName, _layer_name.c_str(), XR_MAX_API_LAYER_NAME_SIZE - 1);
+    if (_layer_name.size() >= XR_MAX_API_LAYER_NAME_SIZE - 1) {
+        props.layerName[XR_MAX_API_LAYER_NAME_SIZE - 1] = '\0';
     }
+    strncpy(props.description, _description.c_str(), XR_MAX_API_LAYER_DESCRIPTION_SIZE - 1);
+    if (_description.size() >= XR_MAX_API_LAYER_DESCRIPTION_SIZE - 1) {
+        props.description[XR_MAX_API_LAYER_DESCRIPTION_SIZE - 1] = '\0';
+    }
+    return props;
 }
 
 // Find all layer manifest files in the appropriate search paths/registries for the given type.
 XrResult ApiLayerManifestFile::FindManifestFiles(ManifestFileType type,
                                                  std::vector<std::unique_ptr<ApiLayerManifestFile>> &manifest_files) {
-    try {
-        std::string relative_path;
-        std::string override_env_var;
-        std::string registry_location = "";
+    std::string relative_path;
+    std::string override_env_var;
+    std::string registry_location = "";
 
-        // Add the appropriate top-level folders for the relative path.  These should be
-        // the string "openxr/" followed by the API major version as a string.
-        relative_path = OPENXR_RELATIVE_PATH;
-        relative_path += std::to_string(XR_VERSION_MAJOR(XR_CURRENT_API_VERSION));
+    // Add the appropriate top-level folders for the relative path.  These should be
+    // the string "openxr/" followed by the API major version as a string.
+    relative_path = OPENXR_RELATIVE_PATH;
+    relative_path += std::to_string(XR_VERSION_MAJOR(XR_CURRENT_API_VERSION));
 
-        switch (type) {
-            case MANIFEST_TYPE_IMPLICIT_API_LAYER:
-                relative_path += OPENXR_IMPLICIT_API_LAYER_RELATIVE_PATH;
-                override_env_var = "";
+    switch (type) {
+        case MANIFEST_TYPE_IMPLICIT_API_LAYER:
+            relative_path += OPENXR_IMPLICIT_API_LAYER_RELATIVE_PATH;
+            override_env_var = "";
 #ifdef XR_OS_WINDOWS
-                registry_location = OPENXR_IMPLICIT_API_LAYER_REGISTRY_LOCATION;
+            registry_location = OPENXR_IMPLICIT_API_LAYER_REGISTRY_LOCATION;
 #endif
-                break;
-            case MANIFEST_TYPE_EXPLICIT_API_LAYER:
-                relative_path += OPENXR_EXPLICIT_API_LAYER_RELATIVE_PATH;
-                override_env_var = OPENXR_API_LAYER_PATH_ENV_VAR;
+            break;
+        case MANIFEST_TYPE_EXPLICIT_API_LAYER:
+            relative_path += OPENXR_EXPLICIT_API_LAYER_RELATIVE_PATH;
+            override_env_var = OPENXR_API_LAYER_PATH_ENV_VAR;
 #ifdef XR_OS_WINDOWS
-                registry_location = OPENXR_EXPLICIT_API_LAYER_REGISTRY_LOCATION;
+            registry_location = OPENXR_EXPLICIT_API_LAYER_REGISTRY_LOCATION;
 #endif
-                break;
-            default:
-                LoaderLogger::LogErrorMessage("", "ApiLayerManifestFile::FindManifestFiles - unknown manifest file requested");
-                throw std::runtime_error("invalid manifest type");
-        }
-
-        bool override_active = false;
-        std::vector<std::string> filenames;
-        ReadDataFilesInSearchPaths(type, override_env_var, relative_path, override_active, filenames);
-
-#ifdef XR_OS_WINDOWS
-        // Read the registry if the override wasn't active.
-        if (!override_active) {
-            ReadLayerDataFilesInRegistry(type, registry_location, filenames);
-        }
-#endif
-
-        switch (type) {
-            case MANIFEST_TYPE_IMPLICIT_API_LAYER:
-            case MANIFEST_TYPE_EXPLICIT_API_LAYER:
-                for (std::string &cur_file : filenames) {
-                    ApiLayerManifestFile::CreateIfValid(type, cur_file, manifest_files);
-                }
-                break;
-            default:
-                break;
-        }
-
-    } catch (std::bad_alloc &) {
-        LoaderLogger::LogErrorMessage("", "ApiLayerManifestFile::FindManifestFiles - memory allocation failed");
-        return XR_ERROR_OUT_OF_MEMORY;
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("", "ApiLayerManifestFile::FindManifestFiles - unknown error occurred");
-        return XR_ERROR_FILE_ACCESS_ERROR;
+            break;
+        default:
+            LoaderLogger::LogErrorMessage("", "ApiLayerManifestFile::FindManifestFiles - unknown manifest file requested");
+            return XR_ERROR_FILE_ACCESS_ERROR;
     }
+
+    bool override_active = false;
+    std::vector<std::string> filenames;
+    ReadDataFilesInSearchPaths(type, override_env_var, relative_path, override_active, filenames);
+
+#ifdef XR_OS_WINDOWS
+    // Read the registry if the override wasn't active.
+    if (!override_active) {
+        ReadLayerDataFilesInRegistry(type, registry_location, filenames);
+    }
+#endif
+
+    switch (type) {
+        case MANIFEST_TYPE_IMPLICIT_API_LAYER:
+        case MANIFEST_TYPE_EXPLICIT_API_LAYER:
+            for (std::string &cur_file : filenames) {
+                ApiLayerManifestFile::CreateIfValid(type, cur_file, manifest_files);
+            }
+            break;
+        default:
+            break;
+    }
+
     return XR_SUCCESS;
 }

--- a/src/loader/runtime_interface.cpp
+++ b/src/loader/runtime_interface.cpp
@@ -33,139 +33,131 @@ uint32_t RuntimeInterface::_single_runtime_count = 0;
 XrResult RuntimeInterface::LoadRuntime(const std::string& openxr_command) {
     XrResult last_error = XR_SUCCESS;
     bool any_loaded = false;
-    try {
-        // If something's already loaded, we're done here.
-        if (_single_runtime_interface != nullptr) {
-            _single_runtime_count++;
-            return XR_SUCCESS;
-        }
+    // If something's already loaded, we're done here.
+    if (_single_runtime_interface != nullptr) {
+        _single_runtime_count++;
+        return XR_SUCCESS;
+    }
 
-        std::vector<std::unique_ptr<RuntimeManifestFile>> runtime_manifest_files = {};
+    std::vector<std::unique_ptr<RuntimeManifestFile>> runtime_manifest_files = {};
 
-        // Find the available runtimes which we may need to report information for.
-        last_error = RuntimeManifestFile::FindManifestFiles(MANIFEST_TYPE_RUNTIME, runtime_manifest_files);
-        if (XR_SUCCESS != last_error) {
-            LoaderLogger::LogErrorMessage(openxr_command, "RuntimeInterface::LoadRuntimes - unknown error");
-            last_error = XR_ERROR_FILE_ACCESS_ERROR;
-        } else {
-            for (std::unique_ptr<RuntimeManifestFile>& manifest_file : runtime_manifest_files) {
-                LoaderPlatformLibraryHandle runtime_library = LoaderPlatformLibraryOpen(manifest_file->LibraryPath());
-                if (nullptr == runtime_library) {
-                    if (!any_loaded) {
-                        last_error = XR_ERROR_INSTANCE_LOST;
-                    }
-                    std::string library_message = LoaderPlatformLibraryOpenError(manifest_file->LibraryPath());
-                    std::string warning_message = "RuntimeInterface::LoadRuntime skipping manifest file ";
-                    warning_message += manifest_file->Filename();
-                    warning_message += ", failed to load with message \"";
-                    warning_message += library_message;
-                    warning_message += "\"";
-                    LoaderLogger::LogErrorMessage(openxr_command, warning_message);
-                    continue;
-                }
-
-                // Get and settle on an runtime interface version (using any provided name if required).
-                std::string function_name = manifest_file->GetFunctionName("xrNegotiateLoaderRuntimeInterface");
-                PFN_xrNegotiateLoaderRuntimeInterface negotiate = reinterpret_cast<PFN_xrNegotiateLoaderRuntimeInterface>(
-                    LoaderPlatformLibraryGetProcAddr(runtime_library, function_name));
-
-                // Loader info for negotiation
-                XrNegotiateLoaderInfo loader_info = {};
-                loader_info.structType = XR_LOADER_INTERFACE_STRUCT_LOADER_INFO;
-                loader_info.structVersion = XR_LOADER_INFO_STRUCT_VERSION;
-                loader_info.structSize = sizeof(XrNegotiateLoaderInfo);
-                loader_info.minInterfaceVersion = 1;
-                loader_info.maxInterfaceVersion = XR_CURRENT_LOADER_RUNTIME_VERSION;
-                loader_info.minXrVersion = XR_MAKE_VERSION(0, 1, 0);
-                loader_info.maxXrVersion = XR_MAKE_VERSION(1, 0, 0);
-
-                // Set up the runtime return structure
-                XrNegotiateRuntimeRequest runtime_info = {};
-                runtime_info.structType = XR_LOADER_INTERFACE_STRUCT_RUNTIME_REQUEST;
-                runtime_info.structVersion = XR_RUNTIME_INFO_STRUCT_VERSION;
-                runtime_info.structSize = sizeof(XrNegotiateRuntimeRequest);
-
-                XrResult res = negotiate(&loader_info, &runtime_info);
-                // If we supposedly succeeded, but got a nullptr for GetInstanceProcAddr
-                // then something still went wrong, so return with an error.
-                if (XR_SUCCESS == res) {
-                    uint32_t runtime_major = XR_VERSION_MAJOR(runtime_info.runtimeXrVersion);
-                    uint32_t runtime_minor = XR_VERSION_MINOR(runtime_info.runtimeXrVersion);
-                    uint32_t loader_major = XR_VERSION_MAJOR(XR_CURRENT_API_VERSION);
-                    if (nullptr == runtime_info.getInstanceProcAddr) {
-                        std::string error_message = "RuntimeInterface::LoadRuntime skipping manifest file ";
-                        error_message += manifest_file->Filename();
-                        error_message += ", negotiation succeeded but returned NULL getInstanceProcAddr";
-                        LoaderLogger::LogErrorMessage(openxr_command, error_message);
-                        res = XR_ERROR_FILE_CONTENTS_INVALID;
-                    } else if (0 >= runtime_info.runtimeInterfaceVersion ||
-                               XR_CURRENT_LOADER_RUNTIME_VERSION < runtime_info.runtimeInterfaceVersion) {
-                        std::string error_message = "RuntimeInterface::LoadRuntime skipping manifest file ";
-                        error_message += manifest_file->Filename();
-                        error_message += ", negotiation succeeded but returned invalid interface version";
-                        LoaderLogger::LogErrorMessage(openxr_command, error_message);
-                        res = XR_ERROR_FILE_CONTENTS_INVALID;
-                    } else if (runtime_major != loader_major || (runtime_major == 0 && runtime_minor == 0)) {
-                        std::string error_message = "RuntimeInterface::LoadRuntime skipping manifest file ";
-                        error_message += manifest_file->Filename();
-                        error_message += ", OpenXR version returned not compatible with this loader";
-                        LoaderLogger::LogErrorMessage(openxr_command, error_message);
-                        res = XR_ERROR_FILE_CONTENTS_INVALID;
-                    }
-                }
-                if (XR_SUCCESS != res) {
-                    if (!any_loaded) {
-                        last_error = res;
-                    }
-                    std::string warning_message = "RuntimeInterface::LoadRuntime skipping manifest file ";
-                    warning_message += manifest_file->Filename();
-                    warning_message += ", negotiation failed with error ";
-                    warning_message += std::to_string(res);
-                    LoaderLogger::LogErrorMessage(openxr_command, warning_message);
-                    LoaderPlatformLibraryClose(runtime_library);
-                    continue;
-                }
-
-                std::string info_message = "RuntimeInterface::LoadRuntime succeeded loading runtime defined in manifest file ";
-                info_message += manifest_file->Filename();
-                info_message += " using interface version ";
-                info_message += std::to_string(runtime_info.runtimeInterfaceVersion);
-                info_message += " and OpenXR API version ";
-                info_message += std::to_string(XR_VERSION_MAJOR(runtime_info.runtimeXrVersion));
-                info_message += ".";
-                info_message += std::to_string(XR_VERSION_MINOR(runtime_info.runtimeXrVersion));
-                LoaderLogger::LogInfoMessage(openxr_command, info_message);
-
-                // Use this runtime
-                _single_runtime_interface.reset(new RuntimeInterface(runtime_library, runtime_info.getInstanceProcAddr));
-                _single_runtime_count++;
-
-                // Grab the list of extensions this runtime supports for easy filtering after the
-                // xrCreateInstance call
-                std::vector<std::string> supported_extensions;
-                std::vector<XrExtensionProperties> extension_properties;
-                _single_runtime_interface->GetInstanceExtensionProperties(extension_properties);
-                for (XrExtensionProperties ext_prop : extension_properties) {
-                    supported_extensions.push_back(ext_prop.extensionName);
-                }
-                _single_runtime_interface->SetSupportedExtensions(supported_extensions);
-
-                // If we load one, clear all errors.
-                any_loaded = true;
-                last_error = XR_SUCCESS;
-                break;
-            }
-        }
-
-        // Always clear the manifest file list.  Either we use them or we don't.
-        runtime_manifest_files.clear();
-    } catch (std::bad_alloc&) {
-        LoaderLogger::LogErrorMessage(openxr_command, "RuntimeInterface::LoadRuntimes - failed to allocate memory");
-        last_error = XR_ERROR_OUT_OF_MEMORY;
-    } catch (...) {
+    // Find the available runtimes which we may need to report information for.
+    last_error = RuntimeManifestFile::FindManifestFiles(MANIFEST_TYPE_RUNTIME, runtime_manifest_files);
+    if (XR_SUCCESS != last_error) {
         LoaderLogger::LogErrorMessage(openxr_command, "RuntimeInterface::LoadRuntimes - unknown error");
         last_error = XR_ERROR_FILE_ACCESS_ERROR;
+    } else {
+        for (std::unique_ptr<RuntimeManifestFile>& manifest_file : runtime_manifest_files) {
+            LoaderPlatformLibraryHandle runtime_library = LoaderPlatformLibraryOpen(manifest_file->LibraryPath());
+            if (nullptr == runtime_library) {
+                if (!any_loaded) {
+                    last_error = XR_ERROR_INSTANCE_LOST;
+                }
+                std::string library_message = LoaderPlatformLibraryOpenError(manifest_file->LibraryPath());
+                std::string warning_message = "RuntimeInterface::LoadRuntime skipping manifest file ";
+                warning_message += manifest_file->Filename();
+                warning_message += ", failed to load with message \"";
+                warning_message += library_message;
+                warning_message += "\"";
+                LoaderLogger::LogErrorMessage(openxr_command, warning_message);
+                continue;
+            }
+
+            // Get and settle on an runtime interface version (using any provided name if required).
+            std::string function_name = manifest_file->GetFunctionName("xrNegotiateLoaderRuntimeInterface");
+            PFN_xrNegotiateLoaderRuntimeInterface negotiate = reinterpret_cast<PFN_xrNegotiateLoaderRuntimeInterface>(
+                LoaderPlatformLibraryGetProcAddr(runtime_library, function_name));
+
+            // Loader info for negotiation
+            XrNegotiateLoaderInfo loader_info = {};
+            loader_info.structType = XR_LOADER_INTERFACE_STRUCT_LOADER_INFO;
+            loader_info.structVersion = XR_LOADER_INFO_STRUCT_VERSION;
+            loader_info.structSize = sizeof(XrNegotiateLoaderInfo);
+            loader_info.minInterfaceVersion = 1;
+            loader_info.maxInterfaceVersion = XR_CURRENT_LOADER_RUNTIME_VERSION;
+            loader_info.minXrVersion = XR_MAKE_VERSION(0, 1, 0);
+            loader_info.maxXrVersion = XR_MAKE_VERSION(1, 0, 0);
+
+            // Set up the runtime return structure
+            XrNegotiateRuntimeRequest runtime_info = {};
+            runtime_info.structType = XR_LOADER_INTERFACE_STRUCT_RUNTIME_REQUEST;
+            runtime_info.structVersion = XR_RUNTIME_INFO_STRUCT_VERSION;
+            runtime_info.structSize = sizeof(XrNegotiateRuntimeRequest);
+
+            XrResult res = negotiate(&loader_info, &runtime_info);
+            // If we supposedly succeeded, but got a nullptr for GetInstanceProcAddr
+            // then something still went wrong, so return with an error.
+            if (XR_SUCCESS == res) {
+                uint32_t runtime_major = XR_VERSION_MAJOR(runtime_info.runtimeXrVersion);
+                uint32_t runtime_minor = XR_VERSION_MINOR(runtime_info.runtimeXrVersion);
+                uint32_t loader_major = XR_VERSION_MAJOR(XR_CURRENT_API_VERSION);
+                if (nullptr == runtime_info.getInstanceProcAddr) {
+                    std::string error_message = "RuntimeInterface::LoadRuntime skipping manifest file ";
+                    error_message += manifest_file->Filename();
+                    error_message += ", negotiation succeeded but returned NULL getInstanceProcAddr";
+                    LoaderLogger::LogErrorMessage(openxr_command, error_message);
+                    res = XR_ERROR_FILE_CONTENTS_INVALID;
+                } else if (0 >= runtime_info.runtimeInterfaceVersion ||
+                           XR_CURRENT_LOADER_RUNTIME_VERSION < runtime_info.runtimeInterfaceVersion) {
+                    std::string error_message = "RuntimeInterface::LoadRuntime skipping manifest file ";
+                    error_message += manifest_file->Filename();
+                    error_message += ", negotiation succeeded but returned invalid interface version";
+                    LoaderLogger::LogErrorMessage(openxr_command, error_message);
+                    res = XR_ERROR_FILE_CONTENTS_INVALID;
+                } else if (runtime_major != loader_major || (runtime_major == 0 && runtime_minor == 0)) {
+                    std::string error_message = "RuntimeInterface::LoadRuntime skipping manifest file ";
+                    error_message += manifest_file->Filename();
+                    error_message += ", OpenXR version returned not compatible with this loader";
+                    LoaderLogger::LogErrorMessage(openxr_command, error_message);
+                    res = XR_ERROR_FILE_CONTENTS_INVALID;
+                }
+            }
+            if (XR_SUCCESS != res) {
+                if (!any_loaded) {
+                    last_error = res;
+                }
+                std::string warning_message = "RuntimeInterface::LoadRuntime skipping manifest file ";
+                warning_message += manifest_file->Filename();
+                warning_message += ", negotiation failed with error ";
+                warning_message += std::to_string(res);
+                LoaderLogger::LogErrorMessage(openxr_command, warning_message);
+                LoaderPlatformLibraryClose(runtime_library);
+                continue;
+            }
+
+            std::string info_message = "RuntimeInterface::LoadRuntime succeeded loading runtime defined in manifest file ";
+            info_message += manifest_file->Filename();
+            info_message += " using interface version ";
+            info_message += std::to_string(runtime_info.runtimeInterfaceVersion);
+            info_message += " and OpenXR API version ";
+            info_message += std::to_string(XR_VERSION_MAJOR(runtime_info.runtimeXrVersion));
+            info_message += ".";
+            info_message += std::to_string(XR_VERSION_MINOR(runtime_info.runtimeXrVersion));
+            LoaderLogger::LogInfoMessage(openxr_command, info_message);
+
+            // Use this runtime
+            _single_runtime_interface.reset(new RuntimeInterface(runtime_library, runtime_info.getInstanceProcAddr));
+            _single_runtime_count++;
+
+            // Grab the list of extensions this runtime supports for easy filtering after the
+            // xrCreateInstance call
+            std::vector<std::string> supported_extensions;
+            std::vector<XrExtensionProperties> extension_properties;
+            _single_runtime_interface->GetInstanceExtensionProperties(extension_properties);
+            for (XrExtensionProperties ext_prop : extension_properties) {
+                supported_extensions.push_back(ext_prop.extensionName);
+            }
+            _single_runtime_interface->SetSupportedExtensions(supported_extensions);
+
+            // If we load one, clear all errors.
+            any_loaded = true;
+            last_error = XR_SUCCESS;
+            break;
+        }
     }
+
+    // Always clear the manifest file list.  Either we use them or we don't.
+    runtime_manifest_files.clear();
 
     // We found no valid runtimes, throw the initialization failed message
     if (!any_loaded) {
@@ -200,17 +192,13 @@ const XrGeneratedDispatchTable* RuntimeInterface::GetDispatchTable(XrInstance in
 }
 
 const XrGeneratedDispatchTable* RuntimeInterface::GetDebugUtilsMessengerDispatchTable(XrDebugUtilsMessengerEXT messenger) {
-    try {
-        std::unique_lock<std::mutex> mlock(_single_runtime_interface->_messenger_to_instance_mutex);
-        XrInstance runtime_instance = XR_NULL_HANDLE;
-        if (0 != _single_runtime_interface->_messenger_to_instance_map.count(messenger)) {
-            runtime_instance = _single_runtime_interface->_messenger_to_instance_map[messenger];
-        }
-        mlock.unlock();
-        return GetDispatchTable(runtime_instance);
-    } catch (...) {
-        return nullptr;
+    std::unique_lock<std::mutex> mlock(_single_runtime_interface->_messenger_to_instance_mutex);
+    XrInstance runtime_instance = XR_NULL_HANDLE;
+    if (0 != _single_runtime_interface->_messenger_to_instance_map.count(messenger)) {
+        runtime_instance = _single_runtime_interface->_messenger_to_instance_map[messenger];
     }
+    mlock.unlock();
+    return GetDispatchTable(runtime_instance);
 }
 
 RuntimeInterface::RuntimeInterface(LoaderPlatformLibraryHandle runtime_library, PFN_xrGetInstanceProcAddr get_instant_proc_addr)
@@ -229,70 +217,55 @@ RuntimeInterface::~RuntimeInterface() {
 }
 
 void RuntimeInterface::GetInstanceExtensionProperties(std::vector<XrExtensionProperties>& extension_properties) {
-    try {
-        std::vector<XrExtensionProperties> runtime_extension_properties;
-        PFN_xrEnumerateInstanceExtensionProperties rt_xrEnumerateInstanceExtensionProperties;
-        _get_instant_proc_addr(XR_NULL_HANDLE, "xrEnumerateInstanceExtensionProperties",
-                               reinterpret_cast<PFN_xrVoidFunction*>(&rt_xrEnumerateInstanceExtensionProperties));
-        uint32_t count = 0;
-        uint32_t count_output = 0;
-        // Get the count from the runtime
-        rt_xrEnumerateInstanceExtensionProperties(nullptr, count, &count_output, nullptr);
-        if (count_output > 0) {
-            runtime_extension_properties.resize(count_output);
-            count = count_output;
-            for (XrExtensionProperties& ext_prop : runtime_extension_properties) {
-                ext_prop.type = XR_TYPE_EXTENSION_PROPERTIES;
-                ext_prop.next = nullptr;
-            }
-            rt_xrEnumerateInstanceExtensionProperties(nullptr, count, &count_output, runtime_extension_properties.data());
+    std::vector<XrExtensionProperties> runtime_extension_properties;
+    PFN_xrEnumerateInstanceExtensionProperties rt_xrEnumerateInstanceExtensionProperties;
+    _get_instant_proc_addr(XR_NULL_HANDLE, "xrEnumerateInstanceExtensionProperties",
+                           reinterpret_cast<PFN_xrVoidFunction*>(&rt_xrEnumerateInstanceExtensionProperties));
+    uint32_t count = 0;
+    uint32_t count_output = 0;
+    // Get the count from the runtime
+    rt_xrEnumerateInstanceExtensionProperties(nullptr, count, &count_output, nullptr);
+    if (count_output > 0) {
+        runtime_extension_properties.resize(count_output);
+        count = count_output;
+        for (XrExtensionProperties& ext_prop : runtime_extension_properties) {
+            ext_prop.type = XR_TYPE_EXTENSION_PROPERTIES;
+            ext_prop.next = nullptr;
         }
-        size_t ext_count = runtime_extension_properties.size();
-        size_t props_count = extension_properties.size();
-        for (size_t ext = 0; ext < ext_count; ++ext) {
-            bool found = false;
-            for (size_t prop = 0; prop < props_count; ++prop) {
-                // If we find it, then make sure the spec version matches that of the runtime instead of the
-                // layer.
-                if (!strcmp(extension_properties[prop].extensionName, runtime_extension_properties[ext].extensionName)) {
-                    // Make sure the spec version used is the runtime's
-                    extension_properties[prop].specVersion = runtime_extension_properties[ext].specVersion;
-                    found = true;
-                    break;
-                }
-            }
-            if (!found) {
-                extension_properties.push_back(runtime_extension_properties[ext]);
+        rt_xrEnumerateInstanceExtensionProperties(nullptr, count, &count_output, runtime_extension_properties.data());
+    }
+    size_t ext_count = runtime_extension_properties.size();
+    size_t props_count = extension_properties.size();
+    for (size_t ext = 0; ext < ext_count; ++ext) {
+        bool found = false;
+        for (size_t prop = 0; prop < props_count; ++prop) {
+            // If we find it, then make sure the spec version matches that of the runtime instead of the
+            // layer.
+            if (!strcmp(extension_properties[prop].extensionName, runtime_extension_properties[ext].extensionName)) {
+                // Make sure the spec version used is the runtime's
+                extension_properties[prop].specVersion = runtime_extension_properties[ext].specVersion;
+                found = true;
+                break;
             }
         }
-
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("xrEnumerateInstanceExtensionProperties",
-                                      "RuntimeInterface::GetInstanceExtensionProperties - unknown error");
-        throw;
+        if (!found) {
+            extension_properties.push_back(runtime_extension_properties[ext]);
+        }
     }
 }
 
 XrResult RuntimeInterface::CreateInstance(const XrInstanceCreateInfo* info, XrInstance* instance) {
     XrResult res = XR_SUCCESS;
     bool create_succeeded = false;
-    try {
-        PFN_xrCreateInstance rt_xrCreateInstance;
-        _get_instant_proc_addr(XR_NULL_HANDLE, "xrCreateInstance", reinterpret_cast<PFN_xrVoidFunction*>(&rt_xrCreateInstance));
-        res = rt_xrCreateInstance(info, instance);
-        if (XR_SUCCESS == res) {
-            create_succeeded = true;
-            XrGeneratedDispatchTable* dispatch_table = new XrGeneratedDispatchTable();
-            GeneratedXrPopulateDispatchTable(dispatch_table, *instance, _get_instant_proc_addr);
-            std::unique_lock<std::mutex> mlock(_dispatch_table_mutex);
-            _dispatch_table_map[*instance] = dispatch_table;
-        }
-    } catch (std::bad_alloc&) {
-        LoaderLogger::LogErrorMessage("xrCreateInstance", "RuntimeInterface::CreateInstance - failed to allocate memory");
-        res = XR_ERROR_OUT_OF_MEMORY;
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("xrCreateInstance", "RuntimeInterface::CreateInstance - unknown error");
-        res = XR_ERROR_INSTANCE_LOST;
+    PFN_xrCreateInstance rt_xrCreateInstance;
+    _get_instant_proc_addr(XR_NULL_HANDLE, "xrCreateInstance", reinterpret_cast<PFN_xrVoidFunction*>(&rt_xrCreateInstance));
+    res = rt_xrCreateInstance(info, instance);
+    if (XR_SUCCESS == res) {
+        create_succeeded = true;
+        XrGeneratedDispatchTable* dispatch_table = new XrGeneratedDispatchTable();
+        GeneratedXrPopulateDispatchTable(dispatch_table, *instance, _get_instant_proc_addr);
+        std::unique_lock<std::mutex> mlock(_dispatch_table_mutex);
+        _dispatch_table_map[*instance] = dispatch_table;
     }
 
     // If the failure occurred during the populate, clean up the instance we had picked up from the runtime
@@ -307,41 +280,32 @@ XrResult RuntimeInterface::CreateInstance(const XrInstanceCreateInfo* info, XrIn
 }
 
 XrResult RuntimeInterface::DestroyInstance(XrInstance instance) {
-    try {
-        if (XR_NULL_HANDLE != instance) {
-            // Destroy the dispatch table for this instance first
-            std::unique_lock<std::mutex> mlock(_dispatch_table_mutex);
-            XrGeneratedDispatchTable* table = nullptr;
-            auto map_iter = _dispatch_table_map.find(instance);
-            if (map_iter != _dispatch_table_map.end()) {
-                table = map_iter->second;
-                _dispatch_table_map.erase(map_iter);
-            }
-            mlock.unlock();
-
-            if (nullptr != table) {
-                delete table;
-            }
-            // Now delete the instance
-            PFN_xrDestroyInstance rt_xrDestroyInstance;
-            _get_instant_proc_addr(instance, "xrDestroyInstance", reinterpret_cast<PFN_xrVoidFunction*>(&rt_xrDestroyInstance));
-            rt_xrDestroyInstance(instance);
+    if (XR_NULL_HANDLE != instance) {
+        // Destroy the dispatch table for this instance first
+        std::unique_lock<std::mutex> mlock(_dispatch_table_mutex);
+        XrGeneratedDispatchTable* table = nullptr;
+        auto map_iter = _dispatch_table_map.find(instance);
+        if (map_iter != _dispatch_table_map.end()) {
+            table = map_iter->second;
+            _dispatch_table_map.erase(map_iter);
         }
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("xrDestroyInstance", "RuntimeInterface::DestroyInstance - unknown error");
-        // Can't return anything but success
+        mlock.unlock();
+
+        if (nullptr != table) {
+            delete table;
+        }
+        // Now delete the instance
+        PFN_xrDestroyInstance rt_xrDestroyInstance;
+        _get_instant_proc_addr(instance, "xrDestroyInstance", reinterpret_cast<PFN_xrVoidFunction*>(&rt_xrDestroyInstance));
+        rt_xrDestroyInstance(instance);
     }
     return XR_SUCCESS;
 }
 
 bool RuntimeInterface::TrackDebugMessenger(XrInstance instance, XrDebugUtilsMessengerEXT messenger) {
-    try {
-        std::unique_lock<std::mutex> mlock(_messenger_to_instance_mutex);
-        _messenger_to_instance_map[messenger] = instance;
-        return true;
-    } catch (...) {
-        return false;
-    }
+    std::unique_lock<std::mutex> mlock(_messenger_to_instance_mutex);
+    _messenger_to_instance_map[messenger] = instance;
+    return true;
 }
 
 void RuntimeInterface::ForgetDebugMessenger(XrDebugUtilsMessengerEXT messenger) {
@@ -357,14 +321,11 @@ void RuntimeInterface::SetSupportedExtensions(std::vector<std::string>& supporte
 
 bool RuntimeInterface::SupportsExtension(const std::string& extension_name) {
     bool found_prop = false;
-    try {
-        for (std::string supported_extension : _supported_extensions) {
-            if (supported_extension == extension_name) {
-                found_prop = true;
-                break;
-            }
+    for (std::string supported_extension : _supported_extensions) {
+        if (supported_extension == extension_name) {
+            found_prop = true;
+            break;
         }
-    } catch (...) {
     }
     return found_prop;
 }

--- a/src/scripts/api_dump_generator.py
+++ b/src/scripts/api_dump_generator.py
@@ -557,19 +557,20 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
         return write_string
 
     # Output a single parameter/member.
-    #   self                The ApiDumpOutputGenerator object
-    #   base_type           The base type of the parameter
-    #   is_pointer          Boolean indicating whether or not the contents of the arrays are pointers
-    #   pointer_count       The number of pointers per variable (void*[] would be one, void**[] would be two)
-    #   member_param        The structure from automatic_source_generator for the member or parameter.
-    #   member_param_prefix The prefix to place in front of the member/param items
-    #   member_param_name   The prefixed name of this member/param
-    #   has_prefix          Boolean indicates that there's an incoming C++ prefix that needs to be added to the variable.
-    #   prefix_string1      The first prefix string to add prior to writing out the variable information
-    #   prefix_string1      The second prefix string to add prior to writing out the variable information
-    #   expand              Boolean indicates whether or not to try to expand/derefernce the contents of this parameter
-    #   indent              the number of "tabs" to space in for the resulting C+ code.
-    def writeExpandedMember(self, base_type, is_pointer, pointer_count, member_param, member_param_prefix, member_param_name, has_prefix, prefix_string1, prefix_string2, expand, indent):
+    #   self                 The ApiDumpOutputGenerator object
+    #   base_type            The base type of the parameter
+    #   is_pointer           Boolean indicating whether or not the contents of the arrays are pointers
+    #   pointer_count        The number of pointers per variable (void*[] would be one, void**[] would be two)
+    #   member_param         The structure from automatic_source_generator for the member or parameter.
+    #   member_param_prefix  The prefix to place in front of the member/param items
+    #   member_param_name    The prefixed name of this member/param
+    #   has_prefix           Boolean indicates that there's an incoming C++ prefix that needs to be added to the variable.
+    #   prefix_string1       The first prefix string to add prior to writing out the variable information
+    #   prefix_string1       The second prefix string to add prior to writing out the variable information
+    #   expand               Boolean indicates whether or not to try to expand/derefernce the contents of this parameter
+    #   indent               the number of "tabs" to space in for the resulting C+ code.
+    #...function_return_bool.Boolean indicate whether top level function return bool or XrResult
+    def writeExpandedMember(self, base_type, is_pointer, pointer_count, member_param, member_param_prefix, member_param_name, has_prefix, prefix_string1, prefix_string2, expand, indent, function_return_bool):
         member_string = ''
         derefernce_str = ''
         if not is_pointer:
@@ -605,7 +606,10 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
                                                                                                            member_param_name,
                                                                                                            member_param_prefix)
             member_string += self.writeIndent(indent + 1)
-            member_string += 'throw std::invalid_argument("Invalid Operation");\n'
+            if function_return_bool:
+                member_string += 'return false;\n'
+            else:
+                member_string += 'return XR_ERROR_VALIDATION_FAILURE;\n'
             member_string += self.writeIndent(indent)
             member_string += '}\n'
         elif is_struct_union and expand:
@@ -634,7 +638,10 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
                                                                      full_type,
                                                                      pointer_string)
             member_string += self.writeIndent(indent + 1)
-            member_string += 'throw std::invalid_argument("Invalid Operation");\n'
+            if function_return_bool:
+                member_string += 'return false;\n'
+            else:
+                member_string += 'return XR_ERROR_VALIDATION_FAILURE;\n'
             member_string += self.writeIndent(indent)
             member_string += '}\n'
         else:
@@ -690,19 +697,20 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
         return member_string
 
     # Output an array of parameters/members.
-    #   self                The ApiDumpOutputGenerator object
-    #   base_type           The base type of the parameter
-    #   is_pointer          Boolean indicating whether or not the contents of the arrays are pointers
-    #   pointer_count       The number of pointers per variable (void*[] would be one, void**[] would be two)
-    #   member_param        The structure from automatic_source_generator for the member or parameter.
-    #   array_param         The member/parameter used to indicate the size of the array (or None)
-    #   member_param_prefix The prefix to place in front of the member/param items
-    #   member_param_name   The prefixed name of this member/param
-    #   has_prefix          Boolean indicates that there's an incoming C++ prefix that needs to be added to the variable.
-    #   prefix_string1      The first prefix string to add prior to writing out the variable information
-    #   prefix_string1      The second prefix string to add prior to writing out the variable information
-    #   indent              the number of "tabs" to space in for the resulting C+ code.
-    def writeExpandedArray(self, base_type, is_pointer, pointer_count, member_param, array_param, member_param_prefix, member_param_name, has_prefix, prefix_string1, prefix_string2, indent):
+    #   self                 The ApiDumpOutputGenerator object
+    #   base_type            The base type of the parameter
+    #   is_pointer           Boolean indicating whether or not the contents of the arrays are pointers
+    #   pointer_count        The number of pointers per variable (void*[] would be one, void**[] would be two)
+    #   member_param         The structure from automatic_source_generator for the member or parameter.
+    #   array_param          The member/parameter used to indicate the size of the array (or None)
+    #   member_param_prefix  The prefix to place in front of the member/param items
+    #   member_param_name    The prefixed name of this member/param
+    #   has_prefix           Boolean indicates that there's an incoming C++ prefix that needs to be added to the variable.
+    #   prefix_string1       The first prefix string to add prior to writing out the variable information
+    #   prefix_string1       The second prefix string to add prior to writing out the variable information
+    #   indent               the number of "tabs" to space in for the resulting C+ code.
+    #...function_return_bool.Boolean indicate whether top level function return bool or XrResult
+    def writeExpandedArray(self, base_type, is_pointer, pointer_count, member_param, array_param, member_param_prefix, member_param_name, has_prefix, prefix_string1, prefix_string2, indent, function_return_bool):
         member_array_string = ''
         loop_count_name = ''
         loop_param_name = ''
@@ -788,19 +796,20 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
                                               values=member_param.values)
 
         member_array_string += self.writeExpandedMember(base_type, is_pointer, pointer_count, tmp_member_param,
-                                                        member_param_prefix, member_param_name, True, prefix_string1, prefix_string2, True, indent)
+                                                        member_param_prefix, member_param_name, True, prefix_string1, prefix_string2, True, indent, function_return_bool)
         indent = indent - 1
         member_array_string += self.writeIndent(indent)
         member_array_string += '}\n'
         return member_array_string
 
     # Output a single parameter or member based on whether it is an array or not
-    #   self            the ApiDumpOutputGenerator object
-    #   member_param    the structure from automatic_source_generator for the member or parameter.
-    #   has_prefix      Boolean indicates that there's an incoming C++ prefix that needs to be added to the variable.
-    #   expand_parent   Boolean indicating that the parent could or could not be expanded.
-    #   indent          the number of "tabs" to space in for the resulting C+ code.
-    def writeParamMember(self, member_param, has_prefix, expand_parent, indent):
+    #   self                 the ApiDumpOutputGenerator object
+    #   member_param         the structure from automatic_source_generator for the member or parameter.
+    #   has_prefix           Boolean indicates that there's an incoming C++ prefix that needs to be added to the variable.
+    #   expand_parent        Boolean indicating that the parent could or could not be expanded.
+    #   indent               the number of "tabs" to space in for the resulting C+ code.
+    #...function_return_bool.Boolean indicate whether top level function return bool or XrResult
+    def writeParamMember(self, member_param, has_prefix, expand_parent, indent, function_return_bool):
         member_param_string = ''
         # Can only expand non-pointers or constant pointer values and only if we can
         # expand the parent
@@ -883,7 +892,7 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
                     member_param_string += 'if (%s[0].type == %s) {\n' % (
                         member_param_name, self.genXrStructureType(child))
                     member_param_string += self.writeExpandedArray(base_type, is_pointer, pointer_count, member_param, array_param,
-                                                                   member_param_prefix, member_param_name, has_prefix, prefix_string1, prefix_string2, indent + 1)
+                                                                   member_param_prefix, member_param_name, has_prefix, prefix_string1, prefix_string2, indent + 1, function_return_bool)
                     member_param_string += self.writeIndent(indent + 1)
                     member_param_string += '%s = true;\n' % decoded_var
                     member_param_string += self.writeIndent(indent)
@@ -894,25 +903,26 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
                 member_param_string += 'if (!%s) {\n' % decoded_var
                 indent += 1
             member_param_string += self.writeExpandedArray(base_type, is_pointer, pointer_count, member_param,
-                                                           array_param, member_param_prefix, member_param_name, has_prefix, prefix_string1, prefix_string2, indent)
+                                                           array_param, member_param_prefix, member_param_name, has_prefix, prefix_string1, prefix_string2, indent, function_return_bool)
             if is_relation_group:
                 indent -= 1
                 member_param_string += self.writeIndent(indent)
                 member_param_string += '}\n'
         else:
             member_param_string += self.writeExpandedMember(base_type, is_pointer, pointer_count, member_param,
-                                                            member_param_prefix, member_param_name, has_prefix, prefix_string1, prefix_string2, can_expand, indent)
+                                                            member_param_prefix, member_param_name, has_prefix, prefix_string1, prefix_string2, can_expand, indent, function_return_bool)
         return member_param_string
 
     # Generate the C++ output code for each member of a union or structure.
-    #   self            the ApiDumpOutputGenerator object
-    #   union_struct    the structure from automatic_source_generator for the XR union or structure.
-    #   indent          the number of "tabs" to space in for the resulting C+ code.
-    def writeUnionStructMembers(self, union_struct, indent):
+    #   self                 the ApiDumpOutputGenerator object
+    #   union_struct         the structure from automatic_source_generator for the XR union or structure.
+    #   indent               the number of "tabs" to space in for the resulting C+ code.
+    #...function_return_bool.Boolean indicate whether top level function return bool or XrResult
+    def writeUnionStructMembers(self, union_struct, indent, function_return_bool):
         struct_union_member = ''
         for member in union_struct.members:
             struct_union_member += self.writeParamMember(
-                member, True, True, indent)
+                member, True, True, indent, function_return_bool)
         return struct_union_member
 
     # Write the C++ Api Dump function for every union and structure we know about.
@@ -926,32 +936,24 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
             struct_union_check += '                          std::string prefix, std::string type_string, bool is_pointer,\n'
             struct_union_check += '                          std::vector<std::tuple<std::string, std::string, std::string>> &contents) {\n'
             struct_union_check += self.writeIndent(1)
-            struct_union_check += 'try {\n'
-            struct_union_check += self.writeIndent(2)
             struct_union_check += 'std::ostringstream oss_union;\n'
-            struct_union_check += self.writeIndent(2)
+            struct_union_check += self.writeIndent(1)
             struct_union_check += 'oss_union << std::hex << reinterpret_cast<const void*>(value);\n'
-            struct_union_check += self.writeIndent(2)
+            struct_union_check += self.writeIndent(1)
             struct_union_check += 'contents.push_back(std::make_tuple(type_string, prefix, oss_union.str()));\n'
-            struct_union_check += self.writeIndent(2)
+            struct_union_check += self.writeIndent(1)
             struct_union_check += 'if (is_pointer) {\n'
-            struct_union_check += self.writeIndent(3)
+            struct_union_check += self.writeIndent(2)
             struct_union_check += 'prefix += "->";\n'
-            struct_union_check += self.writeIndent(2)
+            struct_union_check += self.writeIndent(1)
             struct_union_check += '} else {\n'
-            struct_union_check += self.writeIndent(3)
+            struct_union_check += self.writeIndent(2)
             struct_union_check += 'prefix += ".";\n'
-            struct_union_check += self.writeIndent(2)
+            struct_union_check += self.writeIndent(1)
             struct_union_check += '}\n'
-            struct_union_check += self.writeUnionStructMembers(xr_union, 2)
-            struct_union_check += self.writeIndent(2)
+            struct_union_check += self.writeUnionStructMembers(xr_union, 1, True)
+            struct_union_check += self.writeIndent(1)
             struct_union_check += 'return true;\n'
-            struct_union_check += self.writeIndent(1)
-            struct_union_check += '} catch(...) {\n'
-            struct_union_check += self.writeIndent(1)
-            struct_union_check += '}\n'
-            struct_union_check += self.writeIndent(1)
-            struct_union_check += 'return false;\n'
             struct_union_check += '}\n\n'
             if xr_union.protect_value:
                 struct_union_check += '#endif // %s\n' % xr_union.protect_string
@@ -962,9 +964,6 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
             struct_union_check += '                           std::string prefix, std::string type_string, bool is_pointer,\n'
             struct_union_check += '                           std::vector<std::tuple<std::string, std::string, std::string>> &contents) {\n'
             indent = 1
-            struct_union_check += self.writeIndent(indent)
-            struct_union_check += 'try {\n'
-            indent = indent + 1
             is_relation_group = False
             relation_group = None
             # Check to see if this struct is the base of a relation group
@@ -1011,33 +1010,25 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
             struct_union_check += self.writeIndent(indent)
             struct_union_check += '}\n'
             struct_union_check += self.writeUnionStructMembers(
-                xr_struct, indent)
+                xr_struct, indent, True)
             struct_union_check += self.writeIndent(indent)
             struct_union_check += 'return true;\n'
-            indent = indent - 1
-            struct_union_check += self.writeIndent(indent)
-            struct_union_check += '} catch(...) {\n'
-            struct_union_check += self.writeIndent(indent)
-            struct_union_check += '}\n'
-            struct_union_check += self.writeIndent(indent)
-            struct_union_check += 'return false;\n'
             struct_union_check += '}\n'
             if xr_struct.protect_value:
                 struct_union_check += '#endif // %s\n' % xr_struct.protect_string
             struct_union_check += '\n'
         struct_union_check += 'bool ApiDumpDecodeNextChain(XrGeneratedDispatchTable* gen_dispatch_table, const void* value, std::string prefix,\n'
         struct_union_check += '                            std::vector<std::tuple<std::string, std::string, std::string>> &contents) {\n'
-        struct_union_check += '    try {\n'
-        struct_union_check += '        std::ostringstream oss_next;\n'
-        struct_union_check += '        oss_next << std::hex << reinterpret_cast<const void*>(value);\n'
-        struct_union_check += '        contents.push_back(std::make_tuple("const void *", prefix, oss_next.str()));\n'
-        struct_union_check += '        if (nullptr == value) {\n'
-        struct_union_check += '            return true;\n'
-        struct_union_check += '        }\n'
-        struct_union_check += self.writeIndent(2)
+        struct_union_check += '    std::ostringstream oss_next;\n'
+        struct_union_check += '    oss_next << std::hex << reinterpret_cast<const void*>(value);\n'
+        struct_union_check += '    contents.push_back(std::make_tuple("const void *", prefix, oss_next.str()));\n'
+        struct_union_check += '    if (nullptr == value) {\n'
+        struct_union_check += '        return true;\n'
+        struct_union_check += '    }\n'
+        struct_union_check += self.writeIndent(1)
         struct_union_check += 'const XrBaseInStructure* next_header = reinterpret_cast<const XrBaseInStructure*>(value);\n'
         # Validate the rest of this struct
-        struct_union_check += self.writeIndent(2)
+        struct_union_check += self.writeIndent(1)
         struct_union_check += 'switch (next_header->type) {\n'
         for enum_tuple in self.api_enums:
             if enum_tuple.name == 'XrStructureType':
@@ -1050,29 +1041,27 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
                         cur_struct = self.getStruct(struct_define_name)
                         if cur_struct.protect_value:
                             struct_union_check += '#if %s\n' % cur_struct.protect_string
-                        struct_union_check += self.writeIndent(3)
+                        struct_union_check += self.writeIndent(2)
                         struct_union_check += 'case %s:\n' % cur_value.name
-                        struct_union_check += self.writeIndent(4)
+                        struct_union_check += self.writeIndent(3)
                         struct_union_check += 'if (!ApiDumpOutputXrStruct(gen_dispatch_table, reinterpret_cast<const %s*>(value), prefix, "const %s*", true, contents)) {\n' % (
                             struct_define_name, struct_define_name)
-                        struct_union_check += self.writeIndent(5)
+                        struct_union_check += self.writeIndent(4)
                         struct_union_check += 'return false;\n'
-                        struct_union_check += self.writeIndent(4)
+                        struct_union_check += self.writeIndent(3)
                         struct_union_check += '}\n'
-                        struct_union_check += self.writeIndent(4)
+                        struct_union_check += self.writeIndent(3)
                         struct_union_check += 'return true;\n'
                         if cur_struct.protect_value:
                             struct_union_check += '#endif // %s\n' % cur_struct.protect_string
                 if enum_tuple.protect_value:
                     struct_union_check += '#endif // %s\n' % enum_tuple.protect_string
-        struct_union_check += self.writeIndent(3)
-        struct_union_check += 'default:\n'
-        struct_union_check += self.writeIndent(4)
-        struct_union_check += 'return false;\n'
         struct_union_check += self.writeIndent(2)
+        struct_union_check += 'default:\n'
+        struct_union_check += self.writeIndent(3)
+        struct_union_check += 'return false;\n'
+        struct_union_check += self.writeIndent(1)
         struct_union_check += '}\n'
-        struct_union_check += '    } catch(...) {\n'
-        struct_union_check += '    }\n'
         struct_union_check += '    return false;\n'
         struct_union_check += '}\n\n'
         return struct_union_check
@@ -1138,9 +1127,8 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
                         return_prefix += ';\n'
                     generated_commands += return_prefix
 
-                generated_commands += '    try {\n'
-                generated_commands += '        // Generate output for this command\n'
-                generated_commands += '        std::vector<std::tuple<std::string, std::string, std::string>> contents;\n'
+                generated_commands += '    // Generate output for this command\n'
+                generated_commands += '    std::vector<std::tuple<std::string, std::string, std::string>> contents;\n'
 
                 # Next, we have to call down to the next implementation of this command in the call chain.
                 # Before we can do that, we have to figure out what the dispatch table is
@@ -1148,21 +1136,21 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
                     handle_param = cur_cmd.params[0]
                     base_handle_name = undecorate(handle_param.type)
                     first_handle_name = self.getFirstHandleName(handle_param)
-                    generated_commands += '        std::unique_lock<std::mutex> mlock(g_%s_dispatch_mutex);\n' % base_handle_name
-                    generated_commands += '        auto map_iter = g_%s_dispatch_map.find(%s);\n' % (base_handle_name, first_handle_name)
-                    generated_commands += '        mlock.unlock();\n\n'
-                    generated_commands += '        if (map_iter == g_%s_dispatch_map.end()) return XR_ERROR_VALIDATION_FAILURE;\n' % base_handle_name
-                    generated_commands += '        XrGeneratedDispatchTable *gen_dispatch_table = map_iter->second;\n'
+                    generated_commands += '    std::unique_lock<std::mutex> mlock(g_%s_dispatch_mutex);\n' % base_handle_name
+                    generated_commands += '    auto map_iter = g_%s_dispatch_map.find(%s);\n' % (base_handle_name, first_handle_name)
+                    generated_commands += '    mlock.unlock();\n\n'
+                    generated_commands += '    if (map_iter == g_%s_dispatch_map.end()) return XR_ERROR_VALIDATION_FAILURE;\n' % base_handle_name
+                    generated_commands += '    XrGeneratedDispatchTable *gen_dispatch_table = map_iter->second;\n'
                 else:
                     generated_commands += self.printCodeGenErrorMessage(
                         'Command %s does not have an OpenXR Object handle as the first parameter.' % cur_cmd.name)
 
                 # Print out a tuple for the header
                 if has_return:
-                    generated_commands += '        contents.push_back(std::make_tuple("%s", "%s", ""));\n' % (
+                    generated_commands += '    contents.push_back(std::make_tuple("%s", "%s", ""));\n' % (
                         cur_cmd.return_type.text, cur_cmd.name)
                 else:
-                    generated_commands += '        contents.push_back(std::make_tuple("void", "%s", ""));\n' % cur_cmd.name
+                    generated_commands += '    contents.push_back(std::make_tuple("void", "%s", ""));\n' % cur_cmd.name
                 # Print out information for each parameter
                 for param in cur_cmd.params:
                     can_expand = False
@@ -1171,13 +1159,13 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
                             (param.is_const or param.pointer_count == 0)):
                         can_expand = True
                     generated_commands += self.writeParamMember(
-                        param, False, can_expand, 2)
+                        param, False, can_expand, 1, False)
 
                 # Now record the information
-                generated_commands += '        ApiDumpLayerRecordContent(contents);\n\n'
+                generated_commands += '    ApiDumpLayerRecordContent(contents);\n\n'
 
                 # Call down, looking for the returned result if required.
-                generated_commands += '        '
+                generated_commands += '    '
                 if has_return:
                     generated_commands += 'result = '
                 generated_commands += 'gen_dispatch_table->%s(' % base_name
@@ -1198,30 +1186,23 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
                 if cur_cmd.params[-1].is_handle and (is_create or is_destroy):
                     second_base_handle_name = undecorate(cur_cmd.params[-1].type)
                     if is_create:
-                        generated_commands += '        if (XR_SUCCESS == result && nullptr != %s) {\n' % cur_cmd.params[-1].name
-                        generated_commands += '            auto exists = g_%s_dispatch_map.find(*%s);\n' % (
+                        generated_commands += '    if (XR_SUCCESS == result && nullptr != %s) {\n' % cur_cmd.params[-1].name
+                        generated_commands += '       auto exists = g_%s_dispatch_map.find(*%s);\n' % (
                             second_base_handle_name, cur_cmd.params[-1].name)
-                        generated_commands += '            if (exists == g_%s_dispatch_map.end()) {\n' % second_base_handle_name
-                        generated_commands += '                std::unique_lock<std::mutex> lock(g_%s_dispatch_mutex);\n' % second_base_handle_name
-                        generated_commands += '                g_%s_dispatch_map[*%s] = gen_dispatch_table;\n' % (
-                            second_base_handle_name, cur_cmd.params[-1].name)
-                        generated_commands += '            }\n'
-                        generated_commands += '        }\n'
-                    elif is_destroy:
-                        generated_commands += '        auto exists = g_%s_dispatch_map.find(%s);\n' % (
-                            second_base_handle_name, cur_cmd.params[-1].name)
-                        generated_commands += '        if (exists != g_%s_dispatch_map.end()) {\n' % second_base_handle_name
+                        generated_commands += '        if (exists == g_%s_dispatch_map.end()) {\n' % second_base_handle_name
                         generated_commands += '            std::unique_lock<std::mutex> lock(g_%s_dispatch_mutex);\n' % second_base_handle_name
-                        generated_commands += '            g_%s_dispatch_map.erase(%s);\n' % (
+                        generated_commands += '            g_%s_dispatch_map[*%s] = gen_dispatch_table;\n' % (
                             second_base_handle_name, cur_cmd.params[-1].name)
                         generated_commands += '        }\n'
-
-                # Catch any exceptions that may have occurred.  If any occurred between any of the
-                # valid mutex lock/unlock statements, perform the unlock now.
-                generated_commands += '    } catch (...) {\n'
-                if has_return:
-                    generated_commands += '        return XR_ERROR_VALIDATION_FAILURE;\n'
-                generated_commands += '    }\n'
+                        generated_commands += '    }\n'
+                    elif is_destroy:
+                        generated_commands += '    auto exists = g_%s_dispatch_map.find(%s);\n' % (
+                            second_base_handle_name, cur_cmd.params[-1].name)
+                        generated_commands += '    if (exists != g_%s_dispatch_map.end()) {\n' % second_base_handle_name
+                        generated_commands += '        std::unique_lock<std::mutex> lock(g_%s_dispatch_mutex);\n' % second_base_handle_name
+                        generated_commands += '        g_%s_dispatch_map.erase(%s);\n' % (
+                            second_base_handle_name, cur_cmd.params[-1].name)
+                        generated_commands += '    }\n'
 
                 if has_return:
                     generated_commands += '    return result;\n'
@@ -1236,19 +1217,18 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
         generated_commands += '    XrInstance                                  instance,\n'
         generated_commands += '    const char*                                 name,\n'
         generated_commands += '    PFN_xrVoidFunction*                         function) {\n'
-        generated_commands += '    try {\n'
-        generated_commands += '        std::string func_name = name;\n\n'
-        generated_commands += '        // Generate output for this command\n'
-        generated_commands += '        std::vector<std::tuple<std::string, std::string, std::string>> contents;\n'
-        generated_commands += '        contents.push_back(std::make_tuple("XrResult", "xrGetInstanceProcAddr", ""));\n'
-        generated_commands += '        std::ostringstream oss_instance;\n'
-        generated_commands += '        oss_instance << std::hex << reinterpret_cast<const void*>(instance);\n'
-        generated_commands += '        contents.push_back(std::make_tuple("XrInstance", "instance", oss_instance.str()));\n'
-        generated_commands += '        contents.push_back(std::make_tuple("const char*", "name", name));\n'
-        generated_commands += '        std::ostringstream oss_function;\n'
-        generated_commands += '        oss_function << std::hex << reinterpret_cast<const void*>(function);\n'
-        generated_commands += '        contents.push_back(std::make_tuple("PFN_xrVoidFunction*", "function", oss_function.str()));\n'
-        generated_commands += '        ApiDumpLayerRecordContent(contents);\n'
+        generated_commands += '    std::string func_name = name;\n\n'
+        generated_commands += '    // Generate output for this command\n'
+        generated_commands += '    std::vector<std::tuple<std::string, std::string, std::string>> contents;\n'
+        generated_commands += '    contents.push_back(std::make_tuple("XrResult", "xrGetInstanceProcAddr", ""));\n'
+        generated_commands += '    std::ostringstream oss_instance;\n'
+        generated_commands += '    oss_instance << std::hex << reinterpret_cast<const void*>(instance);\n'
+        generated_commands += '    contents.push_back(std::make_tuple("XrInstance", "instance", oss_instance.str()));\n'
+        generated_commands += '    contents.push_back(std::make_tuple("const char*", "name", name));\n'
+        generated_commands += '    std::ostringstream oss_function;\n'
+        generated_commands += '    oss_function << std::hex << reinterpret_cast<const void*>(function);\n'
+        generated_commands += '    contents.push_back(std::make_tuple("PFN_xrVoidFunction*", "function", oss_function.str()));\n'
+        generated_commands += '    ApiDumpLayerRecordContent(contents);\n'
 
         count = 0
         for x in range(0, 2):
@@ -1260,10 +1240,10 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
             for cur_cmd in commands:
                 if cur_cmd.ext_name != cur_extension_name:
                     if self.isCoreExtensionName(cur_cmd.ext_name):
-                        generated_commands += '\n        // ---- Core %s commands\n' % cur_cmd.ext_name[11:].replace(
+                        generated_commands += '\n    // ---- Core %s commands\n' % cur_cmd.ext_name[11:].replace(
                             "_", ".")
                     else:
-                        generated_commands += '\n        // ---- %s extension commands\n' % cur_cmd.ext_name
+                        generated_commands += '\n    // ---- %s extension commands\n' % cur_cmd.ext_name
                     cur_extension_name = cur_cmd.ext_name
 
                 if cur_cmd.name in DONT_GEN_IN_LAYER:
@@ -1281,34 +1261,31 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
                     generated_commands += '#if %s\n' % cur_cmd.protect_string
 
                 if count == 0:
-                    generated_commands += '        if (func_name == "%s") {\n' % cur_cmd.name
+                    generated_commands += '    if (func_name == "%s") {\n' % cur_cmd.name
                 else:
-                    generated_commands += '        } else if (func_name == "%s") {\n' % cur_cmd.name
+                    generated_commands += '    } else if (func_name == "%s") {\n' % cur_cmd.name
                 count = count + 1
 
-                generated_commands += '            *function = reinterpret_cast<PFN_xrVoidFunction>(%s);\n' % layer_command_name
+                generated_commands += '        *function = reinterpret_cast<PFN_xrVoidFunction>(%s);\n' % layer_command_name
                 if cur_cmd.protect_value:
                     generated_commands += '#endif // %s\n' % cur_cmd.protect_string
 
-        generated_commands += '        }\n'
-        generated_commands += '        // If we setup the function, just return\n'
-        generated_commands += '        if (*function != nullptr) {\n'
-        generated_commands += '            return XR_SUCCESS;\n'
-        generated_commands += '        }\n\n'
-        generated_commands += '        // We have not found it, so pass it down to the next layer/runtime\n'
-        generated_commands += '        std::unique_lock<std::mutex> mlock(g_instance_dispatch_mutex);\n'
-        generated_commands += '        auto map_iter = g_instance_dispatch_map.find(instance);\n'
-        generated_commands += '        mlock.unlock();\n\n'
-        generated_commands += '        if (map_iter == g_instance_dispatch_map.end()) {\n'
-        generated_commands += '            return XR_ERROR_HANDLE_INVALID;\n'
-        generated_commands += '        }\n\n'
-        generated_commands += '        XrGeneratedDispatchTable *gen_dispatch_table = map_iter->second;\n'
-        generated_commands += '        if (nullptr == gen_dispatch_table) {\n'
-        generated_commands += '            return XR_ERROR_HANDLE_INVALID;\n'
-        generated_commands += '        }\n\n'
-        generated_commands += '        return gen_dispatch_table->GetInstanceProcAddr(instance, name, function);\n'
-        generated_commands += '    } catch (...) {\n'
-        generated_commands += '        return XR_ERROR_VALIDATION_FAILURE;\n'
         generated_commands += '    }\n'
+        generated_commands += '    // If we setup the function, just return\n'
+        generated_commands += '    if (*function != nullptr) {\n'
+        generated_commands += '        return XR_SUCCESS;\n'
+        generated_commands += '    }\n\n'
+        generated_commands += '    // We have not found it, so pass it down to the next layer/runtime\n'
+        generated_commands += '    std::unique_lock<std::mutex> mlock(g_instance_dispatch_mutex);\n'
+        generated_commands += '    auto map_iter = g_instance_dispatch_map.find(instance);\n'
+        generated_commands += '    mlock.unlock();\n\n'
+        generated_commands += '    if (map_iter == g_instance_dispatch_map.end()) {\n'
+        generated_commands += '        return XR_ERROR_HANDLE_INVALID;\n'
+        generated_commands += '    }\n\n'
+        generated_commands += '    XrGeneratedDispatchTable *gen_dispatch_table = map_iter->second;\n'
+        generated_commands += '    if (nullptr == gen_dispatch_table) {\n'
+        generated_commands += '        return XR_ERROR_HANDLE_INVALID;\n'
+        generated_commands += '    }\n\n'
+        generated_commands += '    return gen_dispatch_table->GetInstanceProcAddr(instance, name, function);\n'
         generated_commands += '}\n'
         return generated_commands


### PR DESCRIPTION
Try to make exception free by doing the following:
1. For Exceptions are thrown and caught directly by the function that throws. These instances are changed to early return with a corresponding XrResult and logging, if any.
2. For Throws that are the result of a catch(..) with some “unknown error” or “bad alloc” logging. Remove these instances
3. Remove all catches directly.
4. Change JSON_USE_EXCEPTION to be defined as 0 so jsoncpp will not throw exception.

Note: This PR does not touch throws and catches in all tests, core_validation and xr_generated_core_validation. core_validation and xr_generated_core_validation are intended to be used by application developers and not part of the loader.