### PR TITLE
Loader proper UNICODE support.

### DIFF
--- a/src/common/platform_utils.hpp
+++ b/src/common/platform_utils.hpp
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "xr_dependencies.h"
+#include <string>
 
 #if defined(XR_OS_LINUX)
 #include <unistd.h>
@@ -96,11 +97,53 @@ static inline bool PlatformGetGlobalRuntimeFileName(uint16_t major_version, std:
 
 #elif defined(XR_OS_WINDOWS)
 
+#if defined(_DEBUG)
+inline void LogError(const std::string& error) { OutputDebugStringA(error.c_str()); }
+#else
+#define LogError(x)
+#endif
+inline std::wstring utf8_to_wide(const std::string& utf8Text) {
+    if (utf8Text.empty()) {
+        return {};
+    }
+    std::wstring wideText;
+    const int wideLength = ::MultiByteToWideChar(CP_UTF8, 0, utf8Text.data(), (int)utf8Text.size(), nullptr, 0);
+    if (wideLength == 0) {
+        LogError("utf8_to_wide convert string error: " + std::to_string(::GetLastError()));
+        return {};
+    }
+    wideText.resize(wideLength, 0);
+    wchar_t* wideString = const_cast<wchar_t*>(wideText.data());  // mutable data() only exists in c++17
+    const int length = ::MultiByteToWideChar(CP_UTF8, 0, utf8Text.data(), (int)utf8Text.size(), wideString, wideLength);
+    if (length != wideLength) {
+        LogError("utf8_to_wide convert string error: " + std::to_string(::GetLastError()));
+        return {};
+    }
+    return wideText;
+}
+inline std::string wide_to_utf8(const std::wstring& wideText) {
+    if (wideText.empty()) {
+        return {};
+    }
+    std::string narrowText;
+    int narrowLength = ::WideCharToMultiByte(CP_UTF8, 0, wideText.data(), (int)wideText.size(), nullptr, 0, nullptr, nullptr);
+    if (narrowLength == 0) {
+        LogError("wide_to_utf8 get size error: " + std::to_string(::GetLastError()));
+        return {};
+    }
+    narrowText.resize(narrowLength, 0);
+    char* narrowString = const_cast<char*>(narrowText.data());  // mutable data() only exists in c++17
+    const int length =
+        ::WideCharToMultiByte(CP_UTF8, 0, wideText.data(), (int)wideText.size(), narrowString, narrowLength, nullptr, nullptr);
+    if (length != narrowLength) {
+        LogError("wide_to_utf8 convert string error: " + std::to_string(::GetLastError()));
+        return {};
+    }
+    return narrowText;
+}
 static inline char *PlatformUtilsGetEnv(const char *name) {
-    char *retVal;
-    DWORD valSize;
-
-    valSize = GetEnvironmentVariableA(name, nullptr, 0);
+    const std::wstring wname = utf8_to_wide(name);
+    const DWORD valSize = ::GetEnvironmentVariableW(wname.c_str(), nullptr, 0);
 
     // valSize DOES include the null terminator, so for any set variable
     // will always be at least 1. If it's 0, the variable wasn't set.
@@ -108,9 +151,17 @@ static inline char *PlatformUtilsGetEnv(const char *name) {
         return nullptr;
     }
 
+    std::wstring wValue(valSize, 0);
+    wchar_t* wValueData = const_cast<wchar_t*>(wValue.data());  // mutable data() only exists in c++17
+    const int length = ::GetEnvironmentVariableW(wname.c_str(), wValueData, (DWORD)wValue.size());
+    if (!length) {
+        LogError("GetEnvironmentVariable get value error: " + std::to_string(::GetLastError()));
+        return nullptr;
+    }
+    const std::string value = wide_to_utf8(wValue);
     // Allocate the space necessary for the registry entry
-    retVal = new char[valSize + 1];
-    GetEnvironmentVariableA(name, retVal, valSize);
+    char* retVal = new char[value.size() + 1]{};
+    value.copy(retVal, value.size());
     return retVal;
 }
 

--- a/src/common/platform_utils.hpp
+++ b/src/common/platform_utils.hpp
@@ -111,7 +111,7 @@ inline std::wstring utf8_to_wide(const std::string& utf8Text) {
     std::wstring wideText;
     const int wideLength = ::MultiByteToWideChar(CP_UTF8, 0, utf8Text.data(), (int)utf8Text.size(), nullptr, 0);
     if (wideLength == 0) {
-        LogError("utf8_to_wide convert string error: " + std::to_string(::GetLastError()));
+        LogError("utf8_to_wide get size error: " + std::to_string(::GetLastError()));
         return {};
     }
 

--- a/src/common/xr_dependencies.h
+++ b/src/common/xr_dependencies.h
@@ -27,13 +27,12 @@
 #if !(WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP | WINAPI_PARTITION_SYSTEM))
 // Enable desktop partition APIs, such as RegOpenKeyEx, LoadLibraryEx, PathFileExists etc.
 #undef WINAPI_PARTITION_DESKTOP
-#define WINAPI_PARTITION_DESKTOP 1  // Enable desktop partition apis, such as RegOpenKeyEx, LoadLibraryEx etc.
+#define WINAPI_PARTITION_DESKTOP 1
 #endif
 
 #define NOMINMAX
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-
 
 #endif  // XR_USE_PLATFORM_WIN32
 

--- a/src/common/xr_dependencies.h
+++ b/src/common/xr_dependencies.h
@@ -25,18 +25,15 @@
 
 #include <winapifamily.h>
 #if !(WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP | WINAPI_PARTITION_SYSTEM))
-#pragma push_macro("WINAPI_PARTITION_DESKTOP")
+// Enable desktop partition APIs, such as RegOpenKeyEx, LoadLibraryEx, PathFileExists etc.
 #undef WINAPI_PARTITION_DESKTOP
 #define WINAPI_PARTITION_DESKTOP 1  // Enable desktop partition apis, such as RegOpenKeyEx, LoadLibraryEx etc.
-#define CHANGED_WINAPI_PARTITION_DESKTOP_VALUE
 #endif
 
+#define NOMINMAX
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
-#if defined(CHANGED_WINAPI_PARTITION_DESKTOP_VALUE)
-#pragma pop_macro("WINAPI_PARTITION_DESKTOP")
-#endif
 
 #endif  // XR_USE_PLATFORM_WIN32
 

--- a/src/loader/manifest_file.cpp
+++ b/src/loader/manifest_file.cpp
@@ -376,6 +376,7 @@ static void ReadRuntimeDataFilesInRegistry(ManifestFileType type, const std::str
 
         const std::wstring full_registry_location_w = utf8_to_wide(full_registry_location);
         const std::wstring default_runtime_value_name_w = utf8_to_wide(default_runtime_value_name);
+
         // Use 64 bit regkey for 64bit application, and use 32 bit regkey in WOW for 32bit application.
         access_flags = KEY_QUERY_VALUE;
         LONG open_value = RegOpenKeyExW(HKEY_LOCAL_MACHINE, full_registry_location_w.c_str(), 0, access_flags, &hkey);

--- a/src/tests/loader_test/CMakeLists.txt
+++ b/src/tests/loader_test/CMakeLists.txt
@@ -27,6 +27,7 @@ add_dependencies(loader_test
 )
 target_include_directories(loader_test
     PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
+    PRIVATE ${CMAKE_BINARY_DIR}/src
     PRIVATE ${CMAKE_BINARY_DIR}/include
     PRIVATE ${CMAKE_SOURCE_DIR}/src/common
     PRIVATE ${CMAKE_SOURCE_DIR}/external/include


### PR DESCRIPTION
Change to use "W" version of Win32 APIs for regkey, file path, etc. instead of "A" functions.
This is applied regardless of _UNICODE settings of the project, and always use UTF8 and UTF16 for string manipulations, which has better support in Win32 APIs for security, long file name, and globalization.