### PR TITLE
Clang tidy

### DIFF
--- a/src/api_layers/api_dump.cpp
+++ b/src/api_layers/api_dump.cpp
@@ -17,21 +17,27 @@
 // Author: Mark Young <marky@lunarg.com>
 //
 
-#include <iostream>
-#include <fstream>
-#include <sstream>
-#include <cstring>
-#include <string>
-#include <mutex>
-#include <unordered_map>
-#include <algorithm>
-#include <cctype>
-
-#include "xr_generated_api_dump.hpp"
-#include "xr_generated_dispatch_table.h"
+#include "hex_and_handles.h"
 #include "loader_interfaces.h"
 #include "platform_utils.hpp"
-#include "hex_and_handles.h"
+#include "xr_generated_api_dump.hpp"
+#include "xr_generated_dispatch_table.h"
+
+#include <openxr/openxr.h>
+
+#include <algorithm>
+#include <cctype>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <mutex>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 #if defined(__GNUC__) && __GNUC__ >= 4
 #define LAYER_EXPORT __attribute__((visibility("default")))

--- a/src/api_layers/api_layer_platform_defines.h
+++ b/src/api_layers/api_layer_platform_defines.h
@@ -43,6 +43,6 @@
 #define XR_USE_GRAPHICS_API_METAL 1   // Metal exists
 #endif                                // XR_OS_APPLE_MACOS
 
-#include "xr_dependencies.h"
+#include "xr_dependencies.h" // IWYU pragma: export
 
 #endif  // API_LAYER_PLATFORM_DEFINES_H_

--- a/src/api_layers/core_validation.cpp
+++ b/src/api_layers/core_validation.cpp
@@ -679,34 +679,34 @@ XrResult CoreValidationXrCreateSession(XrInstance instance, const XrSessionCreat
 // ---- XR_EXT_debug_utils extension commands
 XrResult CoreValidationXrSetDebugUtilsObjectNameEXT(XrInstance instance, const XrDebugUtilsObjectNameInfoEXT *nameInfo) {
     try {
-        if (!GenValidUsageInputsXrSetDebugUtilsObjectNameEXT(instance, nameInfo)) {
-            return XR_ERROR_VALIDATION_FAILURE;
+        XrResult result = GenValidUsageInputsXrSetDebugUtilsObjectNameEXT(instance, nameInfo);
+        if (!XR_UNQUALIFIED_SUCCESS(result)) {
+            return result;
         }
-        XrResult result = GenValidUsageNextXrSetDebugUtilsObjectNameEXT(instance, nameInfo);
-        if (XR_SUCCESS == result) {
-            auto info_with_lock = g_instance_info.getWithLock(instance);
-            GenValidUsageXrInstanceInfo *gen_instance_info = info_with_lock.second;
-            if (nullptr != gen_instance_info) {
-                // Create a copy of the base object name info (no next items)
-                char *name_string = new char[strlen(nameInfo->objectName) + 1];
-                strcpy(name_string, nameInfo->objectName);
-                bool found = false;
-                for (uint32_t name_index = 0; name_index < gen_instance_info->object_names.size(); ++name_index) {
-                    if (gen_instance_info->object_names[name_index]->objectHandle == nameInfo->objectHandle &&
-                        gen_instance_info->object_names[name_index]->objectType == nameInfo->objectType) {
-                        delete[] gen_instance_info->object_names[name_index]->objectName;
-                        gen_instance_info->object_names[name_index]->objectName = name_string;
-                        found = true;
-                        break;
-                    }
+        result = GenValidUsageNextXrSetDebugUtilsObjectNameEXT(instance, nameInfo);
+        if (!XR_UNQUALIFIED_SUCCESS(result)) {
+            return result;
+        }
+        auto info_with_lock = g_instance_info.getWithLock(instance);
+        GenValidUsageXrInstanceInfo *gen_instance_info = info_with_lock.second;
+        if (nullptr != gen_instance_info) {
+            // Create a copy of the base object name info (no next items)
+            char *name_string = new char[strlen(nameInfo->objectName) + 1];
+            strcpy(name_string, nameInfo->objectName);
+            bool found = false;
+            for (auto &object_name : gen_instance_info->object_names) {
+                if (object_name->objectHandle == nameInfo->objectHandle && object_name->objectType == nameInfo->objectType) {
+                    delete[] object_name->objectName;
+                    object_name->objectName = name_string;
+                    found = true;
+                    break;
                 }
-                if (!found) {
-                    UniqueXrDebugUtilsObjectNameInfoEXT new_object_name(new XrDebugUtilsObjectNameInfoEXT);
-                    *new_object_name = *nameInfo;
-                    new_object_name->next = nullptr;
-                    new_object_name->objectName = name_string;
-                    gen_instance_info->object_names.push_back(std::move(new_object_name));
-                }
+            }
+            if (!found) {
+                UniqueXrDebugUtilsObjectNameInfoEXT new_object_name(new XrDebugUtilsObjectNameInfoEXT(*nameInfo));
+                new_object_name->next = nullptr;
+                new_object_name->objectName = name_string;
+                gen_instance_info->object_names.push_back(std::move(new_object_name));
             }
         }
         return result;
@@ -717,48 +717,50 @@ XrResult CoreValidationXrSetDebugUtilsObjectNameEXT(XrInstance instance, const X
 
 XrResult CoreValidationXrCreateDebugUtilsMessengerEXT(XrInstance instance, const XrDebugUtilsMessengerCreateInfoEXT *createInfo,
                                                       XrDebugUtilsMessengerEXT *messenger) {
-    XrResult result = XR_SUCCESS;
     try {
-        if (!GenValidUsageInputsXrCreateDebugUtilsMessengerEXT(instance, createInfo, messenger)) {
-            return XR_ERROR_VALIDATION_FAILURE;
+        XrResult result = GenValidUsageInputsXrCreateDebugUtilsMessengerEXT(instance, createInfo, messenger);
+        if (!XR_UNQUALIFIED_SUCCESS(result)) {
+            return result;
         }
         result = GenValidUsageNextXrCreateDebugUtilsMessengerEXT(instance, createInfo, messenger);
-        if (XR_SUCCESS == result) {
-            auto info_with_lock = g_instance_info.getWithLock(instance);
-            GenValidUsageXrInstanceInfo *gen_instance_info = info_with_lock.second;
-            if (nullptr != gen_instance_info) {
-                XrDebugUtilsMessengerCreateInfoEXT *new_create_info = new XrDebugUtilsMessengerCreateInfoEXT;
-                *new_create_info = *createInfo;
-                new_create_info->next = nullptr;
-                UniqueCoreValidationMessengerInfo new_messenger_info(new CoreValidationMessengerInfo);
-                new_messenger_info->messenger = *messenger;
-                new_messenger_info->create_info = new_create_info;
-                gen_instance_info->debug_messengers.push_back(std::move(new_messenger_info));
-            }
+        if (!XR_UNQUALIFIED_SUCCESS(result)) {
+            return result;
         }
+        auto info_with_lock = g_instance_info.getWithLock(instance);
+        GenValidUsageXrInstanceInfo *gen_instance_info = info_with_lock.second;
+        if (nullptr != gen_instance_info) {
+            auto *new_create_info = new XrDebugUtilsMessengerCreateInfoEXT(*createInfo);
+            new_create_info->next = nullptr;
+            UniqueCoreValidationMessengerInfo new_messenger_info(new CoreValidationMessengerInfo);
+            new_messenger_info->messenger = *messenger;
+            new_messenger_info->create_info = new_create_info;
+            gen_instance_info->debug_messengers.push_back(std::move(new_messenger_info));
+        }
+        return result;
     } catch (...) {
         return XR_ERROR_VALIDATION_FAILURE;
     }
-    return result;
 }
 
 XrResult CoreValidationXrDestroyDebugUtilsMessengerEXT(XrDebugUtilsMessengerEXT messenger) {
     try {
-        if (!GenValidUsageInputsXrDestroyDebugUtilsMessengerEXT(messenger)) {
-            return XR_ERROR_VALIDATION_FAILURE;
+        XrResult result = GenValidUsageInputsXrDestroyDebugUtilsMessengerEXT(messenger);
+        if (!XR_UNQUALIFIED_SUCCESS(result)) {
+            return result;
         }
-        XrResult result = GenValidUsageNextXrDestroyDebugUtilsMessengerEXT(messenger);
-        if (XR_NULL_HANDLE != messenger) {
-            auto info_with_lock = g_debugutilsmessengerext_info.getWithLock(messenger);
-            GenValidUsageXrHandleInfo *gen_handle_info = info_with_lock.second;
-            if (nullptr != gen_handle_info) {
-                auto &debug_messengers = gen_handle_info->instance_info->debug_messengers;
-                vector_remove_if_and_erase(
-                    debug_messengers, [=](UniqueCoreValidationMessengerInfo const &msg) { return msg->messenger == messenger; });
-
-            } else {
-                return XR_ERROR_DEBUG_UTILS_MESSENGER_INVALID_EXT;
-            }
+        result = GenValidUsageNextXrDestroyDebugUtilsMessengerEXT(messenger);
+        if (!XR_UNQUALIFIED_SUCCESS(result)) {
+            return result;
+        }
+        if (XR_NULL_HANDLE == messenger) {
+            return XR_ERROR_DEBUG_UTILS_MESSENGER_INVALID_EXT;
+        }
+        auto info_with_lock = g_debugutilsmessengerext_info.getWithLock(messenger);
+        GenValidUsageXrHandleInfo *gen_handle_info = info_with_lock.second;
+        if (nullptr != gen_handle_info) {
+            auto &debug_messengers = gen_handle_info->instance_info->debug_messengers;
+            vector_remove_if_and_erase(debug_messengers,
+                                       [=](UniqueCoreValidationMessengerInfo const &msg) { return msg->messenger == messenger; });
         }
         return result;
     } catch (...) {

--- a/src/api_layers/core_validation.cpp
+++ b/src/api_layers/core_validation.cpp
@@ -17,23 +17,30 @@
 // Author: Mark Young <marky@lunarg.com>
 //
 
-#include <iostream>
-#include <fstream>
-#include <sstream>
-#include <cstring>
-#include <string>
-#include <mutex>
-#include <unordered_map>
-#include <algorithm>
-#include <cctype>
-#include <vector>
-#include <memory>
-
-#include "xr_generated_core_validation.hpp"
+#include "api_layer_platform_defines.h"
+#include "extra_algorithms.h"
+#include "hex_and_handles.h"
 #include "loader_interfaces.h"
 #include "platform_utils.hpp"
+#include "validation_utils.h"
+#include "xr_generated_core_validation.hpp"
 #include "xr_generated_dispatch_table.h"
-#include "hex_and_handles.h"
+
+#include <openxr/openxr.h>
+
+#include <algorithm>
+#include <cctype>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 #if defined(__GNUC__) && __GNUC__ >= 4
 #define LAYER_EXPORT __attribute__((visibility("default")))

--- a/src/api_layers/core_validation.cpp
+++ b/src/api_layers/core_validation.cpp
@@ -691,8 +691,9 @@ XrResult CoreValidationXrSetDebugUtilsObjectNameEXT(XrInstance instance, const X
         GenValidUsageXrInstanceInfo *gen_instance_info = info_with_lock.second;
         if (nullptr != gen_instance_info) {
             // Create a copy of the base object name info (no next items)
-            char *name_string = new char[strlen(nameInfo->objectName) + 1];
-            strcpy(name_string, nameInfo->objectName);
+            auto len = strlen(nameInfo->objectName);
+            char *name_string = new char[len + 1];
+            strncpy(name_string, nameInfo->objectName, len);
             bool found = false;
             for (auto &object_name : gen_instance_info->object_names) {
                 if (object_name->objectHandle == nameInfo->objectHandle && object_name->objectType == nameInfo->objectType) {

--- a/src/common/filesystem_utils.cpp
+++ b/src/common/filesystem_utils.cpp
@@ -18,9 +18,15 @@
 //          Nat Brown <natb@valvesoftware.com>
 //
 
-#include <cstring>
-#include "xr_dependencies.h"
+#include "filesystem_utils.hpp"
+
 #include "platform_utils.hpp"
+
+#ifdef _WIN32
+#include "xr_dependencies.h"
+#endif
+
+#include <cstring>
 
 #if defined DISABLE_STD_FILESYSTEM
 #define USE_EXPERIMENTAL_FS 0
@@ -76,14 +82,11 @@
 #else
 // Linux/Apple fallback includes
 #include <sys/stat.h>
-#include <sys/param.h>
 #include <unistd.h>
 #include <limits.h>
 #include <stdlib.h>
 #include <dirent.h>
 #endif
-
-#include "filesystem_utils.hpp"
 
 #if defined(XR_USE_PLATFORM_WIN32)
 #define PATH_SEPARATOR ';'
@@ -325,12 +328,6 @@ bool FileSysUtilsFindFilesInPath(const std::string& path, std::vector<std::strin
 }
 
 #else  // XR_OS_LINUX/XR_OS_APPLE fallback
-
-#include <sys/stat.h>
-#include <sys/param.h>
-#include <unistd.h>
-#include <stdlib.h>
-#include <dirent.h>
 
 // simple POSIX-compatible implementation of the <filesystem> pieces used by OpenXR
 

--- a/src/common/hex_and_handles.h
+++ b/src/common/hex_and_handles.h
@@ -33,6 +33,7 @@
 #include <openxr/openxr.h>
 
 #include <string>
+#include <stdint.h>
 
 #if XR_PTR_SIZE == 8
 /// Convert a handle into a same-sized integer.

--- a/src/common/platform_utils.hpp
+++ b/src/common/platform_utils.hpp
@@ -54,7 +54,7 @@ static inline char* PlatformUtilsGetSecureEnv(const char* name) {
 #endif
 }
 
-static inline void PlatformUtilsFreeEnv(char* val) {
+static inline void PlatformUtilsFreeEnv(const char* val) {
     // No freeing of memory necessary for Linux, but we should at least touch
     // the val and inst pointers to get rid of compiler warnings.
     (void)val;

--- a/src/loader/api_layer_interface.cpp
+++ b/src/loader/api_layer_interface.cpp
@@ -16,18 +16,23 @@
 //
 // Author: Mark Young <marky@lunarg.com>
 //
-#include <cstring>
-#include <fstream>
-#include <iostream>
-#include <sstream>
-#include <utility>
 
-#include "platform_utils.hpp"
-#include "manifest_file.hpp"
-#include "xr_generated_dispatch_table.h"
 #include "api_layer_interface.hpp"
+
 #include "loader_interfaces.h"
 #include "loader_logger.hpp"
+#include "loader_platform.hpp"
+#include "manifest_file.hpp"
+#include "platform_utils.hpp"
+
+#include <openxr/openxr.h>
+
+#include <cstring>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
 
 #define OPENXR_ENABLE_LAYERS_ENV_VAR "XR_ENABLE_API_LAYERS"
 

--- a/src/loader/api_layer_interface.cpp
+++ b/src/loader/api_layer_interface.cpp
@@ -20,6 +20,7 @@
 #include <fstream>
 #include <iostream>
 #include <sstream>
+#include <utility>
 
 #include "platform_utils.hpp"
 #include "manifest_file.hpp"
@@ -112,7 +113,8 @@ XrResult ApiLayerInterface::GetApiLayerProperties(const std::string& openxr_comm
                 LoaderLogger::LogErrorMessage(openxr_command,
                                               "VUID-xrEnumerateApiLayerProperties-properties-parameter: invalid properties");
                 return XR_ERROR_VALIDATION_FAILURE;
-            } else if (nullptr != outgoing_count) {
+            }
+            if (nullptr != outgoing_count) {
                 *outgoing_count = prop;
             }
         }
@@ -142,7 +144,7 @@ XrResult ApiLayerInterface::GetInstanceExtensionProperties(const std::string& op
                 }
 
                 bool found = false;
-                uint32_t num_files = static_cast<uint32_t>(manifest_files.size());
+                auto num_files = static_cast<uint32_t>(manifest_files.size());
                 for (uint32_t man_file = 0; man_file < num_files; ++man_file) {
                     // If a layer with the provided name exists, get it's instance extension information.
                     if (manifest_files[man_file]->LayerName() == layer_name) {
@@ -165,12 +167,12 @@ XrResult ApiLayerInterface::GetInstanceExtensionProperties(const std::string& op
                 // since we know that they're going to be enabled.
                 std::vector<std::string> env_enabled_layers;
                 AddEnvironmentApiLayers(openxr_command, env_enabled_layers);
-                if (env_enabled_layers.size() > 0) {
+                if (!env_enabled_layers.empty()) {
                     std::vector<std::unique_ptr<ApiLayerManifestFile>> exp_layer_man_files = {};
                     result = ApiLayerManifestFile::FindManifestFiles(MANIFEST_TYPE_EXPLICIT_API_LAYER, exp_layer_man_files);
                     if (XR_SUCCESS == result) {
                         for (auto l_iter = exp_layer_man_files.begin();
-                             exp_layer_man_files.size() > 0 && l_iter != exp_layer_man_files.end();
+                             !exp_layer_man_files.empty() && l_iter != exp_layer_man_files.end();
                              /* No iterate */) {
                             for (std::string& enabled_layer : env_enabled_layers) {
                                 // If this is an enabled layer, transfer it over to the manifest list.
@@ -186,7 +188,7 @@ XrResult ApiLayerInterface::GetInstanceExtensionProperties(const std::string& op
             }
 
             // Grab the layer instance extensions information
-            uint32_t num_files = static_cast<uint32_t>(manifest_files.size());
+            auto num_files = static_cast<uint32_t>(manifest_files.size());
             for (uint32_t man_file = 0; man_file < num_files; ++man_file) {
                 manifest_files[man_file]->GetInstanceExtensionProperties(extension_properties);
             }
@@ -226,7 +228,7 @@ XrResult ApiLayerInterface::LoadApiLayers(const std::string& openxr_command, uin
                     "xrCreateInstance", "VUID-xrCreateInstance-info-parameter: something wrong with XrInstanceCreateInfo contents");
                 return XR_ERROR_VALIDATION_FAILURE;
             }
-            uint32_t num_env_api_layers = static_cast<uint32_t>(enabled_api_layers.size());
+            auto num_env_api_layers = static_cast<uint32_t>(enabled_api_layers.size());
             uint32_t total_api_layers = num_env_api_layers + enabled_api_layer_count;
             enabled_api_layers.resize(total_api_layers);
             for (uint32_t layer = 0; layer < enabled_api_layer_count; ++layer) {
@@ -236,8 +238,8 @@ XrResult ApiLayerInterface::LoadApiLayers(const std::string& openxr_command, uin
 
         // Initialize the layer found vector to false
         layer_found.resize(enabled_api_layers.size());
-        for (uint32_t layer = 0; layer < layer_found.size(); ++layer) {
-            layer_found[layer] = false;
+        for (auto&& layer : layer_found) {
+            layer = false;
         }
 
         for (std::unique_ptr<ApiLayerManifestFile>& manifest_file : layer_manifest_files) {
@@ -280,7 +282,7 @@ XrResult ApiLayerInterface::LoadApiLayers(const std::string& openxr_command, uin
 
             // Get and settle on an layer interface version (using any provided name if required).
             std::string function_name = manifest_file->GetFunctionName("xrNegotiateLoaderApiLayerInterface");
-            PFN_xrNegotiateLoaderApiLayerInterface negotiate = reinterpret_cast<PFN_xrNegotiateLoaderApiLayerInterface>(
+            auto negotiate = reinterpret_cast<PFN_xrNegotiateLoaderApiLayerInterface>(
                 LoaderPlatformLibraryGetProcAddr(layer_library, function_name));
 
             // Loader info for negotiation
@@ -334,8 +336,9 @@ XrResult ApiLayerInterface::LoadApiLayers(const std::string& openxr_command, uin
             std::vector<std::string> supported_extensions;
             std::vector<XrExtensionProperties> extension_properties;
             manifest_file->GetInstanceExtensionProperties(extension_properties);
+            supported_extensions.reserve(extension_properties.size());
             for (XrExtensionProperties& ext_prop : extension_properties) {
-                supported_extensions.push_back(ext_prop.extensionName);
+                supported_extensions.emplace_back(ext_prop.extensionName);
             }
 
             // Add this runtime to the vector
@@ -380,7 +383,7 @@ ApiLayerInterface::ApiLayerInterface(std::string layer_name, LoaderPlatformLibra
                                      std::vector<std::string>& supported_extensions,
                                      PFN_xrGetInstanceProcAddr get_instant_proc_addr,
                                      PFN_xrCreateApiLayerInstance create_api_layer_instance)
-    : _layer_name(layer_name),
+    : _layer_name(std::move(layer_name)),
       _layer_library(layer_library),
       _get_instant_proc_addr(get_instant_proc_addr),
       _create_api_layer_instance(create_api_layer_instance),
@@ -396,7 +399,7 @@ ApiLayerInterface::~ApiLayerInterface() {
 bool ApiLayerInterface::SupportsExtension(const std::string& extension_name) {
     bool found_prop = false;
     try {
-        for (std::string supported_extension : _supported_extensions) {
+        for (const std::string& supported_extension : _supported_extensions) {
             if (supported_extension == extension_name) {
                 found_prop = true;
                 break;

--- a/src/loader/api_layer_interface.hpp
+++ b/src/loader/api_layer_interface.hpp
@@ -21,9 +21,14 @@
 
 #include <string>
 #include <vector>
+#include <memory>
+
+#include <openxr/openxr.h>
 
 #include "loader_platform.hpp"
 #include "loader_interfaces.h"
+
+struct XrGeneratedDispatchTable;
 
 class ApiLayerInterface {
    public:

--- a/src/loader/loader_core.cpp
+++ b/src/loader/loader_core.cpp
@@ -21,20 +21,30 @@
 #define _CRT_SECURE_NO_WARNINGS
 #endif
 
-#include <cstring>
-#include <string>
-#include <mutex>
-#include <memory>
-#include <sstream>
-
-#include "xr_dependencies.h"
-#include <openxr/openxr.h>
-#include <openxr/openxr_platform.h>
-
-#include "loader_logger.hpp"
-#include "loader_logger_recorders.hpp"
+#include "api_layer_interface.hpp"
+#include "hex_and_handles.h"
 #include "loader_instance.hpp"
+#include "loader_logger_recorders.hpp"
+#include "loader_logger.hpp"
+#include "loader_platform.hpp"
+#include "runtime_interface.hpp"
+#include "xr_generated_dispatch_table.h"
 #include "xr_generated_loader.hpp"
+
+//! @todo can we remove this? Everything but Windows is using it only for includes that aren't needed in this file.
+#ifdef _WIN32
+#include "xr_dependencies.h"
+#endif
+
+#include <openxr/openxr.h>
+
+#include <cstring>
+#include <memory>
+#include <mutex>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
 
 // Flag to cause the one time to init to only occur one time.
 std::once_flag g_one_time_init_flag;

--- a/src/loader/loader_core.cpp
+++ b/src/loader/loader_core.cpp
@@ -551,6 +551,8 @@ XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermDestroyDebugUtilsMessengerEXT(XrDebug
         LoaderLogger::LogVerboseMessage("xrDestroyDebugUtilsMessengerEXT", "Entering loader terminator");
         const auto *dispatch_table = RuntimeInterface::GetDebugUtilsMessengerDispatchTable(messenger);
         XrResult result = XR_SUCCESS;
+        LoaderLogger::GetInstance().RemoveLogRecorder(MakeHandleGeneric(messenger));
+        RuntimeInterface::GetRuntime().ForgetDebugMessenger(messenger);
         // This extension is supported entirely by the loader which means the runtime may or may not support it.
         if (nullptr != dispatch_table->DestroyDebugUtilsMessengerEXT) {
             result = dispatch_table->DestroyDebugUtilsMessengerEXT(messenger);
@@ -559,8 +561,6 @@ XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermDestroyDebugUtilsMessengerEXT(XrDebug
             delete (reinterpret_cast<char *>(MakeHandleGeneric(messenger)));
         }
         LoaderLogger::LogVerboseMessage("xrDestroyDebugUtilsMessengerEXT", "Completed loader terminator");
-        LoaderLogger::GetInstance().RemoveLogRecorder(MakeHandleGeneric(messenger));
-        RuntimeInterface::GetRuntime().ForgetDebugMessenger(messenger);
         return result;
     } catch (...) {
         LoaderLogger::LogErrorMessage("xrDestroyDebugUtilsMessengerEXT",

--- a/src/loader/loader_core.cpp
+++ b/src/loader/loader_core.cpp
@@ -521,7 +521,7 @@ XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermCreateDebugUtilsMessengerEXT(XrInstan
                                                     "xrCreateDebugUtilsMessengerEXT", "invalid messenger pointer");
             return XR_ERROR_VALIDATION_FAILURE;
         }
-        const XrGeneratedDispatchTable *dispatch_table = RuntimeInterface::GetRuntime().GetDispatchTable(instance);
+        const auto *dispatch_table = RuntimeInterface::GetDispatchTable(instance);
         XrResult result = XR_SUCCESS;
         // This extension is supported entirely by the loader which means the runtime may or may not support it.
         if (nullptr != dispatch_table->CreateDebugUtilsMessengerEXT) {
@@ -549,8 +549,7 @@ XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermCreateDebugUtilsMessengerEXT(XrInstan
 XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermDestroyDebugUtilsMessengerEXT(XrDebugUtilsMessengerEXT messenger) {
     try {
         LoaderLogger::LogVerboseMessage("xrDestroyDebugUtilsMessengerEXT", "Entering loader terminator");
-        const XrGeneratedDispatchTable *dispatch_table =
-            RuntimeInterface::GetRuntime().GetDebugUtilsMessengerDispatchTable(messenger);
+        const auto *dispatch_table = RuntimeInterface::GetDebugUtilsMessengerDispatchTable(messenger);
         XrResult result = XR_SUCCESS;
         // This extension is supported entirely by the loader which means the runtime may or may not support it.
         if (nullptr != dispatch_table->DestroyDebugUtilsMessengerEXT) {
@@ -577,7 +576,7 @@ XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermSubmitDebugUtilsMessageEXT(XrInstance
                                                                       const XrDebugUtilsMessengerCallbackDataEXT *callbackData) {
     try {
         LoaderLogger::LogVerboseMessage("xrSubmitDebugUtilsMessageEXT", "Entering loader terminator");
-        const XrGeneratedDispatchTable *dispatch_table = RuntimeInterface::GetRuntime().GetDispatchTable(instance);
+        const auto *dispatch_table = RuntimeInterface::GetDispatchTable(instance);
         XrResult result = XR_SUCCESS;
         if (nullptr != dispatch_table->SubmitDebugUtilsMessageEXT) {
             result = dispatch_table->SubmitDebugUtilsMessageEXT(instance, messageSeverity, messageTypes, callbackData);
@@ -600,7 +599,7 @@ XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermSetDebugUtilsObjectNameEXT(XrInstance
                                                                       const XrDebugUtilsObjectNameInfoEXT *nameInfo) {
     try {
         LoaderLogger::LogVerboseMessage("xrSetDebugUtilsObjectNameEXT", "Entering loader terminator");
-        const XrGeneratedDispatchTable *dispatch_table = RuntimeInterface::GetRuntime().GetDispatchTable(instance);
+        const auto *dispatch_table = RuntimeInterface::GetDispatchTable(instance);
         XrResult result = XR_SUCCESS;
         if (nullptr != dispatch_table->SetDebugUtilsObjectNameEXT) {
             result = dispatch_table->SetDebugUtilsObjectNameEXT(instance, nameInfo);

--- a/src/loader/loader_instance.cpp
+++ b/src/loader/loader_instance.cpp
@@ -177,7 +177,8 @@ XrResult LoaderInstance::CreateInstance(std::vector<std::unique_ptr<ApiLayerInte
             oss << HandleToHexString(*instance);
             LoaderLogger::LogInfoMessage("xrCreateInstance", oss.str());
             // Make the unique_ptr no longer delete this.
-            loader_instance.release();
+            // Don't need to save the return value because we already set *instance
+            (void)loader_instance.release();
         }
     } catch (std::bad_alloc&) {
         LoaderLogger::LogErrorMessage("xrCreateInstance", "LoaderInstance::CreateInstance - failed to allocate memory");

--- a/src/loader/loader_instance.cpp
+++ b/src/loader/loader_instance.cpp
@@ -58,10 +58,10 @@ XrResult LoaderInstance::CreateInstance(std::vector<std::unique_ptr<ApiLayerInte
 
         // Only start the xrCreateApiLayerInstance stack if we have layers.
         std::vector<std::unique_ptr<ApiLayerInterface>>& layer_interfaces = loader_instance->LayerInterfaces();
-        if (layer_interfaces.size() > 0) {
+        if (!layer_interfaces.empty()) {
             // Initialize an array of ApiLayerNextInfo structs
-            XrApiLayerNextInfo* next_info_list = new XrApiLayerNextInfo[layer_interfaces.size()];
-            uint32_t ni_index = static_cast<uint32_t>(layer_interfaces.size() - 1);
+            auto* next_info_list = new XrApiLayerNextInfo[layer_interfaces.size()];
+            auto ni_index = static_cast<uint32_t>(layer_interfaces.size() - 1);
             for (uint32_t i = 0; i <= ni_index; i++) {
                 next_info_list[i].structType = XR_LOADER_INTERFACE_STRUCT_API_LAYER_NEXT_INFO;
                 next_info_list[i].structVersion = XR_API_LAYER_NEXT_INFO_STRUCT_VERSION;
@@ -124,7 +124,7 @@ XrResult LoaderInstance::CreateInstance(std::vector<std::unique_ptr<ApiLayerInte
                 // Next check the loader
                 if (!found) {
                     for (auto loader_extension : LoaderInstance::_loader_supported_extensions) {
-                        if (!strcmp(loader_extension.extensionName, info->enabledExtensionNames[ext])) {
+                        if (strcmp(loader_extension.extensionName, info->enabledExtensionNames[ext]) == 0) {
                             found = true;
                             break;
                         }
@@ -132,9 +132,8 @@ XrResult LoaderInstance::CreateInstance(std::vector<std::unique_ptr<ApiLayerInte
                 }
                 // Finally, check the enabled layers
                 if (!found) {
-                    for (auto layer_interface = layer_interfaces.begin(); layer_interface != layer_interfaces.end();
-                         ++layer_interface) {
-                        if ((*layer_interface)->SupportsExtension(info->enabledExtensionNames[ext])) {
+                    for (auto& layer_interface : layer_interfaces) {
+                        if (layer_interface->SupportsExtension(info->enabledExtensionNames[ext])) {
                             found = true;
                             break;
                         }
@@ -224,7 +223,7 @@ XrResult LoaderInstance::CreateDispatchTable(XrInstance instance) {
         // Go through all layers, and override the instance pointers with the layer version.  However,
         // go backwards through the layer list so we replace in reverse order so the layers can call their next function
         // appropriately.
-        if (_api_layer_interfaces.size() > 0) {
+        if (!_api_layer_interfaces.empty()) {
             (*_api_layer_interfaces.begin())->GenUpdateInstanceDispatchTable(instance, new_instance_dispatch_table);
         }
 

--- a/src/loader/loader_instance.cpp
+++ b/src/loader/loader_instance.cpp
@@ -21,19 +21,28 @@
 #define _CRT_SECURE_NO_WARNINGS
 #endif
 
+#include "loader_instance.hpp"
+
+#include "api_layer_interface.hpp"
+#include "hex_and_handles.h"
+#include "loader_interfaces.h"
+#include "loader_logger.hpp"
+#include "runtime_interface.hpp"
+#include "xr_generated_dispatch_table.h"
+#include "xr_generated_loader.hpp"
+
+//! @todo can we remove this? Everything but Windows is using it only for includes that aren't needed in this file.
+#ifdef _WIN32
+#include "xr_dependencies.h"
+#endif
+#include <openxr/openxr.h>
+
 #include <cstring>
 #include <memory>
 #include <sstream>
-#include <stack>
-
-#include "xr_dependencies.h"
-#include <openxr/openxr.h>
-#include <openxr/openxr_platform.h>
-
-#include "loader_instance.hpp"
-#include "xr_generated_dispatch_table.h"
-#include "xr_generated_loader.hpp"
-#include "loader_logger.hpp"
+#include <string>
+#include <utility>
+#include <vector>
 
 // Extensions that are supported by the loader, but may not be supported
 // the the runtime.

--- a/src/loader/loader_instance.hpp
+++ b/src/loader/loader_instance.hpp
@@ -19,17 +19,20 @@
 
 #pragma once
 
+#include "extra_algorithms.h"
+
+#include <openxr/openxr.h>
+
+#include <cmath>
+#include <memory>
+#include <mutex>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
-#include "loader_platform.hpp"
-#include "platform_utils.hpp"
-#include "extra_algorithms.h"
-#include "runtime_interface.hpp"
-#include "api_layer_interface.hpp"
-#include "xr_generated_dispatch_table.h"
-
 class LoaderInstance;
+class ApiLayerInterface;
+struct XrGeneratedDispatchTable;
 
 typedef std::unique_lock<std::mutex> UniqueLock;
 template <typename HandleType>

--- a/src/loader/loader_logger.cpp
+++ b/src/loader/loader_logger.cpp
@@ -113,16 +113,16 @@ bool ObjectInfoCollection::LookUpObjectName(XrLoaderLogObjectInfo& info) const {
 XrLoaderLogMessageSeverityFlags DebugUtilsSeveritiesToLoaderLogMessageSeverities(
     XrDebugUtilsMessageSeverityFlagsEXT utils_severities) {
     XrLoaderLogMessageSeverityFlags log_severities = 0UL;
-    if (utils_severities & XR_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT) {
+    if ((utils_severities & XR_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT) != 0u) {
         log_severities |= XR_LOADER_LOG_MESSAGE_SEVERITY_VERBOSE_BIT;
     }
-    if (utils_severities & XR_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT) {
+    if ((utils_severities & XR_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT) != 0u) {
         log_severities |= XR_LOADER_LOG_MESSAGE_SEVERITY_INFO_BIT;
     }
-    if (utils_severities & XR_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT) {
+    if ((utils_severities & XR_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT) != 0u) {
         log_severities |= XR_LOADER_LOG_MESSAGE_SEVERITY_WARNING_BIT;
     }
-    if (utils_severities & XR_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT) {
+    if ((utils_severities & XR_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT) != 0u) {
         log_severities |= XR_LOADER_LOG_MESSAGE_SEVERITY_ERROR_BIT;
     }
     return log_severities;
@@ -131,16 +131,16 @@ XrLoaderLogMessageSeverityFlags DebugUtilsSeveritiesToLoaderLogMessageSeverities
 XrDebugUtilsMessageSeverityFlagsEXT LoaderLogMessageSeveritiesToDebugUtilsMessageSeverities(
     XrLoaderLogMessageSeverityFlags log_severities) {
     XrDebugUtilsMessageSeverityFlagsEXT utils_severities = 0UL;
-    if (log_severities & XR_LOADER_LOG_MESSAGE_SEVERITY_VERBOSE_BIT) {
+    if ((log_severities & XR_LOADER_LOG_MESSAGE_SEVERITY_VERBOSE_BIT) != 0u) {
         utils_severities |= XR_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT;
     }
-    if (log_severities & XR_LOADER_LOG_MESSAGE_SEVERITY_INFO_BIT) {
+    if ((log_severities & XR_LOADER_LOG_MESSAGE_SEVERITY_INFO_BIT) != 0u) {
         utils_severities |= XR_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT;
     }
-    if (log_severities & XR_LOADER_LOG_MESSAGE_SEVERITY_WARNING_BIT) {
+    if ((log_severities & XR_LOADER_LOG_MESSAGE_SEVERITY_WARNING_BIT) != 0u) {
         utils_severities |= XR_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT;
     }
-    if (log_severities & XR_LOADER_LOG_MESSAGE_SEVERITY_ERROR_BIT) {
+    if ((log_severities & XR_LOADER_LOG_MESSAGE_SEVERITY_ERROR_BIT) != 0u) {
         utils_severities |= XR_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
     }
     return utils_severities;
@@ -148,13 +148,13 @@ XrDebugUtilsMessageSeverityFlagsEXT LoaderLogMessageSeveritiesToDebugUtilsMessag
 
 XrLoaderLogMessageTypeFlagBits DebugUtilsMessageTypesToLoaderLogMessageTypes(XrDebugUtilsMessageTypeFlagsEXT utils_types) {
     XrLoaderLogMessageTypeFlagBits log_types = 0UL;
-    if (utils_types & XR_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT) {
+    if ((utils_types & XR_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT) != 0u) {
         log_types |= XR_LOADER_LOG_MESSAGE_TYPE_GENERAL_BIT;
     }
-    if (utils_types & XR_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT) {
+    if ((utils_types & XR_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT) != 0u) {
         log_types |= XR_LOADER_LOG_MESSAGE_TYPE_SPECIFICATION_BIT;
     }
-    if (utils_types & XR_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT) {
+    if ((utils_types & XR_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT) != 0u) {
         log_types |= XR_LOADER_LOG_MESSAGE_TYPE_PERFORMANCE_BIT;
     }
     return log_types;
@@ -162,13 +162,13 @@ XrLoaderLogMessageTypeFlagBits DebugUtilsMessageTypesToLoaderLogMessageTypes(XrD
 
 XrDebugUtilsMessageTypeFlagsEXT LoaderLogMessageTypesToDebugUtilsMessageTypes(XrLoaderLogMessageTypeFlagBits log_types) {
     XrDebugUtilsMessageTypeFlagsEXT utils_types = 0UL;
-    if (log_types & XR_LOADER_LOG_MESSAGE_TYPE_GENERAL_BIT) {
+    if ((log_types & XR_LOADER_LOG_MESSAGE_TYPE_GENERAL_BIT) != 0u) {
         utils_types |= XR_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT;
     }
-    if (log_types & XR_LOADER_LOG_MESSAGE_TYPE_SPECIFICATION_BIT) {
+    if ((log_types & XR_LOADER_LOG_MESSAGE_TYPE_SPECIFICATION_BIT) != 0u) {
         utils_types |= XR_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT;
     }
-    if (log_types & XR_LOADER_LOG_MESSAGE_TYPE_PERFORMANCE_BIT) {
+    if ((log_types & XR_LOADER_LOG_MESSAGE_TYPE_PERFORMANCE_BIT) != 0u) {
         utils_types |= XR_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT;
     }
     return utils_types;

--- a/src/loader/loader_logger.cpp
+++ b/src/loader/loader_logger.cpp
@@ -17,26 +17,29 @@
 // Author: Mark Young <marky@lunarg.com>
 //
 
+#include "loader_logger.hpp"
+
+#include "extra_algorithms.h"
+#include "hex_and_handles.h"
+#include "loader_logger_recorders.hpp"
+#include "platform_utils.hpp"
+
+//! @todo can we remove this? Everything but Windows is using it only for includes that aren't needed in this file.
+#ifdef _WIN32
+#include "xr_dependencies.h"
+#endif
+
+#include <openxr/openxr.h>
 
 #include <algorithm>
-#include <iomanip>
-#include <iostream>
 #include <iterator>
 #include <memory>
+#include <mutex>
 #include <sstream>
 #include <string>
+#include <unordered_map>
+#include <utility>
 #include <vector>
-
-#include "xr_dependencies.h"
-#include <openxr/openxr.h>
-#include <openxr/openxr_platform.h>
-
-#include "hex_and_handles.h"
-#include "extra_algorithms.h"
-#include "loader_platform.hpp"
-#include "platform_utils.hpp"
-#include "loader_logger.hpp"
-#include "loader_logger_recorders.hpp"
 
 std::unique_ptr<LoaderLogger> LoaderLogger::_instance;
 std::once_flag LoaderLogger::_once_flag;

--- a/src/loader/loader_logger.cpp
+++ b/src/loader/loader_logger.cpp
@@ -50,6 +50,12 @@ std::string XrLoaderLogObjectInfo::ToString() const {
     return oss.str();
 }
 
+bool LoaderLogRecorder::LogDebugUtilsMessage(XrDebugUtilsMessageSeverityFlagsEXT /*message_severity*/,
+                                             XrDebugUtilsMessageTypeFlagsEXT /*message_type*/,
+                                             const XrDebugUtilsMessengerCallbackDataEXT* /*callback_data*/) {
+    return false;
+}
+
 void ObjectInfoCollection::AddObjectName(uint64_t object_handle, XrObjectType object_type, const std::string& object_name) {
     // If name is empty, we should erase it
     if (object_name.empty()) {

--- a/src/loader/loader_logger.hpp
+++ b/src/loader/loader_logger.hpp
@@ -120,7 +120,7 @@ class LoaderLogRecorder {
         _message_severities = message_severities;
         _message_types = message_types;
     }
-    virtual ~LoaderLogRecorder() {}
+    virtual ~LoaderLogRecorder() = default;
 
     XrLoaderLogType Type() { return _type; }
     uint64_t UniqueId() { return _unique_id; }

--- a/src/loader/loader_logger.hpp
+++ b/src/loader/loader_logger.hpp
@@ -139,9 +139,7 @@ class LoaderLogRecorder {
     // Extension-specific logging functions - defaults to do nothing.
     virtual bool LogDebugUtilsMessage(XrDebugUtilsMessageSeverityFlagsEXT message_severity,
                                       XrDebugUtilsMessageTypeFlagsEXT message_type,
-                                      const XrDebugUtilsMessengerCallbackDataEXT* callback_data) {
-        return false;
-    }
+                                      const XrDebugUtilsMessengerCallbackDataEXT* callback_data);
 
    protected:
     bool _active;

--- a/src/loader/loader_logger_recorders.cpp
+++ b/src/loader/loader_logger_recorders.cpp
@@ -29,7 +29,7 @@ namespace {
 class OstreamLoaderLogRecorder : public LoaderLogRecorder {
    public:
     OstreamLoaderLogRecorder(std::ostream& os, void* user_data, XrLoaderLogMessageSeverityFlags flags);
-    ~OstreamLoaderLogRecorder() {}
+    ~OstreamLoaderLogRecorder() override = default;
 
     bool LogMessage(XrLoaderLogMessageSeverityFlagBits message_severity, XrLoaderLogMessageTypeFlags message_type,
                     const XrLoaderLogMessengerCallbackData* callback_data) override;
@@ -42,7 +42,7 @@ class OstreamLoaderLogRecorder : public LoaderLogRecorder {
 class DebugUtilsLogRecorder : public LoaderLogRecorder {
    public:
     DebugUtilsLogRecorder(const XrDebugUtilsMessengerCreateInfoEXT* create_info, XrDebugUtilsMessengerEXT debug_messenger);
-    ~DebugUtilsLogRecorder() {}
+    ~DebugUtilsLogRecorder() override = default;
 
     bool LogMessage(XrLoaderLogMessageSeverityFlagBits message_severity, XrLoaderLogMessageTypeFlags message_type,
                     const XrLoaderLogMessengerCallbackData* callback_data) override;

--- a/src/loader/loader_logger_recorders.cpp
+++ b/src/loader/loader_logger_recorders.cpp
@@ -17,10 +17,17 @@
 // Author: Mark Young <marky@lunarg.com>
 //
 
-#include <sstream>
-#include <iostream>
-
 #include "loader_logger_recorders.hpp"
+
+#include "hex_and_handles.h"
+#include "loader_logger.hpp"
+
+#include <openxr/openxr.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+#include <iostream>
 
 // Anonymous namespace to keep these types private
 namespace {

--- a/src/loader/loader_platform.hpp
+++ b/src/loader/loader_platform.hpp
@@ -21,8 +21,9 @@
 #pragma once
 
 #include <cassert>
-#include <string>
 #include <sstream>
+#include <string>
+
 #include "xr_dependencies.h"
 #include "platform_utils.hpp"
 

--- a/src/loader/loader_platform.hpp
+++ b/src/loader/loader_platform.hpp
@@ -71,7 +71,7 @@ static inline void LoaderPlatformLibraryClose(LoaderPlatformLibraryHandle librar
 
 static inline void *LoaderPlatformLibraryGetProcAddr(LoaderPlatformLibraryHandle library, const std::string &name) {
     assert(library);
-    assert(name.size() > 0);
+    assert(!name.empty());
     return dlsym(library, name.c_str());
 }
 

--- a/src/loader/manifest_file.cpp
+++ b/src/loader/manifest_file.cpp
@@ -21,21 +21,28 @@
 #define _CRT_SECURE_NO_WARNINGS
 #endif
 
-#include <cstring>
-#include <fstream>
-#include <iostream>
-#include <sstream>
-#include <stdexcept>
-#include <algorithm>
-#include <cmath>
+#include "manifest_file.hpp"
 
 #include "filesystem_utils.hpp"
 #include "loader_platform.hpp"
 #include "platform_utils.hpp"
-#include "manifest_file.hpp"
 #include "loader_logger.hpp"
-#include "loader_instance.hpp"
-#include "xr_generated_loader.hpp"
+
+#include <json/json.h>
+#include <openxr/openxr.h>
+
+#include <algorithm>
+#include <cstring>
+#include <fstream>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 // OpenXR paths and registry key locations
 #define OPENXR_RELATIVE_PATH "openxr/"
@@ -730,9 +737,8 @@ XrResult RuntimeManifestFile::FindManifestFiles(ManifestFileType type,
             }
             filename = filenames[0];
 #elif defined(XR_OS_LINUX)
-            const std::string relative_path = "openxr/"
-                + std::to_string(XR_VERSION_MAJOR(XR_CURRENT_API_VERSION))
-                + "/active_runtime.json";
+            const std::string relative_path =
+                "openxr/" + std::to_string(XR_VERSION_MAJOR(XR_CURRENT_API_VERSION)) + "/active_runtime.json";
             if (!FindXDGConfigFile(relative_path, filename)) {
                 LoaderLogger::LogErrorMessage(
                     "",

--- a/src/loader/manifest_file.cpp
+++ b/src/loader/manifest_file.cpp
@@ -410,7 +410,7 @@ static void ReadRuntimeDataFilesInRegistry(ManifestFileType type, const std::str
             warning_message += default_runtime_value_name;
             LoaderLogger::LogWarningMessage("", warning_message);
         } else {
-            AddFilesInPath(type, wide_to_utf8(value_w), false, manifest_files);
+            AddFilesInPath(wide_to_utf8(value_w), false, manifest_files);
         }
     } catch (...) {
         LoaderLogger::LogErrorMessage("", "ReadLayerDataFilesInRegistry - unknown error occurred");
@@ -456,7 +456,7 @@ static void ReadLayerDataFilesInRegistry(ManifestFileType type, const std::strin
                    (rtn_value = RegEnumValueW(hkey, key_index++, name_w, &name_size, NULL, NULL, (LPBYTE)&value, &value_size))) {
                 if (value_size == sizeof(value) && value == 0) {
                     const std::string filename = wide_to_utf8(name_w);
-                    AddFilesInPath(type, filename, false, manifest_files);
+                    AddFilesInPath(filename, false, manifest_files);
                 }
                 // Reset some items for the next loop
                 name_size = 1023;

--- a/src/loader/manifest_file.cpp
+++ b/src/loader/manifest_file.cpp
@@ -59,9 +59,9 @@ static inline bool StringEndsWith(std::string const &value, std::string const &e
 }
 
 // If the file found is a manifest file name, add it to the out_files manifest list.
-static void AddIfJson(ManifestFileType type, const std::string &full_file, std::vector<std::string> &manifest_files) {
+static void AddIfJson(const std::string &full_file, std::vector<std::string> &manifest_files) {
     try {
-        if (0 == full_file.size() || !StringEndsWith(full_file, ".json")) {
+        if (full_file.empty() || !StringEndsWith(full_file, ".json")) {
             return;
         }
         manifest_files.push_back(full_file);
@@ -74,7 +74,7 @@ static void AddIfJson(ManifestFileType type, const std::string &full_file, std::
 // Check the current path for any manifest files.  If the provided search_path is a directory, look for
 // all included JSON files in that directory.  Otherwise, just check the provided search_path which should
 // be a single filename.
-static void CheckAllFilesInThePath(ManifestFileType type, const std::string &search_path, bool is_directory_list,
+static void CheckAllFilesInThePath(const std::string &search_path, bool is_directory_list,
                                    std::vector<std::string> &manifest_files) {
     try {
         if (FileSysUtilsPathExists(search_path)) {
@@ -83,7 +83,7 @@ static void CheckAllFilesInThePath(ManifestFileType type, const std::string &sea
                 // If the file exists, try to add it
                 if (FileSysUtilsIsRegularFile(search_path)) {
                     FileSysUtilsGetAbsolutePath(search_path, absolute_path);
-                    AddIfJson(type, absolute_path, manifest_files);
+                    AddIfJson(absolute_path, manifest_files);
                 }
             } else {
                 std::vector<std::string> files;
@@ -94,7 +94,7 @@ static void CheckAllFilesInThePath(ManifestFileType type, const std::string &sea
                         if (!FileSysUtilsGetAbsolutePath(relative_path, absolute_path)) {
                             continue;
                         }
-                        AddIfJson(type, absolute_path, manifest_files);
+                        AddIfJson(absolute_path, manifest_files);
                     }
                 }
             }
@@ -108,8 +108,7 @@ static void CheckAllFilesInThePath(ManifestFileType type, const std::string &sea
 // Add all manifest files in the provided paths to the manifest_files list.  If search_path
 // is made up of directory listings (versus direct manifest file names) search each path for
 // any manifest files.
-static void AddFilesInPath(ManifestFileType type, const std::string &search_path, bool is_directory_list,
-                           std::vector<std::string> &manifest_files) {
+static void AddFilesInPath(const std::string &search_path, bool is_directory_list, std::vector<std::string> &manifest_files) {
     std::size_t last_found = 0;
     std::size_t found = search_path.find_first_of(PATH_SEPARATOR);
     std::string cur_search;
@@ -121,7 +120,7 @@ static void AddFilesInPath(ManifestFileType type, const std::string &search_path
             std::size_t length = found - last_found;
             cur_search = search_path.substr(last_found, length);
 
-            CheckAllFilesInThePath(type, cur_search, is_directory_list, manifest_files);
+            CheckAllFilesInThePath(cur_search, is_directory_list, manifest_files);
 
             // This works around issue if multiple path separator follow each other directly.
             last_found = found;
@@ -134,7 +133,7 @@ static void AddFilesInPath(ManifestFileType type, const std::string &search_path
         // If there's something remaining in the string, copy it over
         if (last_found < search_path.size()) {
             cur_search = search_path.substr(last_found);
-            CheckAllFilesInThePath(type, cur_search, is_directory_list, manifest_files);
+            CheckAllFilesInThePath(cur_search, is_directory_list, manifest_files);
         }
     } catch (...) {
         LoaderLogger::LogErrorMessage("", "AddFilesInPath - unknown error occurred");
@@ -145,7 +144,7 @@ static void AddFilesInPath(ManifestFileType type, const std::string &search_path
 // Copy all paths listed in the cur_path string into output_path and append the appropriate relative_path onto the end of each.
 static void CopyIncludedPaths(bool is_directory_list, const std::string &cur_path, const std::string &relative_path,
                               std::string &output_path) {
-    if (0 != cur_path.size()) {
+    if (!cur_path.empty()) {
         std::size_t last_found = 0;
         std::size_t found = cur_path.find_first_of(PATH_SEPARATOR);
 
@@ -187,11 +186,11 @@ static void ReadDataFilesInSearchPaths(ManifestFileType type, const std::string 
     bool is_directory_list = true;
     bool is_runtime = (type == MANIFEST_TYPE_RUNTIME);
     char *override_env = nullptr;
-    std::string override_path = "";
-    std::string search_path = "";
+    std::string override_path;
+    std::string search_path;
 
     try {
-        if (override_env_var.size() != 0) {
+        if (!override_env_var.empty()) {
 #ifndef XR_OS_WINDOWS
             if (geteuid() != getuid() || getegid() != getgid()) {
                 // Don't allow setuid apps to use the env var:
@@ -210,7 +209,7 @@ static void ReadDataFilesInSearchPaths(ManifestFileType type, const std::string 
             }
         }
 
-        if (nullptr != override_env && override_path.size() != 0) {
+        if (nullptr != override_env && !override_path.empty()) {
             CopyIncludedPaths(is_directory_list, override_path, "", search_path);
             PlatformUtilsFreeEnv(override_env);
             override_active = true;
@@ -276,7 +275,7 @@ static void ReadDataFilesInSearchPaths(ManifestFileType type, const std::string 
         }
 
         // Now, parse the paths and add any manifest files found in them.
-        AddFilesInPath(type, search_path, is_directory_list, manifest_files);
+        AddFilesInPath(search_path, is_directory_list, manifest_files);
     } catch (...) {
         LoaderLogger::LogErrorMessage("", "ReadDataFilesInSearchPaths - unknown error occurred");
         throw;
@@ -292,27 +291,27 @@ static void ReadDataFilesInSearchPaths(ManifestFileType type, const std::string 
 static std::string GetXDGEnv(const char *name, const char *fallback_env, const char *fallback_path) {
     char *path = PlatformUtilsGetSecureEnv(name);
     std::string result;
-    if (path) {
+    if (path != nullptr) {
         result = path;
         PlatformUtilsFreeEnv(path);
         if (!result.empty()) {
             return result;
         }
     }
-    if (fallback_env) {
+    if (fallback_env != nullptr) {
         char *path = PlatformUtilsGetSecureEnv(fallback_env);
-        if (path) {
+        if (path != nullptr) {
             result = path;
             PlatformUtilsFreeEnv(path);
         }
         if (result.empty()) {
             return "";
         }
-        if (fallback_path) {
+        if (fallback_path != nullptr) {
             result += "/";
         }
     }
-    if (fallback_path) {
+    if (fallback_path != nullptr) {
         result += fallback_path;
     }
     return result;
@@ -325,29 +324,39 @@ static bool FindXDGConfigFile(const std::string &relative_path, std::string &out
     if (!out.empty()) {
         out += "/";
         out += relative_path;
-        if (FileSysUtilsPathExists(out)) return true;
+        if (FileSysUtilsPathExists(out)) {
+            return true;
+        }
     }
 
     std::istringstream iss(GetXDGEnv("XDG_CONFIG_DIRS", nullptr, FALLBACK_CONFIG_DIRS));
-    std::string path;    
+    std::string path;
     while (std::getline(iss, path, PATH_SEPARATOR)) {
-        if (path.empty()) continue;
+        if (path.empty()) {
+            continue;
+        }
         out = path;
         out += "/";
         out += relative_path;
-        if (FileSysUtilsPathExists(out)) return true;
+        if (FileSysUtilsPathExists(out)) {
+            return true;
+        }
     }
 
     out = SYSCONFDIR;
     out += "/";
     out += relative_path;
-    if (FileSysUtilsPathExists(out)) return true;
+    if (FileSysUtilsPathExists(out)) {
+        return true;
+    }
 
 #if defined(EXTRASYSCONFDIR)
     out = EXTRASYSCONFDIR;
     out += "/";
     out += relative_path;
-    if (FileSysUtilsPathExists(out)) return true;
+    if (FileSysUtilsPathExists(out)) {
+        return true;
+    }
 #endif
 
     out.clear();
@@ -455,7 +464,7 @@ static void ReadLayerDataFilesInRegistry(ManifestFileType type, const std::strin
 ManifestFile::ManifestFile(ManifestFileType type, const std::string &filename, const std::string &library_path)
     : _filename(filename), _type(type), _library_path(library_path) {}
 
-ManifestFile::~ManifestFile() {}
+ManifestFile::~ManifestFile() = default;
 
 bool ManifestFile::IsValidJson(Json::Value &root_node, JsonVersion &version) {
     try {
@@ -555,7 +564,7 @@ void ManifestFile::GetDeviceExtensionProperties(std::vector<XrExtensionPropertie
 
 const std::string &ManifestFile::GetFunctionName(const std::string &func_name) {
     try {
-        if (_functions_renamed.size() > 0) {
+        if (!_functions_renamed.empty()) {
             auto found = _functions_renamed.find(func_name);
             if (found != _functions_renamed.end()) {
                 return found->second;
@@ -571,9 +580,10 @@ const std::string &ManifestFile::GetFunctionName(const std::string &func_name) {
 RuntimeManifestFile::RuntimeManifestFile(const std::string &filename, const std::string &library_path)
     : ManifestFile(MANIFEST_TYPE_RUNTIME, filename, library_path) {}
 
-RuntimeManifestFile::~RuntimeManifestFile() {}
+RuntimeManifestFile::~RuntimeManifestFile() = default;
 
-void RuntimeManifestFile::CreateIfValid(std::string filename, std::vector<std::unique_ptr<RuntimeManifestFile>> &manifest_files) {
+void RuntimeManifestFile::CreateIfValid(std::string const &filename,
+                                        std::vector<std::unique_ptr<RuntimeManifestFile>> &manifest_files) {
     try {
         std::ifstream json_stream = std::ifstream(filename, std::ifstream::in);
         if (!json_stream.is_open()) {
@@ -617,7 +627,7 @@ void RuntimeManifestFile::CreateIfValid(std::string filename, std::vector<std::u
 
         // If the library_path variable has no directory symbol, it's just a file name and should be accessible on the
         // global library path.
-        if (lib_path.find("\\") != lib_path.npos || lib_path.find("/") != lib_path.npos) {
+        if (lib_path.find('\\') != std::string::npos || lib_path.find('/') != std::string::npos) {
             // If the library_path is an absolute path, just use that if it exists
             if (FileSysUtilsIsAbsolutePath(lib_path)) {
                 if (!FileSysUtilsPathExists(lib_path)) {
@@ -785,19 +795,14 @@ ApiLayerManifestFile::ApiLayerManifestFile(ManifestFileType type, const std::str
       _description(description),
       _implementation_version(implementation_version) {}
 
-ApiLayerManifestFile::~ApiLayerManifestFile() {}
+ApiLayerManifestFile::~ApiLayerManifestFile() = default;
 
-void ApiLayerManifestFile::CreateIfValid(ManifestFileType type, std::string filename,
+void ApiLayerManifestFile::CreateIfValid(ManifestFileType type, std::string const &filename,
                                          std::vector<std::unique_ptr<ApiLayerManifestFile>> &manifest_files) {
     try {
         std::ifstream json_stream = std::ifstream(filename, std::ifstream::in);
         Json::Reader reader;
         Json::Value root_node = Json::nullValue;
-        JsonVersion file_version = {};
-        JsonVersion api_version = {};
-        std::string layer_name = "";
-        std::string library_path = "";
-        std::string description = "";
         if (!reader.parse(json_stream, root_node, false) || root_node.isNull()) {
             std::string error_message = "ApiLayerManifestFile::CreateIfValid failed to parse ";
             error_message += filename;
@@ -805,6 +810,7 @@ void ApiLayerManifestFile::CreateIfValid(ManifestFileType type, std::string file
             LoaderLogger::LogErrorMessage("", error_message);
             return;
         }
+        JsonVersion file_version = {};
         if (!ManifestFile::IsValidJson(root_node, file_version)) {
             std::string error_message = "ApiLayerManifestFile::CreateIfValid isValidJson indicates ";
             error_message += filename;
@@ -841,7 +847,7 @@ void ApiLayerManifestFile::CreateIfValid(ManifestFileType type, std::string file
             if (!layer_root_node["enable_environment"].isNull() && layer_root_node["enable_environment"].isString()) {
                 char *enable_val = PlatformUtilsGetEnv(layer_root_node["enable_environment"].asString().c_str());
                 // If it's not set in the environment, disable the layer
-                if (NULL == enable_val) {
+                if (nullptr == enable_val) {
                     enabled = false;
                 }
                 PlatformUtilsFreeEnv(enable_val);
@@ -849,7 +855,7 @@ void ApiLayerManifestFile::CreateIfValid(ManifestFileType type, std::string file
             // Check for the disable environment variable, which must be provided in the JSON
             char *disable_val = PlatformUtilsGetEnv(layer_root_node["disable_environment"].asString().c_str());
             // If the envar is set, disable the layer. Disable envar overrides enable above
-            if (NULL != disable_val) {
+            if (nullptr != disable_val) {
                 enabled = false;
             }
             PlatformUtilsFreeEnv(disable_val);
@@ -863,8 +869,9 @@ void ApiLayerManifestFile::CreateIfValid(ManifestFileType type, std::string file
                 return;
             }
         }
-        layer_name = layer_root_node["name"].asString();
+        std::string layer_name = layer_root_node["name"].asString();
         std::string api_version_string = layer_root_node["api_version"].asString();
+        JsonVersion api_version = {};
         sscanf(api_version_string.c_str(), "%d.%d", &api_version.major, &api_version.minor);
         api_version.patch = 0;
 
@@ -877,11 +884,11 @@ void ApiLayerManifestFile::CreateIfValid(ManifestFileType type, std::string file
         }
 
         uint32_t implementation_version = atoi(layer_root_node["implementation_version"].asString().c_str());
-        library_path = layer_root_node["library_path"].asString();
+        std::string library_path = layer_root_node["library_path"].asString();
 
         // If the library_path variable has no directory symbol, it's just a file name and should be accessible on the
         // global library path.
-        if (library_path.find("\\") != library_path.npos || library_path.find("/") != library_path.npos) {
+        if (library_path.find('\\') != std::string::npos || library_path.find('/') != std::string::npos) {
             // If the library_path is an absolute path, just use that if it exists
             if (FileSysUtilsIsAbsolutePath(library_path)) {
                 if (!FileSysUtilsPathExists(library_path)) {
@@ -911,6 +918,7 @@ void ApiLayerManifestFile::CreateIfValid(ManifestFileType type, std::string file
             }
         }
 
+        std::string description;
         if (!layer_root_node["description"].isNull() && layer_root_node["description"].isString()) {
             description = layer_root_node["description"].asString();
         }
@@ -1008,7 +1016,7 @@ XrResult ApiLayerManifestFile::FindManifestFiles(ManifestFileType type,
     try {
         std::string relative_path;
         std::string override_env_var;
-        std::string registry_location = "";
+        std::string registry_location;
 
         // Add the appropriate top-level folders for the relative path.  These should be
         // the string "openxr/" followed by the API major version as a string.

--- a/src/loader/manifest_file.cpp
+++ b/src/loader/manifest_file.cpp
@@ -701,7 +701,7 @@ void RuntimeManifestFile::CreateIfValid(std::string const &filename,
         }
 
         Json::Value funcs_renamed = runtime_root_node["functions"];
-        if (!funcs_renamed.isNull() && funcs_renamed.size() > 0) {
+        if (!funcs_renamed.isNull() && !funcs_renamed.empty()) {
             for (Json::ValueIterator func_it = funcs_renamed.begin(); func_it != funcs_renamed.end(); ++func_it) {
                 if (!(*func_it).isString()) {
                     std::string warning_message = "RuntimeManifestFile::CreateIfValid ";
@@ -968,7 +968,7 @@ void ApiLayerManifestFile::CreateIfValid(ManifestFileType type, std::string cons
         }
 
         Json::Value funcs_renamed = layer_root_node["functions"];
-        if (!funcs_renamed.isNull() && funcs_renamed.size() > 0) {
+        if (!funcs_renamed.isNull() && !funcs_renamed.empty()) {
             for (Json::ValueIterator func_it = funcs_renamed.begin(); func_it != funcs_renamed.end(); ++func_it) {
                 if (!(*func_it).isString()) {
                     std::string warning_message = "ApiLayerManifestFile::CreateIfValid ";

--- a/src/loader/manifest_file.hpp
+++ b/src/loader/manifest_file.hpp
@@ -19,16 +19,16 @@
 
 #pragma once
 
+#include <openxr/openxr.h>
+
 #include <memory>
 #include <string>
 #include <vector>
 #include <unordered_map>
 
-#include "xr_dependencies.h"
-#include <openxr/openxr.h>
-#include <openxr/openxr_platform.h>
-
-#include <json/json.h>
+namespace Json {
+class Value;
+}
 
 enum ManifestFileType {
     MANIFEST_TYPE_UNDEFINED = 0,

--- a/src/loader/manifest_file.hpp
+++ b/src/loader/manifest_file.hpp
@@ -84,8 +84,8 @@ class RuntimeManifestFile : public ManifestFile {
     static XrResult FindManifestFiles(ManifestFileType type, std::vector<std::unique_ptr<RuntimeManifestFile>> &manifest_files);
 
     RuntimeManifestFile(const std::string &filename, const std::string &library_path);
-    virtual ~RuntimeManifestFile();
-    static void CreateIfValid(std::string filename, std::vector<std::unique_ptr<RuntimeManifestFile>> &manifest_files);
+    ~RuntimeManifestFile() override;
+    static void CreateIfValid(std::string const &filename, std::vector<std::unique_ptr<RuntimeManifestFile>> &manifest_files);
 
     // We don't want any copy constructors
     RuntimeManifestFile &operator=(const RuntimeManifestFile &manifest_file) = delete;
@@ -101,8 +101,8 @@ class ApiLayerManifestFile : public ManifestFile {
     ApiLayerManifestFile(ManifestFileType type, const std::string &filename, const std::string &layer_name,
                          const std::string &description, const JsonVersion &api_version, const uint32_t &implementation_version,
                          const std::string &library_path);
-    virtual ~ApiLayerManifestFile();
-    static void CreateIfValid(ManifestFileType type, std::string filename,
+    ~ApiLayerManifestFile() override;
+    static void CreateIfValid(ManifestFileType type, std::string const &filename,
                               std::vector<std::unique_ptr<ApiLayerManifestFile>> &manifest_files);
 
     // We don't want any copy constructors

--- a/src/loader/manifest_file.hpp
+++ b/src/loader/manifest_file.hpp
@@ -87,8 +87,9 @@ class RuntimeManifestFile : public ManifestFile {
     ~RuntimeManifestFile() override;
     static void CreateIfValid(std::string const &filename, std::vector<std::unique_ptr<RuntimeManifestFile>> &manifest_files);
 
-    // We don't want any copy constructors
-    RuntimeManifestFile &operator=(const RuntimeManifestFile &manifest_file) = delete;
+    // Non-copyable
+    RuntimeManifestFile(const RuntimeManifestFile &) = delete;
+    RuntimeManifestFile &operator=(const RuntimeManifestFile &) = delete;
 };
 
 // ApiLayerManifestFile class -
@@ -105,11 +106,12 @@ class ApiLayerManifestFile : public ManifestFile {
     static void CreateIfValid(ManifestFileType type, std::string const &filename,
                               std::vector<std::unique_ptr<ApiLayerManifestFile>> &manifest_files);
 
-    // We don't want any copy constructors
-    ApiLayerManifestFile &operator=(const ApiLayerManifestFile &manifest_file) = delete;
-
     std::string LayerName() { return _layer_name; }
     XrApiLayerProperties GetApiLayerProperties();
+
+    // Non-copyable
+    ApiLayerManifestFile(const ApiLayerManifestFile &) = delete;
+    ApiLayerManifestFile &operator=(const ApiLayerManifestFile &) = delete;
 
    private:
     JsonVersion _api_version;

--- a/src/loader/runtime_interface.cpp
+++ b/src/loader/runtime_interface.cpp
@@ -16,16 +16,24 @@
 //
 // Author: Mark Young <marky@lunarg.com>
 //
-#include <cstring>
-#include <fstream>
-#include <iostream>
-#include <sstream>
+
+#include "runtime_interface.hpp"
 
 #include "manifest_file.hpp"
-#include "runtime_interface.hpp"
-#include "xr_generated_loader.hpp"
 #include "loader_interfaces.h"
 #include "loader_logger.hpp"
+#include "loader_platform.hpp"
+#include "xr_generated_dispatch_table.h"
+
+#include <openxr/openxr.h>
+
+#include <cstring>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 std::unique_ptr<RuntimeInterface> RuntimeInterface::_single_runtime_interface;
 uint32_t RuntimeInterface::_single_runtime_count = 0;

--- a/src/loader/runtime_interface.cpp
+++ b/src/loader/runtime_interface.cpp
@@ -66,7 +66,7 @@ XrResult RuntimeInterface::LoadRuntime(const std::string& openxr_command) {
 
                 // Get and settle on an runtime interface version (using any provided name if required).
                 std::string function_name = manifest_file->GetFunctionName("xrNegotiateLoaderRuntimeInterface");
-                PFN_xrNegotiateLoaderRuntimeInterface negotiate = reinterpret_cast<PFN_xrNegotiateLoaderRuntimeInterface>(
+                auto negotiate = reinterpret_cast<PFN_xrNegotiateLoaderRuntimeInterface>(
                     LoaderPlatformLibraryGetProcAddr(runtime_library, function_name));
 
                 // Loader info for negotiation
@@ -145,8 +145,9 @@ XrResult RuntimeInterface::LoadRuntime(const std::string& openxr_command) {
                 std::vector<std::string> supported_extensions;
                 std::vector<XrExtensionProperties> extension_properties;
                 _single_runtime_interface->GetInstanceExtensionProperties(extension_properties);
+                supported_extensions.reserve(extension_properties.size());
                 for (XrExtensionProperties ext_prop : extension_properties) {
-                    supported_extensions.push_back(ext_prop.extensionName);
+                    supported_extensions.emplace_back(ext_prop.extensionName);
                 }
                 _single_runtime_interface->SetSupportedExtensions(supported_extensions);
 
@@ -255,7 +256,7 @@ void RuntimeInterface::GetInstanceExtensionProperties(std::vector<XrExtensionPro
             for (size_t prop = 0; prop < props_count; ++prop) {
                 // If we find it, then make sure the spec version matches that of the runtime instead of the
                 // layer.
-                if (!strcmp(extension_properties[prop].extensionName, runtime_extension_properties[ext].extensionName)) {
+                if (strcmp(extension_properties[prop].extensionName, runtime_extension_properties[ext].extensionName) == 0) {
                     // Make sure the spec version used is the runtime's
                     extension_properties[prop].specVersion = runtime_extension_properties[ext].specVersion;
                     found = true;
@@ -354,7 +355,7 @@ void RuntimeInterface::SetSupportedExtensions(std::vector<std::string>& supporte
 bool RuntimeInterface::SupportsExtension(const std::string& extension_name) {
     bool found_prop = false;
     try {
-        for (std::string supported_extension : _supported_extensions) {
+        for (const std::string& supported_extension : _supported_extensions) {
             if (supported_extension == extension_name) {
                 found_prop = true;
                 break;

--- a/src/loader/runtime_interface.hpp
+++ b/src/loader/runtime_interface.hpp
@@ -25,6 +25,8 @@
 #include <mutex>
 #include <memory>
 
+#include <openxr/openxr.h>
+
 #include "loader_platform.hpp"
 #include "xr_generated_dispatch_table.h"
 
@@ -47,11 +49,15 @@ class RuntimeInterface {
     bool TrackDebugMessenger(XrInstance instance, XrDebugUtilsMessengerEXT messenger);
     void ForgetDebugMessenger(XrDebugUtilsMessengerEXT messenger);
 
-   private:
+    // No default construction
     RuntimeInterface() = delete;
+
+    // Non-copyable
     RuntimeInterface(const RuntimeInterface&) = delete;
-    RuntimeInterface(LoaderPlatformLibraryHandle runtime_library, PFN_xrGetInstanceProcAddr get_instant_proc_addr);
     RuntimeInterface& operator=(const RuntimeInterface&) = delete;
+
+   private:
+    RuntimeInterface(LoaderPlatformLibraryHandle runtime_library, PFN_xrGetInstanceProcAddr get_instant_proc_addr);
     void SetSupportedExtensions(std::vector<std::string>& supported_extensions);
 
     static std::unique_ptr<RuntimeInterface> _single_runtime_interface;

--- a/src/loader/runtime_interface.hpp
+++ b/src/loader/runtime_interface.hpp
@@ -19,16 +19,17 @@
 
 #pragma once
 
+#include "loader_platform.hpp"
+
+#include <openxr/openxr.h>
+
 #include <string>
 #include <vector>
 #include <unordered_map>
 #include <mutex>
 #include <memory>
 
-#include <openxr/openxr.h>
-
-#include "loader_platform.hpp"
-#include "xr_generated_dispatch_table.h"
+struct XrGeneratedDispatchTable;
 
 class RuntimeInterface {
    public:

--- a/src/loader/runtime_interface.hpp
+++ b/src/loader/runtime_interface.hpp
@@ -40,7 +40,7 @@ class RuntimeInterface {
     static const XrGeneratedDispatchTable* GetDispatchTable(XrInstance instance);
     static const XrGeneratedDispatchTable* GetDebugUtilsMessengerDispatchTable(XrDebugUtilsMessengerEXT messenger);
 
-    void GetInstanceExtensionProperties(std::vector<XrExtensionProperties>& props);
+    void GetInstanceExtensionProperties(std::vector<XrExtensionProperties>& extension_properties);
     bool SupportsExtension(const std::string& extension_name);
     XrResult CreateInstance(const XrInstanceCreateInfo* info, XrInstance* instance);
     XrResult DestroyInstance(XrInstance instance);
@@ -48,7 +48,7 @@ class RuntimeInterface {
     void ForgetDebugMessenger(XrDebugUtilsMessengerEXT messenger);
 
    private:
-    RuntimeInterface();
+    RuntimeInterface() = delete;
     RuntimeInterface(const RuntimeInterface&) = delete;
     RuntimeInterface(LoaderPlatformLibraryHandle runtime_library, PFN_xrGetInstanceProcAddr get_instant_proc_addr);
     RuntimeInterface& operator=(const RuntimeInterface&) = delete;

--- a/src/scripts/api_dump_generator.py
+++ b/src/scripts/api_dump_generator.py
@@ -105,21 +105,24 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
         preamble = ''
         if self.genOpts.filename == 'xr_generated_api_dump.hpp':
             preamble += '#pragma once\n\n'
-            preamble += '#include <string>\n'
-            preamble += '#include <vector>\n'
-            preamble += '#include <tuple>\n\n'
             preamble += '#include "api_layer_platform_defines.h"\n'
             preamble += '#include <openxr/openxr.h>\n'
             preamble += '#include <openxr/openxr_platform.h>\n\n'
-            preamble += '#include "xr_generated_dispatch_table.h"\n'
+            preamble += '#include <mutex>\n'
+            preamble += '#include <string>\n'
+            preamble += '#include <tuple>\n'
+            preamble += '#include <unordered_map>\n'
+            preamble += '#include <vector>\n\n'
+            preamble += 'struct XrGeneratedDispatchTable;\n\n'
         elif self.genOpts.filename == 'xr_generated_api_dump.cpp':
+            preamble += '#include "xr_generated_api_dump.hpp"\n'
+            preamble += '#include "xr_generated_dispatch_table.h"\n'
+            preamble += '#include "hex_and_handles.h"\n\n'
             preamble += '#include <cstring>\n'
             preamble += '#include <mutex>\n'
             preamble += '#include <sstream>\n'
             preamble += '#include <iomanip>\n'
             preamble += '#include <unordered_map>\n\n'
-            preamble += '#include "xr_generated_api_dump.hpp"\n'
-            preamble += '#include "hex_and_handles.h"\n'
         write(preamble, file=self.outFile)
 
     # Write out all the information for the appropriate file,

--- a/src/scripts/api_dump_generator.py
+++ b/src/scripts/api_dump_generator.py
@@ -411,8 +411,8 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
             write_string += self.writeIndent(indent)
             write_string += 'oss_%s << std::nouppercase;\n' % int_short_param_name
             write_string += self.writeIndent(indent)
-            write_string += 'contents.push_back(std::make_tuple("%s", %s' % (full_type, description)
-            write_string += ', oss_%s.str()));\n' % int_short_param_name
+            write_string += 'contents.emplace_back("%s", %s' % (full_type, description)
+            write_string += ', oss_%s.str());\n' % int_short_param_name
             indent = indent - 1
             write_string += self.writeIndent(indent)
             write_string += '}\n'
@@ -433,8 +433,8 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
             write_string += self.writeIndent(indent)
             write_string += 'oss_%s << std::nouppercase;\n' % int_short_param_name
             write_string += self.writeIndent(indent)
-            write_string += 'contents.push_back(std::make_tuple("%s", %s' % (full_type, description)
-            write_string += ', oss_%s.str()));\n' % int_short_param_name
+            write_string += 'contents.emplace_back("%s", %s' % (full_type, description)
+            write_string += ', oss_%s.str());\n' % int_short_param_name
             indent = indent - 1
             write_string += self.writeIndent(indent)
             write_string += '}\n'
@@ -449,8 +449,8 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
                 write_string += '*' * pointer_count
             write_string += '%s).QuadPart );\n' % full_name
             write_string += self.writeIndent(indent)
-            write_string += 'contents.push_back(std::make_tuple("%s", %s' % (full_type, description)
-            write_string += ', oss_%s.str()));\n' % int_short_param_name
+            write_string += 'contents.emplace_back("%s", %s' % (full_type, description)
+            write_string += ', oss_%s.str());\n' % int_short_param_name
         elif base_type == 'timespec':
             # Unbeknownst to XR, this is actually a struct.
             write_string += self.writeIndent(indent)
@@ -470,9 +470,9 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
             write_string += '%s).tv_nsec << "s";\n' % full_name
 
             write_string += self.writeIndent(indent)
-            write_string += 'contents.push_back(std::make_tuple("%s", %s' % (
+            write_string += 'contents.emplace_back("%s", %s' % (
                 full_type, description)
-            write_string += ', oss_%s.str()));\n' % int_short_param_name
+            write_string += ', oss_%s.str());\n' % int_short_param_name
         else:
             if base_type == 'XrResult':
                 write_string += self.writeIndent(indent)
@@ -485,7 +485,7 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
                 write_string += self.writeIndent(indent)
                 write_string += '                                   %s, %s_string);\n' % (full_name, int_short_param_name)
                 write_string += self.writeIndent(indent)
-                write_string += 'contents.push_back(std::make_tuple("%s", %s, %s_string));\n' % (full_type, description, int_short_param_name)
+                write_string += 'contents.emplace_back("%s", %s, %s_string);\n' % (full_type, description, int_short_param_name)
                 write_string += self.writeIndent(indent - 1)
                 write_string += '} else {\n'
                 write_string += self.writeIndent(indent)
@@ -500,7 +500,7 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
                 write_string += self.writeIndent(indent)
                 write_string += '                                          %s, %s_string);\n' % (full_name, int_short_param_name)
                 write_string += self.writeIndent(indent)
-                write_string += 'contents.push_back(std::make_tuple("%s", %s, %s_string));\n' % (full_type, description, int_short_param_name)
+                write_string += 'contents.emplace_back("%s", %s, %s_string);\n' % (full_type, description, int_short_param_name)
                 write_string += self.writeIndent(indent - 1)
                 write_string += '} else {\n'
                 write_string += self.writeIndent(indent)
@@ -535,12 +535,12 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
                     write_string += '*' * pointer_count
                 write_string += '%s);\n' % full_name
                 write_string += self.writeIndent(indent)
-                write_string += 'contents.push_back(std::make_tuple("%s", %s' % (full_type, description)
-                write_string += ', oss_%s.str()));\n' % int_short_param_name
+                write_string += 'contents.emplace_back("%s", %s' % (full_type, description)
+                write_string += ', oss_%s.str());\n' % int_short_param_name
 
             else:
                 write_string += self.writeIndent(indent)
-                write_string += 'contents.push_back(std::make_tuple("%s", %s, ' % (full_type, description)
+                write_string += 'contents.emplace_back("%s", %s, ' % (full_type, description)
                 if not is_char:
                     write_string += 'std::to_string('
                 if can_dereference:
@@ -549,7 +549,7 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
                 # Close std::to_string
                 if not is_char:
                     write_string += ')'
-                write_string += '));\n'
+                write_string += ');\n'
 
             if base_type == 'XrResult' or base_type == 'XrStructureType':
                 indent = indent - 1
@@ -929,7 +929,7 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
             struct_union_check += self.writeIndent(1)
             struct_union_check += 'try {\n'
             struct_union_check += self.writeIndent(2)
-            struct_union_check += 'contents.push_back(std::make_tuple(type_string, prefix, PointerToHexString(value)));\n'
+            struct_union_check += 'contents.emplace_back(type_string, prefix, PointerToHexString(value));\n'
             struct_union_check += self.writeIndent(2)
             struct_union_check += 'if (is_pointer) {\n'
             struct_union_check += self.writeIndent(3)
@@ -992,7 +992,7 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
                 struct_union_check += self.writeIndent(indent)
                 struct_union_check += '// Fallback path - Just output generic information about the base struct\n'
             struct_union_check += self.writeIndent(indent)
-            struct_union_check += 'contents.push_back(std::make_tuple(type_string, prefix, PointerToHexString(value)));\n'
+            struct_union_check += 'contents.emplace_back(type_string, prefix, PointerToHexString(value));\n'
             struct_union_check += self.writeIndent(indent)
             struct_union_check += 'if (is_pointer) {\n'
             struct_union_check += self.writeIndent(indent + 1)
@@ -1021,7 +1021,7 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
         struct_union_check += 'bool ApiDumpDecodeNextChain(XrGeneratedDispatchTable* gen_dispatch_table, const void* value, std::string prefix,\n'
         struct_union_check += '                            std::vector<std::tuple<std::string, std::string, std::string>> &contents) {\n'
         struct_union_check += '    try {\n'
-        struct_union_check += '        contents.push_back(std::make_tuple("const void *", prefix, PointerToHexString(value)));\n'
+        struct_union_check += '        contents.emplace_back("const void *", prefix, PointerToHexString(value));\n'
         struct_union_check += '        if (nullptr == value) {\n'
         struct_union_check += '            return true;\n'
         struct_union_check += '        }\n'
@@ -1150,10 +1150,10 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
 
                 # Print out a tuple for the header
                 if has_return:
-                    generated_commands += '        contents.push_back(std::make_tuple("%s", "%s", ""));\n' % (
+                    generated_commands += '        contents.emplace_back("%s", "%s", "");\n' % (
                         cur_cmd.return_type.text, cur_cmd.name)
                 else:
-                    generated_commands += '        contents.push_back(std::make_tuple("void", "%s", ""));\n' % cur_cmd.name
+                    generated_commands += '        contents.emplace_back("void", "%s", "");\n' % cur_cmd.name
                 # Print out information for each parameter
                 for param in cur_cmd.params:
                     can_expand = False
@@ -1231,10 +1231,10 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
         generated_commands += '        std::string func_name = name;\n\n'
         generated_commands += '        // Generate output for this command\n'
         generated_commands += '        std::vector<std::tuple<std::string, std::string, std::string>> contents;\n'
-        generated_commands += '        contents.push_back(std::make_tuple("XrResult", "xrGetInstanceProcAddr", ""));\n'
-        generated_commands += '        contents.push_back(std::make_tuple("XrInstance", "instance", HandleToHexString(instance)));\n'
-        generated_commands += '        contents.push_back(std::make_tuple("const char*", "name", name));\n'
-        generated_commands += '        contents.push_back(std::make_tuple("PFN_xrVoidFunction*", "function", PointerToHexString(reinterpret_cast<const void*>(function))));\n'
+        generated_commands += '        contents.emplace_back("XrResult", "xrGetInstanceProcAddr", "");\n'
+        generated_commands += '        contents.emplace_back("XrInstance", "instance", HandleToHexString(instance));\n'
+        generated_commands += '        contents.emplace_back("const char*", "name", name);\n'
+        generated_commands += '        contents.emplace_back("PFN_xrVoidFunction*", "function", PointerToHexString(reinterpret_cast<const void*>(function)));\n'
         generated_commands += '        ApiDumpLayerRecordContent(contents);\n'
 
         count = 0

--- a/src/scripts/loader_source_generator.py
+++ b/src/scripts/loader_source_generator.py
@@ -346,7 +346,7 @@ class LoaderSourceOutputGenerator(AutomaticSourceOutputGenerator):
         result_to_str += self.writeIndent(indent)
         result_to_str += '// If we did not find it in the generated code, ask the runtime.\n'
         result_to_str += self.writeIndent(indent)
-        result_to_str += 'const XrGeneratedDispatchTable* dispatch_table = RuntimeInterface::GetRuntime().GetDispatchTable(instance);\n'
+        result_to_str += 'const auto* dispatch_table = RuntimeInterface::GetDispatchTable(instance);\n'
         return result_to_str
 
     # A special-case handling of the "StructureTypeToString" command.  Since we can actually
@@ -370,7 +370,7 @@ class LoaderSourceOutputGenerator(AutomaticSourceOutputGenerator):
         struct_to_str += self.writeIndent(indent)
         struct_to_str += '// If we did not find it in the generated code, ask the runtime.\n'
         struct_to_str += self.writeIndent(indent)
-        struct_to_str += 'const XrGeneratedDispatchTable* dispatch_table = RuntimeInterface::GetRuntime().GetDispatchTable(instance);\n'
+        struct_to_str += 'const auto* dispatch_table = RuntimeInterface::GetDispatchTable(instance);\n'
         return struct_to_str
 
     # Instantiate the unordered_maps and mutexes for each of the object types.  Also, output a utility

--- a/src/scripts/loader_source_generator.py
+++ b/src/scripts/loader_source_generator.py
@@ -174,23 +174,32 @@ class LoaderSourceOutputGenerator(AutomaticSourceOutputGenerator):
             preamble += '#include <unordered_map>\n'
             preamble += '#include <thread>\n'
             preamble += '#include <mutex>\n\n'
+            preamble += '#include "xr_dependencies.h"\n'
+            preamble += '#include "openxr/openxr.h"\n'
+            preamble += '#include "openxr/openxr_platform.h"\n\n'
             preamble += '#include "loader_interfaces.h"\n\n'
             preamble += '#include "loader_instance.hpp"\n\n'
 
         elif self.genOpts.filename == 'xr_generated_loader.cpp':
-            preamble += '#include <ios>\n'
-            preamble += '#include <sstream>\n'
-            preamble += '#include <cstring>\n'
-            preamble += '#include <string>\n\n'
-            preamble += '#include <algorithm>\n\n'
+            preamble += '#include "xr_generated_loader.hpp"\n\n'
+            preamble += '#include "api_layer_interface.hpp"\n'
+            preamble += '#include "hex_and_handles.h"\n'
+            preamble += '#include "loader_instance.hpp"\n'
+            preamble += '#include "loader_logger.hpp"\n'
+            preamble += '#include "loader_platform.hpp"\n'
+            preamble += '#include "runtime_interface.hpp"\n'
+            preamble += '#include "xr_generated_dispatch_table.h"\n'
+            preamble += '#include "xr_generated_utilities.h"\n\n'
+
             preamble += '#include "xr_dependencies.h"\n'
             preamble += '#include <openxr/openxr.h>\n'
             preamble += '#include <openxr/openxr_platform.h>\n\n'
-            preamble += '#include "loader_logger.hpp"\n'
-            preamble += '#include "xr_generated_loader.hpp"\n'
-            preamble += '#include "xr_generated_dispatch_table.h"\n'
-            preamble += '#include "xr_generated_utilities.h"\n'
-            preamble += '#include "api_layer_interface.hpp"\n'
+
+            preamble += '#include <cstring>\n'
+            preamble += '#include <memory>\n'
+            preamble += '#include <new>\n'
+            preamble += '#include <string>\n'
+            preamble += '#include <unordered_map>\n'
 
         write(preamble, file=self.outFile)
 

--- a/src/scripts/utility_source_generator.py
+++ b/src/scripts/utility_source_generator.py
@@ -124,25 +124,26 @@ class UtilitySourceOutputGenerator(AutomaticSourceOutputGenerator):
         preamble = ''
         if self.genOpts.filename == 'xr_generated_dispatch_table.h':
             preamble += '#pragma once\n'
+            preamble += '#include "xr_dependencies.h"\n'
+            preamble += '#include <openxr/openxr.h>\n'
+            preamble += '#include <openxr/openxr_platform.h>\n\n'
         elif self.genOpts.filename == 'xr_generated_dispatch_table.c':
             preamble += '#include "xr_dependencies.h"\n'
             preamble += '#include <openxr/openxr.h>\n'
             preamble += '#include <openxr/openxr_platform.h>\n\n'
             preamble += '#include "xr_generated_dispatch_table.h"\n'
         elif self.genOpts.filename == 'xr_generated_utilities.h':
-            preamble += '#ifndef XR_GENERATED_UTILITIES_HEADER_FILE\n'
-            preamble += '#define XR_GENERATED_UTILITIES_HEADER_FILE\n\n'
+            preamble += '#pragma once\n\n'
+            preamble += '#include <openxr/openxr.h>\n\n'
         elif self.genOpts.filename == 'xr_generated_utilities.c':
             preamble += '#ifdef _WIN32\n'
             preamble += '// Disable Windows warning about using strncpy_s instead of strncpy\n'
             preamble += '#define  _CRT_SECURE_NO_WARNINGS 1\n'
             preamble += '#endif // _WIN32\n\n'
+            preamble += '#include "xr_generated_utilities.h"\n\n'
+            preamble += '#include <openxr/openxr.h>\n\n'
             preamble += '#include <stdio.h>\n'
             preamble += '#include <string.h>\n\n'
-            preamble += '#include "xr_dependencies.h"\n'
-            preamble += '#include <openxr/openxr.h>\n'
-            preamble += '#include <openxr/openxr_platform.h>\n\n'
-            preamble += '#include "xr_generated_utilities.h"\n\n'
         write(preamble, file=self.outFile)
 
     # Write out all the information for the appropriate file,
@@ -178,7 +179,6 @@ class UtilitySourceOutputGenerator(AutomaticSourceOutputGenerator):
             file_data += '} // extern "C"\n'
             file_data += '#endif\n'
             file_data += self.outputUtilityVersionDefine()
-            file_data += '#endif // XR_GENERATED_UTILITIES_HEADER_FILE\n'
 
         elif self.genOpts.filename == 'xr_generated_utilities.c':
             file_data += '#ifdef __cplusplus\n'

--- a/src/scripts/validation_layer_generator.py
+++ b/src/scripts/validation_layer_generator.py
@@ -119,21 +119,44 @@ class ValidationSourceOutputGenerator(AutomaticSourceOutputGenerator):
         preamble = ''
         if self.genOpts.filename == 'xr_generated_core_validation.hpp':
             preamble += '#pragma once\n'
+
+            preamble += '#include "xr_generated_dispatch_table.h"\n'
+            preamble += '#include "validation_utils.h"\n'
+
+            preamble += '#include "api_layer_platform_defines.h"\n'
+            preamble += '#include "xr_dependencies.h"\n'
+            preamble += '#include <openxr/openxr.h>\n'
+            preamble += '#include <openxr/openxr_platform.h>\n\n'
+
             preamble += '#include <vector>\n'
             preamble += '#include <string>\n'
             preamble += '#include <unordered_map>\n'
             preamble += '#include <thread>\n'
             preamble += '#include <mutex>\n\n'
+        elif self.genOpts.filename == 'xr_generated_core_validation.cpp':
+            preamble += '#include "xr_generated_core_validation.hpp"\n'
+            preamble += '\n'
             preamble += '#include "api_layer_platform_defines.h"\n'
+            preamble += '#include "hex_and_handles.h"\n'
+            preamble += '#include "validation_utils.h"\n'
+            preamble += '#include "xr_dependencies.h"\n'
+            preamble += '#include "xr_generated_dispatch_table.h"\n'
+            preamble += '\n'
+
+            preamble += '#include "api_layer_platform_defines.h"\n'
+            preamble += '#include "xr_dependencies.h"\n'
             preamble += '#include <openxr/openxr.h>\n'
             preamble += '#include <openxr/openxr_platform.h>\n\n'
-            preamble += '#include "xr_generated_dispatch_table.h"\n'
-            preamble += '#include "validation_utils.h"\n'
-        elif self.genOpts.filename == 'xr_generated_core_validation.cpp':
-            preamble += '#include <sstream>\n'
+
+            preamble += '#include <algorithm>\n'
             preamble += '#include <cstring>\n'
-            preamble += '#include <algorithm>\n\n'
-            preamble += '#include "xr_generated_core_validation.hpp"\n'
+            preamble += '#include <memory>\n'
+            preamble += '#include <sstream>\n'
+            preamble += '#include <string>\n'
+            preamble += '#include <unordered_map>\n'
+            preamble += '#include <utility>\n'
+            preamble += '#include <vector>\n'
+            preamble += '\n'
         write(preamble, file=self.outFile)
 
     # Write out all the information for the appropriate file,
@@ -1936,7 +1959,7 @@ class ValidationSourceOutputGenerator(AutomaticSourceOutputGenerator):
                     struct_check += '}\n'
                     if child_struct.protect_value:
                         struct_check += '#endif // %s\n' % child_struct.protect_string
-                
+
                 struct_check += self.writeIndent(indent)
                 struct_check += 'InvalidStructureType(instance_info, command_name, objects_info, "%s",\n' % xr_struct.name
                 struct_check += self.writeIndent(indent)


### PR DESCRIPTION
A variety of cleanups prompted by running clang-tidy (and include-what-you-use) over the code in src. Should be mostly simple/small things - no major refactoring this time.