### PR TITLE
Make Loader Exception Free

### DIFF
--- a/doc/loader/OpenXR_loader_design.html
+++ b/doc/loader/OpenXR_loader_design.html
@@ -3856,12 +3856,6 @@ std::experimental::filesystem::path search_path;</code></pre>
 </div>
 </div>
 <div class="paragraph">
-<div class="title">Exceptions</div>
-<p>The OpenXR loader relies on throwing and catching C++ exceptions.  Adding code
-should take this into account and properly wrap executing code with a "try"/"catch"
-block.</p>
-</div>
-<div class="paragraph">
 <div class="title">Experimental Filesystem Usage</div>
 <p>In order to simplify the file management, especially with regards to loading JSON
 manifest files or finding dynamic library files, the experimental/filesystem is used.
@@ -3885,13 +3879,10 @@ find elements of this functionality with the prefix
 <pre class="highlight"><code class="language-cpp" data-lang="cpp">#include &lt;experimental/filesystem&gt;
 
 static void checkAllFilesInThePath(const std::string &amp;search_path) {
-    try {
     // If the file exists, try to add it
     if (std::experimental::filesystem::is_regular_file(search_path)) {
         std::experimental::filesystem::path absolute_path =
             std::experimental::filesystem::absolute(search_path);
-    }
-    } catch (...) {
     }
 }</code></pre>
 </div>
@@ -5092,7 +5083,6 @@ same <code>LoaderInstance*</code>.</p>
     XrSession*                                  session) {
     bool primary_locked = false;
     bool secondary_locked = false;
-    try {
     g_instance_mutex.lock();
     secondary_locked = true;
     LoaderInstance *loader_instance = g_instance_map[instance];
@@ -5122,25 +5112,6 @@ same <code>LoaderInstance*</code>.</p>
         }
     }
     return result;
-} catch (std::bad_alloc &amp;) {
-    if (primary_locked) {
-        g_session_mutex.unlock();
-    }
-    if (secondary_locked) {
-        g_instance_mutex.unlock();
-    }
-    LoaderLogger::LogErrorMessage("xrCreateSession", "xrCreateSession trampoline failed allocating memory");
-    return XR_ERROR_OUT_OF_MEMORY;
-    } catch (...) {
-        if (primary_locked) {
-            g_session_mutex.unlock();
-        }
-        if (secondary_locked) {
-            g_instance_mutex.unlock();
-        }
-        LoaderLogger::LogErrorMessage("xrCreateSession", "xrCreateSession trampoline encountered an unknown error");
-        return XR_ERROR_INITIALIZATION_FAILED;
-    }
 }</code></pre>
 </div>
 </div>
@@ -5158,7 +5129,6 @@ is called.</p>
     XrSession                                   session) {
     bool primary_locked = false;
     bool secondary_locked = false;
-    try {
     g_session_mutex.lock();
     secondary_locked = true;
     LoaderInstance *loader_instance = g_session_map[session];
@@ -5186,17 +5156,6 @@ is called.</p>
         primary_locked = false;
     }
     return result;
-    } catch (...) {
-        if (primary_locked) {
-            g_session_mutex.unlock();
-        }
-        if (secondary_locked) {
-            g_session_mutex.unlock();
-        }
-        LoaderLogger::LogErrorMessage("xrDestroySession", "xrDestroySession trampoline encountered an unknown error");
-        // NOTE: Most calls only allow XR_SUCCESS as a return code
-        return XR_SUCCESS;
-    }
 }</code></pre>
 </div>
 </div>

--- a/doc/loader/OpenXR_loader_design.html
+++ b/doc/loader/OpenXR_loader_design.html
@@ -3856,6 +3856,12 @@ std::experimental::filesystem::path search_path;</code></pre>
 </div>
 </div>
 <div class="paragraph">
+<div class="title">Exceptions</div>
+<p>The OpenXR loader relies on throwing and catching C++ exceptions.  Adding code
+should take this into account and properly wrap executing code with a "try"/"catch"
+block.</p>
+</div>
+<div class="paragraph">
 <div class="title">Experimental Filesystem Usage</div>
 <p>In order to simplify the file management, especially with regards to loading JSON
 manifest files or finding dynamic library files, the experimental/filesystem is used.
@@ -3879,10 +3885,13 @@ find elements of this functionality with the prefix
 <pre class="highlight"><code class="language-cpp" data-lang="cpp">#include &lt;experimental/filesystem&gt;
 
 static void checkAllFilesInThePath(const std::string &amp;search_path) {
-    // If the file exists, try to add it
-    if (std::experimental::filesystem::is_regular_file(search_path)) {
-        std::experimental::filesystem::path absolute_path =
-            std::experimental::filesystem::absolute(search_path);
+    try {
+        // If the file exists, try to add it
+        if (std::experimental::filesystem::is_regular_file(search_path)) {
+            std::experimental::filesystem::path absolute_path =
+                std::experimental::filesystem::absolute(search_path);
+        }
+    } catch (...) {
     }
 }</code></pre>
 </div>
@@ -5083,35 +5092,55 @@ same <code>LoaderInstance*</code>.</p>
     XrSession*                                  session) {
     bool primary_locked = false;
     bool secondary_locked = false;
-    g_instance_mutex.lock();
-    secondary_locked = true;
-    LoaderInstance *loader_instance = g_instance_map[instance];
-    g_instance_mutex.unlock();
-    secondary_locked = false;
-    if (nullptr == loader_instance) {
-        XrLoaderLogObjectInfo bad_object = {};
-        bad_object.type = XR_OBJECT_TYPE_INSTANCE;
-        bad_object.handle = reinterpret_cast&lt;uint64_t&amp;&gt;(instance);
-        std::vector&lt;XrLoaderLogObjectInfo&gt; loader_objects;
-        loader_objects.push_back(bad_object);
-        LoaderLogger::LogValidationErrorMessage("VUID-xrCreateSession-instance-parameter", "xrCreateSession",
-                                                "instance is not a valid XrInstance", loader_objects);
-        return XR_ERROR_HANDLE_INVALID;
-    }
-    const std::unique_ptr&lt;XrGeneratedDispatchTable&gt;&amp; dispatch_table = loader_instance-&gt;DispatchTable();
-    XrResult result = XR_SUCCESS;
-    result = dispatch_table-&gt;CreateSession(instance, createInfo, session);
-    if (XR_SUCCESS == result &amp;&amp; nullptr != session) {
-        auto exists = g_session_map.find(*session);
-        if (exists == g_session_map.end()) {
-            g_session_mutex.lock();
-            primary_locked = true;
-            g_session_map[*session] = loader_instance;
-            g_session_mutex.unlock();
-            primary_locked = false;
+    try {
+        g_instance_mutex.lock();
+        secondary_locked = true;
+        LoaderInstance *loader_instance = g_instance_map[instance];
+        g_instance_mutex.unlock();
+        secondary_locked = false;
+        if (nullptr == loader_instance) {
+            XrLoaderLogObjectInfo bad_object = {};
+            bad_object.type = XR_OBJECT_TYPE_INSTANCE;
+            bad_object.handle = reinterpret_cast&lt;uint64_t&amp;&gt;(instance);
+            std::vector&lt;XrLoaderLogObjectInfo&gt; loader_objects;
+            loader_objects.push_back(bad_object);
+            LoaderLogger::LogValidationErrorMessage("VUID-xrCreateSession-instance-parameter", "xrCreateSession",
+                                                    "instance is not a valid XrInstance", loader_objects);
+            return XR_ERROR_HANDLE_INVALID;
         }
+        const std::unique_ptr&lt;XrGeneratedDispatchTable&gt;&amp; dispatch_table = loader_instance-&gt;DispatchTable();
+        XrResult result = XR_SUCCESS;
+        result = dispatch_table-&gt;CreateSession(instance, createInfo, session);
+        if (XR_SUCCESS == result &amp;&amp; nullptr != session) {
+            auto exists = g_session_map.find(*session);
+            if (exists == g_session_map.end()) {
+                g_session_mutex.lock();
+                primary_locked = true;
+                g_session_map[*session] = loader_instance;
+                g_session_mutex.unlock();
+                primary_locked = false;
+            }
+        }
+        return result;
+    } catch (std::bad_alloc &amp;) {
+        if (primary_locked) {
+            g_session_mutex.unlock();
+        }
+        if (secondary_locked) {
+            g_instance_mutex.unlock();
+        }
+        LoaderLogger::LogErrorMessage("xrCreateSession", "xrCreateSession trampoline failed allocating memory");
+        return XR_ERROR_OUT_OF_MEMORY;
+    } catch (...) {
+        if (primary_locked) {
+            g_session_mutex.unlock();
+        }
+        if (secondary_locked) {
+            g_instance_mutex.unlock();
+        }
+        LoaderLogger::LogErrorMessage("xrCreateSession", "xrCreateSession trampoline encountered an unknown error");
+        return XR_ERROR_INITIALIZATION_FAILED;
     }
-    return result;
 }</code></pre>
 </div>
 </div>
@@ -5129,33 +5158,45 @@ is called.</p>
     XrSession                                   session) {
     bool primary_locked = false;
     bool secondary_locked = false;
-    g_session_mutex.lock();
-    secondary_locked = true;
-    LoaderInstance *loader_instance = g_session_map[session];
-    g_session_mutex.unlock();
-    secondary_locked = false;
-    if (nullptr == loader_instance) {
-        XrLoaderLogObjectInfo bad_object = {};
-        bad_object.type = XR_OBJECT_TYPE_SESSION;
-        bad_object.handle = reinterpret_cast&lt;uint64_t&amp;&gt;(session);
-        std::vector&lt;XrLoaderLogObjectInfo&gt; loader_objects;
-        loader_objects.push_back(bad_object);
-        LoaderLogger::LogValidationErrorMessage("VUID-xrDestroySession-session-parameter", "xrDestroySession",
-                                                "session is not a valid XrSession", loader_objects);
-        return XR_ERROR_HANDLE_INVALID;
-    }
-    const std::unique_ptr&lt;XrGeneratedDispatchTable&gt;&amp; dispatch_table = loader_instance-&gt;DispatchTable();
-    XrResult result = XR_SUCCESS;
-    result = dispatch_table-&gt;DestroySession(session);
-    auto exists = g_session_map.find(session);
-    if (exists != g_session_map.end()) {
+    try {
         g_session_mutex.lock();
-        primary_locked = true;
-        g_session_map.erase(session);
+        secondary_locked = true;
+        LoaderInstance *loader_instance = g_session_map[session];
         g_session_mutex.unlock();
-        primary_locked = false;
+        secondary_locked = false;
+        if (nullptr == loader_instance) {
+            XrLoaderLogObjectInfo bad_object = {};
+            bad_object.type = XR_OBJECT_TYPE_SESSION;
+            bad_object.handle = reinterpret_cast&lt;uint64_t&amp;&gt;(session);
+            std::vector&lt;XrLoaderLogObjectInfo&gt; loader_objects;
+            loader_objects.push_back(bad_object);
+            LoaderLogger::LogValidationErrorMessage("VUID-xrDestroySession-session-parameter", "xrDestroySession",
+                                                    "session is not a valid XrSession", loader_objects);
+            return XR_ERROR_HANDLE_INVALID;
+        }
+        const std::unique_ptr&lt;XrGeneratedDispatchTable&gt;&amp; dispatch_table = loader_instance-&gt;DispatchTable();
+        XrResult result = XR_SUCCESS;
+        result = dispatch_table-&gt;DestroySession(session);
+        auto exists = g_session_map.find(session);
+        if (exists != g_session_map.end()) {
+            g_session_mutex.lock();
+            primary_locked = true;
+            g_session_map.erase(session);
+            g_session_mutex.unlock();
+            primary_locked = false;
+        }
+        return result;
+    } catch (...) {
+        if (primary_locked) {
+            g_session_mutex.unlock();
+        }
+        if (secondary_locked) {
+            g_session_mutex.unlock();
+        }
+        LoaderLogger::LogErrorMessage("xrDestroySession", "xrDestroySession trampoline encountered an unknown error");
+        // NOTE: Most calls only allow XR_SUCCESS as a return code
+        return XR_SUCCESS;
     }
-    return result;
 }</code></pre>
 </div>
 </div>

--- a/doc/loader/OpenXR_loader_design.html
+++ b/doc/loader/OpenXR_loader_design.html
@@ -3886,11 +3886,11 @@ find elements of this functionality with the prefix
 
 static void checkAllFilesInThePath(const std::string &amp;search_path) {
     try {
-        // If the file exists, try to add it
-        if (std::experimental::filesystem::is_regular_file(search_path)) {
-            std::experimental::filesystem::path absolute_path =
-                std::experimental::filesystem::absolute(search_path);
-        }
+    // If the file exists, try to add it
+    if (std::experimental::filesystem::is_regular_file(search_path)) {
+        std::experimental::filesystem::path absolute_path =
+            std::experimental::filesystem::absolute(search_path);
+    }
     } catch (...) {
     }
 }</code></pre>
@@ -5093,44 +5093,44 @@ same <code>LoaderInstance*</code>.</p>
     bool primary_locked = false;
     bool secondary_locked = false;
     try {
-        g_instance_mutex.lock();
-        secondary_locked = true;
-        LoaderInstance *loader_instance = g_instance_map[instance];
-        g_instance_mutex.unlock();
-        secondary_locked = false;
-        if (nullptr == loader_instance) {
-            XrLoaderLogObjectInfo bad_object = {};
-            bad_object.type = XR_OBJECT_TYPE_INSTANCE;
-            bad_object.handle = reinterpret_cast&lt;uint64_t&amp;&gt;(instance);
-            std::vector&lt;XrLoaderLogObjectInfo&gt; loader_objects;
-            loader_objects.push_back(bad_object);
-            LoaderLogger::LogValidationErrorMessage("VUID-xrCreateSession-instance-parameter", "xrCreateSession",
-                                                    "instance is not a valid XrInstance", loader_objects);
-            return XR_ERROR_HANDLE_INVALID;
-        }
-        const std::unique_ptr&lt;XrGeneratedDispatchTable&gt;&amp; dispatch_table = loader_instance-&gt;DispatchTable();
-        XrResult result = XR_SUCCESS;
-        result = dispatch_table-&gt;CreateSession(instance, createInfo, session);
-        if (XR_SUCCESS == result &amp;&amp; nullptr != session) {
-            auto exists = g_session_map.find(*session);
-            if (exists == g_session_map.end()) {
-                g_session_mutex.lock();
-                primary_locked = true;
-                g_session_map[*session] = loader_instance;
-                g_session_mutex.unlock();
-                primary_locked = false;
-            }
-        }
-        return result;
-    } catch (std::bad_alloc &amp;) {
-        if (primary_locked) {
+    g_instance_mutex.lock();
+    secondary_locked = true;
+    LoaderInstance *loader_instance = g_instance_map[instance];
+    g_instance_mutex.unlock();
+    secondary_locked = false;
+    if (nullptr == loader_instance) {
+        XrLoaderLogObjectInfo bad_object = {};
+        bad_object.type = XR_OBJECT_TYPE_INSTANCE;
+        bad_object.handle = reinterpret_cast&lt;uint64_t&amp;&gt;(instance);
+        std::vector&lt;XrLoaderLogObjectInfo&gt; loader_objects;
+        loader_objects.push_back(bad_object);
+        LoaderLogger::LogValidationErrorMessage("VUID-xrCreateSession-instance-parameter", "xrCreateSession",
+                                                "instance is not a valid XrInstance", loader_objects);
+        return XR_ERROR_HANDLE_INVALID;
+    }
+    const std::unique_ptr&lt;XrGeneratedDispatchTable&gt;&amp; dispatch_table = loader_instance-&gt;DispatchTable();
+    XrResult result = XR_SUCCESS;
+    result = dispatch_table-&gt;CreateSession(instance, createInfo, session);
+    if (XR_SUCCESS == result &amp;&amp; nullptr != session) {
+        auto exists = g_session_map.find(*session);
+        if (exists == g_session_map.end()) {
+            g_session_mutex.lock();
+            primary_locked = true;
+            g_session_map[*session] = loader_instance;
             g_session_mutex.unlock();
+            primary_locked = false;
         }
-        if (secondary_locked) {
-            g_instance_mutex.unlock();
-        }
-        LoaderLogger::LogErrorMessage("xrCreateSession", "xrCreateSession trampoline failed allocating memory");
-        return XR_ERROR_OUT_OF_MEMORY;
+    }
+    return result;
+} catch (std::bad_alloc &amp;) {
+    if (primary_locked) {
+        g_session_mutex.unlock();
+    }
+    if (secondary_locked) {
+        g_instance_mutex.unlock();
+    }
+    LoaderLogger::LogErrorMessage("xrCreateSession", "xrCreateSession trampoline failed allocating memory");
+    return XR_ERROR_OUT_OF_MEMORY;
     } catch (...) {
         if (primary_locked) {
             g_session_mutex.unlock();
@@ -5159,33 +5159,33 @@ is called.</p>
     bool primary_locked = false;
     bool secondary_locked = false;
     try {
+    g_session_mutex.lock();
+    secondary_locked = true;
+    LoaderInstance *loader_instance = g_session_map[session];
+    g_session_mutex.unlock();
+    secondary_locked = false;
+    if (nullptr == loader_instance) {
+        XrLoaderLogObjectInfo bad_object = {};
+        bad_object.type = XR_OBJECT_TYPE_SESSION;
+        bad_object.handle = reinterpret_cast&lt;uint64_t&amp;&gt;(session);
+        std::vector&lt;XrLoaderLogObjectInfo&gt; loader_objects;
+        loader_objects.push_back(bad_object);
+        LoaderLogger::LogValidationErrorMessage("VUID-xrDestroySession-session-parameter", "xrDestroySession",
+                                                "session is not a valid XrSession", loader_objects);
+        return XR_ERROR_HANDLE_INVALID;
+    }
+    const std::unique_ptr&lt;XrGeneratedDispatchTable&gt;&amp; dispatch_table = loader_instance-&gt;DispatchTable();
+    XrResult result = XR_SUCCESS;
+    result = dispatch_table-&gt;DestroySession(session);
+    auto exists = g_session_map.find(session);
+    if (exists != g_session_map.end()) {
         g_session_mutex.lock();
-        secondary_locked = true;
-        LoaderInstance *loader_instance = g_session_map[session];
+        primary_locked = true;
+        g_session_map.erase(session);
         g_session_mutex.unlock();
-        secondary_locked = false;
-        if (nullptr == loader_instance) {
-            XrLoaderLogObjectInfo bad_object = {};
-            bad_object.type = XR_OBJECT_TYPE_SESSION;
-            bad_object.handle = reinterpret_cast&lt;uint64_t&amp;&gt;(session);
-            std::vector&lt;XrLoaderLogObjectInfo&gt; loader_objects;
-            loader_objects.push_back(bad_object);
-            LoaderLogger::LogValidationErrorMessage("VUID-xrDestroySession-session-parameter", "xrDestroySession",
-                                                    "session is not a valid XrSession", loader_objects);
-            return XR_ERROR_HANDLE_INVALID;
-        }
-        const std::unique_ptr&lt;XrGeneratedDispatchTable&gt;&amp; dispatch_table = loader_instance-&gt;DispatchTable();
-        XrResult result = XR_SUCCESS;
-        result = dispatch_table-&gt;DestroySession(session);
-        auto exists = g_session_map.find(session);
-        if (exists != g_session_map.end()) {
-            g_session_mutex.lock();
-            primary_locked = true;
-            g_session_map.erase(session);
-            g_session_mutex.unlock();
-            primary_locked = false;
-        }
-        return result;
+        primary_locked = false;
+    }
+    return result;
     } catch (...) {
         if (primary_locked) {
             g_session_mutex.unlock();

--- a/src/common/filesystem_utils.cpp
+++ b/src/common/filesystem_utils.cpp
@@ -97,81 +97,48 @@
 // We can use one of the C++ filesystem packages
 
 bool FileSysUtilsIsRegularFile(const std::string& path) {
-    try {
     return FS_PREFIX::is_regular_file(path);
-    } catch (...) {
-        return false;
-    }
 }
 
 bool FileSysUtilsIsDirectory(const std::string& path) {
-    try {
     return FS_PREFIX::is_directory(path);
-    } catch (...) {
-        return false;
-    }
 }
 
 bool FileSysUtilsPathExists(const std::string& path) {
-    try {
     return FS_PREFIX::exists(path);
-    } catch (...) {
-        return false;
-    }
 }
 
 bool FileSysUtilsIsAbsolutePath(const std::string& path) {
-    try {
     FS_PREFIX::path file_path(path);
     return file_path.is_absolute();
-    } catch (...) {
-        return false;
-    }
 }
 
 bool FileSysUtilsGetCurrentPath(std::string& path) {
-    try {
     FS_PREFIX::path cur_path = FS_PREFIX::current_path();
     path = cur_path.string();
     return true;
-    } catch (...) {
-    }
-    return false;
 }
 
 bool FileSysUtilsGetParentPath(const std::string& file_path, std::string& parent_path) {
-    try {
     FS_PREFIX::path path_var(file_path);
     parent_path = path_var.parent_path().string();
     return true;
-    } catch (...) {
-    }
-    return false;
 }
 
 bool FileSysUtilsGetAbsolutePath(const std::string& path, std::string& absolute) {
-    try {
     absolute = FS_PREFIX::absolute(path).string();
     return true;
-    } catch (...) {
-    }
-    return false;
 }
 
 bool FileSysUtilsCombinePaths(const std::string& parent, const std::string& child, std::string& combined) {
-    try {
     FS_PREFIX::path parent_path(parent);
     FS_PREFIX::path child_path(child);
     FS_PREFIX::path full_path = parent_path / child_path;
     combined = full_path.string();
     return true;
-    } catch (...) {
-    }
-    return false;
 }
 
 bool FileSysUtilsParsePathList(std::string& path_list, std::vector<std::string>& paths) {
-    try {
     std::string::size_type start = 0;
     std::string::size_type location = path_list.find(PATH_SEPARATOR);
     while (location != std::string::npos) {
@@ -181,20 +148,13 @@ bool FileSysUtilsParsePathList(std::string& path_list, std::vector<std::string>&
     }
     paths.push_back(path_list.substr(start, location));
     return true;
-    } catch (...) {
-    }
-    return false;
 }
 
 bool FileSysUtilsFindFilesInPath(const std::string& path, std::vector<std::string>& files) {
-    try {
     for (auto& dir_iter : FS_PREFIX::directory_iterator(path)) {
         files.push_back(dir_iter.path().filename().string());
     }
     return true;
-    } catch (...) {
-    }
-    return false;
 }
 
 #elif defined(XR_OS_WINDOWS)
@@ -203,78 +163,53 @@ bool FileSysUtilsFindFilesInPath(const std::string& path, std::vector<std::strin
 #include <shlwapi.h>
 
 bool FileSysUtilsIsRegularFile(const std::string& path) {
-    try {
     return (1 != PathIsDirectoryW(utf8_to_wide(path).c_str()));
-    } catch (...) {
-        return false;
-    }
 }
 
 bool FileSysUtilsIsDirectory(const std::string& path) {
-    try {
     return (1 == PathIsDirectoryW(utf8_to_wide(path).c_str()));
-    } catch (...) {
-        return false;
-    }
 }
 
 bool FileSysUtilsPathExists(const std::string& path) {
-    try {
     return (1 == PathFileExistsW(utf8_to_wide(path).c_str()));
-    } catch (...) {
-        return false;
-    }
 }
 
 bool FileSysUtilsIsAbsolutePath(const std::string& path) {
-    try {
     if ((path[0] == '\\') || (path[1] == ':' && (path[2] == '\\' || path[2] == '/'))) {
         return true;
-    }
-    } catch (...) {
     }
     return false;
 }
 
 bool FileSysUtilsGetCurrentPath(std::string& path) {
-    try {
     wchar_t tmp_path[MAX_PATH];
     if (nullptr != _wgetcwd(tmp_path, MAX_PATH - 1)) {
         path = wide_to_utf8(tmp_path);
         return true;
     }
-    } catch (...) {
-    }
     return false;
 }
 
 bool FileSysUtilsGetParentPath(const std::string& file_path, std::string& parent_path) {
-    try {
     std::string full_path;
     if (FileSysUtilsGetAbsolutePath(file_path, full_path)) {
         std::string::size_type lastSeperator = full_path.find_last_of(DIRECTORY_SYMBOL);
         parent_path = (lastSeperator == 0) ? full_path : full_path.substr(0, lastSeperator);
         return true;
     }
-    } catch (...) {
-    }
     return false;
 }
 
 bool FileSysUtilsGetAbsolutePath(const std::string& path, std::string& absolute) {
-    try {
     wchar_t tmp_path[MAX_PATH];
     if (0 != GetFullPathNameW(utf8_to_wide(path).c_str(), MAX_PATH, tmp_path, NULL)) {
         absolute = wide_to_utf8(tmp_path);
         return true;
     }
-    } catch (...) {
-    }
     return false;
 }
 
 bool FileSysUtilsCombinePaths(const std::string& parent, const std::string& child, std::string& combined) {
-    try {
     std::string::size_type parent_len = parent.length();
     if (0 == parent_len || "." == parent || ".\\" == parent || "./" == parent) {
         combined = child;
@@ -286,13 +221,9 @@ bool FileSysUtilsCombinePaths(const std::string& parent, const std::string& chil
     }
     combined = parent.substr(0, parent_len) + DIRECTORY_SYMBOL + child;
     return true;
-    } catch (...) {
-    }
-    return false;
 }
 
 bool FileSysUtilsParsePathList(std::string& path_list, std::vector<std::string>& paths) {
-    try {
     std::string::size_type start = 0;
     std::string::size_type location = path_list.find(PATH_SEPARATOR);
     while (location != std::string::npos) {
@@ -302,13 +233,9 @@ bool FileSysUtilsParsePathList(std::string& path_list, std::vector<std::string>&
     }
     paths.push_back(path_list.substr(start, location));
     return true;
-    } catch (...) {
-    }
-    return false;
 }
 
 bool FileSysUtilsFindFilesInPath(const std::string& path, std::vector<std::string>& files) {
-    try {
     WIN32_FIND_DATAW file_data;
     HANDLE file_handle = FindFirstFileW(utf8_to_wide(path).c_str(), &file_data);
     if (file_handle != INVALID_HANDLE_VALUE) {
@@ -318,8 +245,6 @@ bool FileSysUtilsFindFilesInPath(const std::string& path, std::vector<std::strin
             }
         } while (FindNextFileW(file_handle, &file_data));
         return true;
-    }
-    } catch (...) {
     }
     return false;
 }
@@ -335,80 +260,54 @@ bool FileSysUtilsFindFilesInPath(const std::string& path, std::vector<std::strin
 // simple POSIX-compatible implementation of the <filesystem> pieces used by OpenXR
 
 bool FileSysUtilsIsRegularFile(const std::string& path) {
-    try {
     struct stat path_stat;
     stat(path.c_str(), &path_stat);
     return S_ISREG(path_stat.st_mode);
-    } catch (...) {
-    }
-    return false;
 }
 
 bool FileSysUtilsIsDirectory(const std::string& path) {
-    try {
     struct stat path_stat;
     stat(path.c_str(), &path_stat);
     return S_ISDIR(path_stat.st_mode);
-    } catch (...) {
-    }
-    return false;
 }
 
 bool FileSysUtilsPathExists(const std::string& path) {
-    try {
     return (access(path.c_str(), F_OK) != -1);
-    } catch (...) {
-    }
-    return false;
 }
 
 bool FileSysUtilsIsAbsolutePath(const std::string& path) {
-    try {
     return (path[0] == DIRECTORY_SYMBOL);
-    } catch (...) {
-    }
-    return false;
 }
 
 bool FileSysUtilsGetCurrentPath(std::string& path) {
-    try {
     char tmp_path[PATH_MAX];
     if (nullptr != getcwd(tmp_path, PATH_MAX - 1)) {
         path = tmp_path;
         return true;
     }
-    } catch (...) {
-    }
     return false;
 }
 
 bool FileSysUtilsGetParentPath(const std::string& file_path, std::string& parent_path) {
-    try {
     std::string full_path;
     if (FileSysUtilsGetAbsolutePath(file_path, full_path)) {
         std::string::size_type lastSeperator = full_path.find_last_of(DIRECTORY_SYMBOL);
         parent_path = (lastSeperator == 0) ? full_path : full_path.substr(0, lastSeperator - 1);
         return true;
     }
-    } catch (...) {
-    }
     return false;
 }
 
 bool FileSysUtilsGetAbsolutePath(const std::string& path, std::string& absolute) {
-    try {
     char buf[PATH_MAX];
     if (nullptr != realpath(path.c_str(), buf)) {
         absolute = buf;
         return true;
     }
-    } catch (...) {
-    }
     return false;
 }
 
 bool FileSysUtilsCombinePaths(const std::string& parent, const std::string& child, std::string& combined) {
-    try {
     std::string::size_type parent_len = parent.length();
     if (0 == parent_len || "." == parent || "./" == parent) {
         combined = child;
@@ -420,13 +319,9 @@ bool FileSysUtilsCombinePaths(const std::string& parent, const std::string& chil
     }
     combined = parent.substr(0, parent_len) + DIRECTORY_SYMBOL + child;
     return true;
-    } catch (...) {
-    }
-    return false;
 }
 
 bool FileSysUtilsParsePathList(std::string& path_list, std::vector<std::string>& paths) {
-    try {
     std::string::size_type start = 0;
     std::string::size_type location = path_list.find(PATH_SEPARATOR);
     while (location != std::string::npos) {
@@ -436,13 +331,9 @@ bool FileSysUtilsParsePathList(std::string& path_list, std::vector<std::string>&
     }
     paths.push_back(path_list.substr(start, location));
     return true;
-    } catch (...) {
-    }
-    return false;
 }
 
 bool FileSysUtilsFindFilesInPath(const std::string& path, std::vector<std::string>& files) {
-    try {
     DIR* dir;
     struct dirent* entry;
     dir = opendir(path.c_str());
@@ -451,9 +342,6 @@ bool FileSysUtilsFindFilesInPath(const std::string& path, std::vector<std::strin
     }
     closedir(dir);
     return true;
-    } catch (...) {
-    }
-    return false;
 }
 
 #endif

--- a/src/common/filesystem_utils.cpp
+++ b/src/common/filesystem_utils.cpp
@@ -98,7 +98,7 @@
 
 bool FileSysUtilsIsRegularFile(const std::string& path) {
     try {
-        return FS_PREFIX::is_regular_file(path);
+    return FS_PREFIX::is_regular_file(path);
     } catch (...) {
         return false;
     }
@@ -106,7 +106,7 @@ bool FileSysUtilsIsRegularFile(const std::string& path) {
 
 bool FileSysUtilsIsDirectory(const std::string& path) {
     try {
-        return FS_PREFIX::is_directory(path);
+    return FS_PREFIX::is_directory(path);
     } catch (...) {
         return false;
     }
@@ -114,7 +114,7 @@ bool FileSysUtilsIsDirectory(const std::string& path) {
 
 bool FileSysUtilsPathExists(const std::string& path) {
     try {
-        return FS_PREFIX::exists(path);
+    return FS_PREFIX::exists(path);
     } catch (...) {
         return false;
     }
@@ -122,8 +122,8 @@ bool FileSysUtilsPathExists(const std::string& path) {
 
 bool FileSysUtilsIsAbsolutePath(const std::string& path) {
     try {
-        FS_PREFIX::path file_path(path);
-        return file_path.is_absolute();
+    FS_PREFIX::path file_path(path);
+    return file_path.is_absolute();
     } catch (...) {
         return false;
     }
@@ -131,9 +131,9 @@ bool FileSysUtilsIsAbsolutePath(const std::string& path) {
 
 bool FileSysUtilsGetCurrentPath(std::string& path) {
     try {
-        FS_PREFIX::path cur_path = FS_PREFIX::current_path();
-        path = cur_path.string();
-        return true;
+    FS_PREFIX::path cur_path = FS_PREFIX::current_path();
+    path = cur_path.string();
+    return true;
     } catch (...) {
     }
     return false;
@@ -141,9 +141,9 @@ bool FileSysUtilsGetCurrentPath(std::string& path) {
 
 bool FileSysUtilsGetParentPath(const std::string& file_path, std::string& parent_path) {
     try {
-        FS_PREFIX::path path_var(file_path);
-        parent_path = path_var.parent_path().string();
-        return true;
+    FS_PREFIX::path path_var(file_path);
+    parent_path = path_var.parent_path().string();
+    return true;
     } catch (...) {
     }
     return false;
@@ -151,8 +151,8 @@ bool FileSysUtilsGetParentPath(const std::string& file_path, std::string& parent
 
 bool FileSysUtilsGetAbsolutePath(const std::string& path, std::string& absolute) {
     try {
-        absolute = FS_PREFIX::absolute(path).string();
-        return true;
+    absolute = FS_PREFIX::absolute(path).string();
+    return true;
     } catch (...) {
     }
     return false;
@@ -160,11 +160,11 @@ bool FileSysUtilsGetAbsolutePath(const std::string& path, std::string& absolute)
 
 bool FileSysUtilsCombinePaths(const std::string& parent, const std::string& child, std::string& combined) {
     try {
-        FS_PREFIX::path parent_path(parent);
-        FS_PREFIX::path child_path(child);
-        FS_PREFIX::path full_path = parent_path / child_path;
-        combined = full_path.string();
-        return true;
+    FS_PREFIX::path parent_path(parent);
+    FS_PREFIX::path child_path(child);
+    FS_PREFIX::path full_path = parent_path / child_path;
+    combined = full_path.string();
+    return true;
     } catch (...) {
     }
     return false;
@@ -172,15 +172,15 @@ bool FileSysUtilsCombinePaths(const std::string& parent, const std::string& chil
 
 bool FileSysUtilsParsePathList(std::string& path_list, std::vector<std::string>& paths) {
     try {
-        std::string::size_type start = 0;
-        std::string::size_type location = path_list.find(PATH_SEPARATOR);
-        while (location != std::string::npos) {
-            paths.push_back(path_list.substr(start, location));
-            start = location + 1;
-            location = path_list.find(PATH_SEPARATOR, start);
-        }
+    std::string::size_type start = 0;
+    std::string::size_type location = path_list.find(PATH_SEPARATOR);
+    while (location != std::string::npos) {
         paths.push_back(path_list.substr(start, location));
-        return true;
+        start = location + 1;
+        location = path_list.find(PATH_SEPARATOR, start);
+    }
+    paths.push_back(path_list.substr(start, location));
+    return true;
     } catch (...) {
     }
     return false;
@@ -188,10 +188,10 @@ bool FileSysUtilsParsePathList(std::string& path_list, std::vector<std::string>&
 
 bool FileSysUtilsFindFilesInPath(const std::string& path, std::vector<std::string>& files) {
     try {
-        for (auto& dir_iter : FS_PREFIX::directory_iterator(path)) {
-            files.push_back(dir_iter.path().filename().string());
-        }
-        return true;
+    for (auto& dir_iter : FS_PREFIX::directory_iterator(path)) {
+        files.push_back(dir_iter.path().filename().string());
+    }
+    return true;
     } catch (...) {
     }
     return false;
@@ -204,7 +204,7 @@ bool FileSysUtilsFindFilesInPath(const std::string& path, std::vector<std::strin
 
 bool FileSysUtilsIsRegularFile(const std::string& path) {
     try {
-        return (1 != PathIsDirectoryW(utf8_to_wide(path).c_str()));
+    return (1 != PathIsDirectoryW(utf8_to_wide(path).c_str()));
     } catch (...) {
         return false;
     }
@@ -212,7 +212,7 @@ bool FileSysUtilsIsRegularFile(const std::string& path) {
 
 bool FileSysUtilsIsDirectory(const std::string& path) {
     try {
-        return (1 == PathIsDirectoryW(utf8_to_wide(path).c_str()));
+    return (1 == PathIsDirectoryW(utf8_to_wide(path).c_str()));
     } catch (...) {
         return false;
     }
@@ -220,7 +220,7 @@ bool FileSysUtilsIsDirectory(const std::string& path) {
 
 bool FileSysUtilsPathExists(const std::string& path) {
     try {
-        return (1 == PathFileExistsW(utf8_to_wide(path).c_str()));
+    return (1 == PathFileExistsW(utf8_to_wide(path).c_str()));
     } catch (...) {
         return false;
     }
@@ -228,9 +228,9 @@ bool FileSysUtilsPathExists(const std::string& path) {
 
 bool FileSysUtilsIsAbsolutePath(const std::string& path) {
     try {
-        if ((path[0] == '\\') || (path[1] == ':' && (path[2] == '\\' || path[2] == '/'))) {
-            return true;
-        }
+    if ((path[0] == '\\') || (path[1] == ':' && (path[2] == '\\' || path[2] == '/'))) {
+        return true;
+    }
     } catch (...) {
     }
     return false;
@@ -238,11 +238,11 @@ bool FileSysUtilsIsAbsolutePath(const std::string& path) {
 
 bool FileSysUtilsGetCurrentPath(std::string& path) {
     try {
-        wchar_t tmp_path[MAX_PATH];
-        if (nullptr != _wgetcwd(tmp_path, MAX_PATH - 1)) {
-            path = wide_to_utf8(tmp_path);
-            return true;
-        }
+    wchar_t tmp_path[MAX_PATH];
+    if (nullptr != _wgetcwd(tmp_path, MAX_PATH - 1)) {
+        path = wide_to_utf8(tmp_path);
+        return true;
+    }
     } catch (...) {
     }
     return false;
@@ -250,12 +250,12 @@ bool FileSysUtilsGetCurrentPath(std::string& path) {
 
 bool FileSysUtilsGetParentPath(const std::string& file_path, std::string& parent_path) {
     try {
-        std::string full_path;
-        if (FileSysUtilsGetAbsolutePath(file_path, full_path)) {
-            std::string::size_type lastSeperator = full_path.find_last_of(DIRECTORY_SYMBOL);
-            parent_path = (lastSeperator == 0) ? full_path : full_path.substr(0, lastSeperator);
-            return true;
-        }
+    std::string full_path;
+    if (FileSysUtilsGetAbsolutePath(file_path, full_path)) {
+        std::string::size_type lastSeperator = full_path.find_last_of(DIRECTORY_SYMBOL);
+        parent_path = (lastSeperator == 0) ? full_path : full_path.substr(0, lastSeperator);
+        return true;
+    }
     } catch (...) {
     }
     return false;
@@ -263,11 +263,11 @@ bool FileSysUtilsGetParentPath(const std::string& file_path, std::string& parent
 
 bool FileSysUtilsGetAbsolutePath(const std::string& path, std::string& absolute) {
     try {
-        wchar_t tmp_path[MAX_PATH];
-        if (0 != GetFullPathNameW(utf8_to_wide(path).c_str(), MAX_PATH, tmp_path, NULL)) {
-            absolute = wide_to_utf8(tmp_path);
-            return true;
-        }
+    wchar_t tmp_path[MAX_PATH];
+    if (0 != GetFullPathNameW(utf8_to_wide(path).c_str(), MAX_PATH, tmp_path, NULL)) {
+        absolute = wide_to_utf8(tmp_path);
+        return true;
+    }
     } catch (...) {
     }
     return false;
@@ -275,17 +275,17 @@ bool FileSysUtilsGetAbsolutePath(const std::string& path, std::string& absolute)
 
 bool FileSysUtilsCombinePaths(const std::string& parent, const std::string& child, std::string& combined) {
     try {
-        std::string::size_type parent_len = parent.length();
-        if (0 == parent_len || "." == parent || ".\\" == parent || "./" == parent) {
-            combined = child;
-            return true;
-        }
-        char last_char = parent[parent_len - 1];
-        if (last_char == DIRECTORY_SYMBOL) {
-            parent_len--;
-        }
-        combined = parent.substr(0, parent_len) + DIRECTORY_SYMBOL + child;
+    std::string::size_type parent_len = parent.length();
+    if (0 == parent_len || "." == parent || ".\\" == parent || "./" == parent) {
+        combined = child;
         return true;
+    }
+    char last_char = parent[parent_len - 1];
+    if (last_char == DIRECTORY_SYMBOL) {
+        parent_len--;
+    }
+    combined = parent.substr(0, parent_len) + DIRECTORY_SYMBOL + child;
+    return true;
     } catch (...) {
     }
     return false;
@@ -293,15 +293,15 @@ bool FileSysUtilsCombinePaths(const std::string& parent, const std::string& chil
 
 bool FileSysUtilsParsePathList(std::string& path_list, std::vector<std::string>& paths) {
     try {
-        std::string::size_type start = 0;
-        std::string::size_type location = path_list.find(PATH_SEPARATOR);
-        while (location != std::string::npos) {
-            paths.push_back(path_list.substr(start, location));
-            start = location + 1;
-            location = path_list.find(PATH_SEPARATOR, start);
-        }
+    std::string::size_type start = 0;
+    std::string::size_type location = path_list.find(PATH_SEPARATOR);
+    while (location != std::string::npos) {
         paths.push_back(path_list.substr(start, location));
-        return true;
+        start = location + 1;
+        location = path_list.find(PATH_SEPARATOR, start);
+    }
+    paths.push_back(path_list.substr(start, location));
+    return true;
     } catch (...) {
     }
     return false;
@@ -309,16 +309,16 @@ bool FileSysUtilsParsePathList(std::string& path_list, std::vector<std::string>&
 
 bool FileSysUtilsFindFilesInPath(const std::string& path, std::vector<std::string>& files) {
     try {
-        WIN32_FIND_DATAW file_data;
-        HANDLE file_handle = FindFirstFileW(utf8_to_wide(path).c_str(), &file_data);
-        if (file_handle != INVALID_HANDLE_VALUE) {
-            do {
-                if (!(file_data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)) {
-                    files.push_back(wide_to_utf8(file_data.cFileName));
-                }
-            } while (FindNextFileW(file_handle, &file_data));
-            return true;
-        }
+    WIN32_FIND_DATAW file_data;
+    HANDLE file_handle = FindFirstFileW(utf8_to_wide(path).c_str(), &file_data);
+    if (file_handle != INVALID_HANDLE_VALUE) {
+        do {
+            if (!(file_data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)) {
+                files.push_back(wide_to_utf8(file_data.cFileName));
+            }
+        } while (FindNextFileW(file_handle, &file_data));
+        return true;
+    }
     } catch (...) {
     }
     return false;
@@ -336,9 +336,9 @@ bool FileSysUtilsFindFilesInPath(const std::string& path, std::vector<std::strin
 
 bool FileSysUtilsIsRegularFile(const std::string& path) {
     try {
-        struct stat path_stat;
-        stat(path.c_str(), &path_stat);
-        return S_ISREG(path_stat.st_mode);
+    struct stat path_stat;
+    stat(path.c_str(), &path_stat);
+    return S_ISREG(path_stat.st_mode);
     } catch (...) {
     }
     return false;
@@ -346,9 +346,9 @@ bool FileSysUtilsIsRegularFile(const std::string& path) {
 
 bool FileSysUtilsIsDirectory(const std::string& path) {
     try {
-        struct stat path_stat;
-        stat(path.c_str(), &path_stat);
-        return S_ISDIR(path_stat.st_mode);
+    struct stat path_stat;
+    stat(path.c_str(), &path_stat);
+    return S_ISDIR(path_stat.st_mode);
     } catch (...) {
     }
     return false;
@@ -356,7 +356,7 @@ bool FileSysUtilsIsDirectory(const std::string& path) {
 
 bool FileSysUtilsPathExists(const std::string& path) {
     try {
-        return (access(path.c_str(), F_OK) != -1);
+    return (access(path.c_str(), F_OK) != -1);
     } catch (...) {
     }
     return false;
@@ -364,7 +364,7 @@ bool FileSysUtilsPathExists(const std::string& path) {
 
 bool FileSysUtilsIsAbsolutePath(const std::string& path) {
     try {
-        return (path[0] == DIRECTORY_SYMBOL);
+    return (path[0] == DIRECTORY_SYMBOL);
     } catch (...) {
     }
     return false;
@@ -372,11 +372,11 @@ bool FileSysUtilsIsAbsolutePath(const std::string& path) {
 
 bool FileSysUtilsGetCurrentPath(std::string& path) {
     try {
-        char tmp_path[PATH_MAX];
-        if (nullptr != getcwd(tmp_path, PATH_MAX - 1)) {
-            path = tmp_path;
-            return true;
-        }
+    char tmp_path[PATH_MAX];
+    if (nullptr != getcwd(tmp_path, PATH_MAX - 1)) {
+        path = tmp_path;
+        return true;
+    }
     } catch (...) {
     }
     return false;
@@ -384,12 +384,12 @@ bool FileSysUtilsGetCurrentPath(std::string& path) {
 
 bool FileSysUtilsGetParentPath(const std::string& file_path, std::string& parent_path) {
     try {
-        std::string full_path;
-        if (FileSysUtilsGetAbsolutePath(file_path, full_path)) {
-            std::string::size_type lastSeperator = full_path.find_last_of(DIRECTORY_SYMBOL);
-            parent_path = (lastSeperator == 0) ? full_path : full_path.substr(0, lastSeperator - 1);
-            return true;
-        }
+    std::string full_path;
+    if (FileSysUtilsGetAbsolutePath(file_path, full_path)) {
+        std::string::size_type lastSeperator = full_path.find_last_of(DIRECTORY_SYMBOL);
+        parent_path = (lastSeperator == 0) ? full_path : full_path.substr(0, lastSeperator - 1);
+        return true;
+    }
     } catch (...) {
     }
     return false;
@@ -397,11 +397,11 @@ bool FileSysUtilsGetParentPath(const std::string& file_path, std::string& parent
 
 bool FileSysUtilsGetAbsolutePath(const std::string& path, std::string& absolute) {
     try {
-        char buf[PATH_MAX];
-        if (nullptr != realpath(path.c_str(), buf)) {
-            absolute = buf;
-            return true;
-        }
+    char buf[PATH_MAX];
+    if (nullptr != realpath(path.c_str(), buf)) {
+        absolute = buf;
+        return true;
+    }
     } catch (...) {
     }
     return false;
@@ -409,17 +409,17 @@ bool FileSysUtilsGetAbsolutePath(const std::string& path, std::string& absolute)
 
 bool FileSysUtilsCombinePaths(const std::string& parent, const std::string& child, std::string& combined) {
     try {
-        std::string::size_type parent_len = parent.length();
-        if (0 == parent_len || "." == parent || "./" == parent) {
-            combined = child;
-            return true;
-        }
-        char last_char = parent[parent_len - 1];
-        if (last_char == DIRECTORY_SYMBOL) {
-            parent_len--;
-        }
-        combined = parent.substr(0, parent_len) + DIRECTORY_SYMBOL + child;
+    std::string::size_type parent_len = parent.length();
+    if (0 == parent_len || "." == parent || "./" == parent) {
+        combined = child;
         return true;
+    }
+    char last_char = parent[parent_len - 1];
+    if (last_char == DIRECTORY_SYMBOL) {
+        parent_len--;
+    }
+    combined = parent.substr(0, parent_len) + DIRECTORY_SYMBOL + child;
+    return true;
     } catch (...) {
     }
     return false;
@@ -427,15 +427,15 @@ bool FileSysUtilsCombinePaths(const std::string& parent, const std::string& chil
 
 bool FileSysUtilsParsePathList(std::string& path_list, std::vector<std::string>& paths) {
     try {
-        std::string::size_type start = 0;
-        std::string::size_type location = path_list.find(PATH_SEPARATOR);
-        while (location != std::string::npos) {
-            paths.push_back(path_list.substr(start, location));
-            start = location + 1;
-            location = path_list.find(PATH_SEPARATOR, start);
-        }
+    std::string::size_type start = 0;
+    std::string::size_type location = path_list.find(PATH_SEPARATOR);
+    while (location != std::string::npos) {
         paths.push_back(path_list.substr(start, location));
-        return true;
+        start = location + 1;
+        location = path_list.find(PATH_SEPARATOR, start);
+    }
+    paths.push_back(path_list.substr(start, location));
+    return true;
     } catch (...) {
     }
     return false;
@@ -443,14 +443,14 @@ bool FileSysUtilsParsePathList(std::string& path_list, std::vector<std::string>&
 
 bool FileSysUtilsFindFilesInPath(const std::string& path, std::vector<std::string>& files) {
     try {
-        DIR* dir;
-        struct dirent* entry;
-        dir = opendir(path.c_str());
-        while (dir && (entry = readdir(dir))) {
-            files.push_back(entry->d_name);
-        }
-        closedir(dir);
-        return true;
+    DIR* dir;
+    struct dirent* entry;
+    dir = opendir(path.c_str());
+    while (dir && (entry = readdir(dir))) {
+        files.push_back(entry->d_name);
+    }
+    closedir(dir);
+    return true;
     } catch (...) {
     }
     return false;

--- a/src/external/jsoncpp/include/json/config.h
+++ b/src/external/jsoncpp/include/json/config.h
@@ -22,7 +22,7 @@
 // If non-zero, the library uses exceptions to report bad input instead of C
 // assertion macros. The default is to use exceptions.
 #ifndef JSON_USE_EXCEPTION
-#define JSON_USE_EXCEPTION 1
+#define JSON_USE_EXCEPTION 0
 #endif
 
 /// If defined, indicates that the source file is amalgated

--- a/src/loader/api_layer_interface.cpp
+++ b/src/loader/api_layer_interface.cpp
@@ -33,29 +33,29 @@
 // Add any layers defined in the loader layer environment variable.
 static void AddEnvironmentApiLayers(const std::string& openxr_command, std::vector<std::string>& enabled_layers) {
     try {
-        char* layer_environment_variable = PlatformUtilsGetEnv(OPENXR_ENABLE_LAYERS_ENV_VAR);
-        if (nullptr != layer_environment_variable) {
-            std::string layers = layer_environment_variable;
-            PlatformUtilsFreeEnv(layer_environment_variable);
+    char* layer_environment_variable = PlatformUtilsGetEnv(OPENXR_ENABLE_LAYERS_ENV_VAR);
+    if (nullptr != layer_environment_variable) {
+        std::string layers = layer_environment_variable;
+        PlatformUtilsFreeEnv(layer_environment_variable);
 
-            std::size_t last_found = 0;
-            std::size_t found = layers.find_first_of(PATH_SEPARATOR);
-            std::string cur_search;
+        std::size_t last_found = 0;
+        std::size_t found = layers.find_first_of(PATH_SEPARATOR);
+        std::string cur_search;
 
-            // Handle any path listings in the string (separated by the appropriate path separator)
-            while (found != std::string::npos) {
-                cur_search = layers.substr(last_found, found);
-                enabled_layers.push_back(cur_search);
-                last_found = found + 1;
-                found = layers.find_first_of(PATH_SEPARATOR, last_found);
-            }
-
-            // If there's something remaining in the string, copy it over
-            if (last_found < layers.size()) {
-                cur_search = layers.substr(last_found);
-                enabled_layers.push_back(cur_search);
-            }
+        // Handle any path listings in the string (separated by the appropriate path separator)
+        while (found != std::string::npos) {
+            cur_search = layers.substr(last_found, found);
+            enabled_layers.push_back(cur_search);
+            last_found = found + 1;
+            found = layers.find_first_of(PATH_SEPARATOR, last_found);
         }
+
+        // If there's something remaining in the string, copy it over
+        if (last_found < layers.size()) {
+            cur_search = layers.substr(last_found);
+            enabled_layers.push_back(cur_search);
+        }
+    }
     } catch (...) {
         LoaderLogger::LogErrorMessage(openxr_command, "AddEnvironmentApiLayers - unknown error occurred");
         throw;
@@ -65,58 +65,58 @@ static void AddEnvironmentApiLayers(const std::string& openxr_command, std::vect
 XrResult ApiLayerInterface::GetApiLayerProperties(const std::string& openxr_command, uint32_t incoming_count,
                                                   uint32_t* outgoing_count, XrApiLayerProperties* api_layer_properties) {
     try {
-        std::vector<std::unique_ptr<ApiLayerManifestFile>> manifest_files;
-        uint32_t manifest_count = 0;
+    std::vector<std::unique_ptr<ApiLayerManifestFile>> manifest_files;
+    uint32_t manifest_count = 0;
 
-        // Find any implicit layers which we may need to report information for.
-        XrResult result = ApiLayerManifestFile::FindManifestFiles(MANIFEST_TYPE_IMPLICIT_API_LAYER, manifest_files);
-        if (XR_SUCCESS == result) {
-            // Find any explicit layers which we may need to report information for.
-            result = ApiLayerManifestFile::FindManifestFiles(MANIFEST_TYPE_EXPLICIT_API_LAYER, manifest_files);
-        }
-        if (XR_SUCCESS != result) {
+    // Find any implicit layers which we may need to report information for.
+    XrResult result = ApiLayerManifestFile::FindManifestFiles(MANIFEST_TYPE_IMPLICIT_API_LAYER, manifest_files);
+    if (XR_SUCCESS == result) {
+        // Find any explicit layers which we may need to report information for.
+        result = ApiLayerManifestFile::FindManifestFiles(MANIFEST_TYPE_EXPLICIT_API_LAYER, manifest_files);
+    }
+    if (XR_SUCCESS != result) {
+        LoaderLogger::LogErrorMessage(
+            openxr_command, "ApiLayerInterface::GetApiLayerProperties - failed searching for API layer manifest files");
+        return result;
+    }
+
+    manifest_count = static_cast<uint32_t>(manifest_files.size());
+    if (0 == incoming_count) {
+        *outgoing_count = manifest_count;
+    } else if (nullptr != api_layer_properties) {
+        if (incoming_count < manifest_count && nullptr != api_layer_properties) {
             LoaderLogger::LogErrorMessage(
-                openxr_command, "ApiLayerInterface::GetApiLayerProperties - failed searching for API layer manifest files");
-            return result;
-        }
-
-        manifest_count = static_cast<uint32_t>(manifest_files.size());
-        if (0 == incoming_count) {
+                "xrEnumerateInstanceExtensionProperties",
+                "VUID-xrEnumerateApiLayerProperties-propertyCapacityInput-parameter: insufficient space in array");
             *outgoing_count = manifest_count;
-        } else if (nullptr != api_layer_properties) {
-            if (incoming_count < manifest_count && nullptr != api_layer_properties) {
-                LoaderLogger::LogErrorMessage(
-                    "xrEnumerateInstanceExtensionProperties",
-                    "VUID-xrEnumerateApiLayerProperties-propertyCapacityInput-parameter: insufficient space in array");
-                *outgoing_count = manifest_count;
-                return XR_ERROR_SIZE_INSUFFICIENT;
-            }
+            return XR_ERROR_SIZE_INSUFFICIENT;
+        }
 
-            uint32_t prop = 0;
-            bool properties_valid = true;
-            for (; prop < incoming_count && prop < manifest_count; ++prop) {
-                if (XR_TYPE_API_LAYER_PROPERTIES != api_layer_properties[prop].type) {
-                    LoaderLogger::LogErrorMessage(openxr_command,
-                                                  "VUID-XrApiLayerProperties-type-type: unknown type in api_layer_properties");
-                    properties_valid = false;
-                }
-                if (nullptr != api_layer_properties[prop].next) {
-                    LoaderLogger::LogErrorMessage(openxr_command, "VUID-XrApiLayerProperties-next-next: expected NULL");
-                    properties_valid = false;
-                }
-                if (properties_valid) {
-                    api_layer_properties[prop] = manifest_files[prop]->GetApiLayerProperties();
-                }
-            }
-            if (!properties_valid) {
+        uint32_t prop = 0;
+        bool properties_valid = true;
+        for (; prop < incoming_count && prop < manifest_count; ++prop) {
+            if (XR_TYPE_API_LAYER_PROPERTIES != api_layer_properties[prop].type) {
                 LoaderLogger::LogErrorMessage(openxr_command,
-                                              "VUID-xrEnumerateApiLayerProperties-properties-parameter: invalid properties");
-                return XR_ERROR_VALIDATION_FAILURE;
-            } else if (nullptr != outgoing_count) {
-                *outgoing_count = prop;
+                                              "VUID-XrApiLayerProperties-type-type: unknown type in api_layer_properties");
+                properties_valid = false;
+            }
+            if (nullptr != api_layer_properties[prop].next) {
+                LoaderLogger::LogErrorMessage(openxr_command, "VUID-XrApiLayerProperties-next-next: expected NULL");
+                properties_valid = false;
+            }
+            if (properties_valid) {
+                api_layer_properties[prop] = manifest_files[prop]->GetApiLayerProperties();
             }
         }
-        return XR_SUCCESS;
+        if (!properties_valid) {
+            LoaderLogger::LogErrorMessage(openxr_command,
+                                          "VUID-xrEnumerateApiLayerProperties-properties-parameter: invalid properties");
+            return XR_ERROR_VALIDATION_FAILURE;
+        } else if (nullptr != outgoing_count) {
+            *outgoing_count = prop;
+        }
+    }
+    return XR_SUCCESS;
     } catch (...) {
         LoaderLogger::LogErrorMessage(openxr_command, "ApiLayerInterface::GetApiLayerProperties - unknown error occurred");
         return XR_ERROR_VALIDATION_FAILURE;
@@ -126,72 +126,72 @@ XrResult ApiLayerInterface::GetApiLayerProperties(const std::string& openxr_comm
 XrResult ApiLayerInterface::GetInstanceExtensionProperties(const std::string& openxr_command, const char* layer_name,
                                                            std::vector<XrExtensionProperties>& extension_properties) {
     try {
-        std::vector<std::unique_ptr<ApiLayerManifestFile>> manifest_files;
+    std::vector<std::unique_ptr<ApiLayerManifestFile>> manifest_files;
 
-        // If a layer name is supplied, only use the information out of that one layer
-        if (nullptr != layer_name && 0 != strlen(layer_name)) {
-            XrResult result = ApiLayerManifestFile::FindManifestFiles(MANIFEST_TYPE_IMPLICIT_API_LAYER, manifest_files);
-            if (XR_SUCCESS == result) {
-                // Find any explicit layers which we may need to report information for.
-                result = ApiLayerManifestFile::FindManifestFiles(MANIFEST_TYPE_EXPLICIT_API_LAYER, manifest_files);
-                if (XR_SUCCESS != result) {
-                    LoaderLogger::LogErrorMessage(
-                        openxr_command,
-                        "ApiLayerInterface::GetInstanceExtensionProperties - failed searching for API layer manifest files");
-                    return result;
-                }
-
-                bool found = false;
-                uint32_t num_files = static_cast<uint32_t>(manifest_files.size());
-                for (uint32_t man_file = 0; man_file < num_files; ++man_file) {
-                    // If a layer with the provided name exists, get it's instance extension information.
-                    if (manifest_files[man_file]->LayerName() == layer_name) {
-                        manifest_files[man_file]->GetInstanceExtensionProperties(extension_properties);
-                        found = true;
-                        break;
-                    }
-                }
-
-                // If nothing found, report 0
-                if (!found) {
-                    return XR_ERROR_API_LAYER_NOT_PRESENT;
-                }
-            }
-            // Otherwise, we want to add only implicit API layers and explicit API layers enabled using the environment variables
-        } else {
-            XrResult result = ApiLayerManifestFile::FindManifestFiles(MANIFEST_TYPE_IMPLICIT_API_LAYER, manifest_files);
-            if (XR_SUCCESS == result) {
-                // Find any environmentally enabled explicit layers.  If they're present, treat them like implicit layers
-                // since we know that they're going to be enabled.
-                std::vector<std::string> env_enabled_layers;
-                AddEnvironmentApiLayers(openxr_command, env_enabled_layers);
-                if (env_enabled_layers.size() > 0) {
-                    std::vector<std::unique_ptr<ApiLayerManifestFile>> exp_layer_man_files = {};
-                    result = ApiLayerManifestFile::FindManifestFiles(MANIFEST_TYPE_EXPLICIT_API_LAYER, exp_layer_man_files);
-                    if (XR_SUCCESS == result) {
-                        for (auto l_iter = exp_layer_man_files.begin();
-                             exp_layer_man_files.size() > 0 && l_iter != exp_layer_man_files.end();
-                             /* No iterate */) {
-                            for (std::string& enabled_layer : env_enabled_layers) {
-                                // If this is an enabled layer, transfer it over to the manifest list.
-                                if (enabled_layer == (*l_iter)->LayerName()) {
-                                    manifest_files.push_back(std::move(*l_iter));
-                                    break;
-                                }
-                            }
-                            exp_layer_man_files.erase(l_iter);
-                        }
-                    }
-                }
+    // If a layer name is supplied, only use the information out of that one layer
+    if (nullptr != layer_name && 0 != strlen(layer_name)) {
+        XrResult result = ApiLayerManifestFile::FindManifestFiles(MANIFEST_TYPE_IMPLICIT_API_LAYER, manifest_files);
+        if (XR_SUCCESS == result) {
+            // Find any explicit layers which we may need to report information for.
+            result = ApiLayerManifestFile::FindManifestFiles(MANIFEST_TYPE_EXPLICIT_API_LAYER, manifest_files);
+            if (XR_SUCCESS != result) {
+                LoaderLogger::LogErrorMessage(
+                    openxr_command,
+                    "ApiLayerInterface::GetInstanceExtensionProperties - failed searching for API layer manifest files");
+                return result;
             }
 
-            // Grab the layer instance extensions information
+            bool found = false;
             uint32_t num_files = static_cast<uint32_t>(manifest_files.size());
             for (uint32_t man_file = 0; man_file < num_files; ++man_file) {
-                manifest_files[man_file]->GetInstanceExtensionProperties(extension_properties);
+                // If a layer with the provided name exists, get it's instance extension information.
+                if (manifest_files[man_file]->LayerName() == layer_name) {
+                    manifest_files[man_file]->GetInstanceExtensionProperties(extension_properties);
+                    found = true;
+                    break;
+                }
+            }
+
+            // If nothing found, report 0
+            if (!found) {
+                return XR_ERROR_API_LAYER_NOT_PRESENT;
             }
         }
-        return XR_SUCCESS;
+        // Otherwise, we want to add only implicit API layers and explicit API layers enabled using the environment variables
+    } else {
+        XrResult result = ApiLayerManifestFile::FindManifestFiles(MANIFEST_TYPE_IMPLICIT_API_LAYER, manifest_files);
+        if (XR_SUCCESS == result) {
+            // Find any environmentally enabled explicit layers.  If they're present, treat them like implicit layers
+            // since we know that they're going to be enabled.
+            std::vector<std::string> env_enabled_layers;
+            AddEnvironmentApiLayers(openxr_command, env_enabled_layers);
+            if (env_enabled_layers.size() > 0) {
+                std::vector<std::unique_ptr<ApiLayerManifestFile>> exp_layer_man_files = {};
+                result = ApiLayerManifestFile::FindManifestFiles(MANIFEST_TYPE_EXPLICIT_API_LAYER, exp_layer_man_files);
+                if (XR_SUCCESS == result) {
+                    for (auto l_iter = exp_layer_man_files.begin();
+                         exp_layer_man_files.size() > 0 && l_iter != exp_layer_man_files.end();
+                         /* No iterate */) {
+                        for (std::string& enabled_layer : env_enabled_layers) {
+                            // If this is an enabled layer, transfer it over to the manifest list.
+                            if (enabled_layer == (*l_iter)->LayerName()) {
+                                manifest_files.push_back(std::move(*l_iter));
+                                break;
+                            }
+                        }
+                        exp_layer_man_files.erase(l_iter);
+                    }
+                }
+            }
+        }
+
+        // Grab the layer instance extensions information
+        uint32_t num_files = static_cast<uint32_t>(manifest_files.size());
+        for (uint32_t man_file = 0; man_file < num_files; ++man_file) {
+            manifest_files[man_file]->GetInstanceExtensionProperties(extension_properties);
+        }
+    }
+    return XR_SUCCESS;
     } catch (...) {
         LoaderLogger::LogErrorMessage(openxr_command, "ApiLayerInterface::GetInstanceExtensionProperties - unknown error occurred");
         return XR_ERROR_INITIALIZATION_FAILED;
@@ -203,163 +203,163 @@ XrResult ApiLayerInterface::LoadApiLayers(const std::string& openxr_command, uin
                                           std::vector<std::unique_ptr<ApiLayerInterface>>& api_layer_interfaces) {
     XrResult last_error = XR_SUCCESS;
     try {
-        bool any_loaded = false;
-        std::vector<bool> layer_found;
-        std::vector<std::unique_ptr<ApiLayerManifestFile>> layer_manifest_files = {};
+    bool any_loaded = false;
+    std::vector<bool> layer_found;
+    std::vector<std::unique_ptr<ApiLayerManifestFile>> layer_manifest_files = {};
 
-        // Find any implicit layers which we may need to report information for.
-        XrResult result = ApiLayerManifestFile::FindManifestFiles(MANIFEST_TYPE_IMPLICIT_API_LAYER, layer_manifest_files);
-        if (XR_SUCCESS == result) {
-            // Find any explicit layers which we may need to report information for.
-            result = ApiLayerManifestFile::FindManifestFiles(MANIFEST_TYPE_EXPLICIT_API_LAYER, layer_manifest_files);
+    // Find any implicit layers which we may need to report information for.
+    XrResult result = ApiLayerManifestFile::FindManifestFiles(MANIFEST_TYPE_IMPLICIT_API_LAYER, layer_manifest_files);
+    if (XR_SUCCESS == result) {
+        // Find any explicit layers which we may need to report information for.
+        result = ApiLayerManifestFile::FindManifestFiles(MANIFEST_TYPE_EXPLICIT_API_LAYER, layer_manifest_files);
+    }
+
+    // Put all the enabled layers into a string vector
+    std::vector<std::string> enabled_api_layers = {};
+    AddEnvironmentApiLayers(openxr_command, enabled_api_layers);
+    if (enabled_api_layer_count > 0) {
+        if (nullptr == enabled_api_layer_names) {
+            LoaderLogger::LogErrorMessage(
+                "xrCreateInstance",
+                "VUID-XrInstanceCreateInfo-enabledApiLayerNames-parameter: enabledApiLayerCount is non-0 but array is NULL");
+            LoaderLogger::LogErrorMessage(
+                "xrCreateInstance", "VUID-xrCreateInstance-info-parameter: something wrong with XrInstanceCreateInfo contents");
+            return XR_ERROR_VALIDATION_FAILURE;
         }
-
-        // Put all the enabled layers into a string vector
-        std::vector<std::string> enabled_api_layers = {};
-        AddEnvironmentApiLayers(openxr_command, enabled_api_layers);
-        if (enabled_api_layer_count > 0) {
-            if (nullptr == enabled_api_layer_names) {
-                LoaderLogger::LogErrorMessage(
-                    "xrCreateInstance",
-                    "VUID-XrInstanceCreateInfo-enabledApiLayerNames-parameter: enabledApiLayerCount is non-0 but array is NULL");
-                LoaderLogger::LogErrorMessage(
-                    "xrCreateInstance", "VUID-xrCreateInstance-info-parameter: something wrong with XrInstanceCreateInfo contents");
-                return XR_ERROR_VALIDATION_FAILURE;
-            }
-            uint32_t num_env_api_layers = static_cast<uint32_t>(enabled_api_layers.size());
-            uint32_t total_api_layers = num_env_api_layers + enabled_api_layer_count;
-            enabled_api_layers.resize(total_api_layers);
-            for (uint32_t layer = 0; layer < enabled_api_layer_count; ++layer) {
-                enabled_api_layers[num_env_api_layers + layer] = enabled_api_layer_names[layer];
-            }
+        uint32_t num_env_api_layers = static_cast<uint32_t>(enabled_api_layers.size());
+        uint32_t total_api_layers = num_env_api_layers + enabled_api_layer_count;
+        enabled_api_layers.resize(total_api_layers);
+        for (uint32_t layer = 0; layer < enabled_api_layer_count; ++layer) {
+            enabled_api_layers[num_env_api_layers + layer] = enabled_api_layer_names[layer];
         }
+    }
 
-        // Initialize the layer found vector to false
-        layer_found.resize(enabled_api_layers.size());
-        for (uint32_t layer = 0; layer < layer_found.size(); ++layer) {
-            layer_found[layer] = false;
-        }
+    // Initialize the layer found vector to false
+    layer_found.resize(enabled_api_layers.size());
+    for (uint32_t layer = 0; layer < layer_found.size(); ++layer) {
+        layer_found[layer] = false;
+    }
 
-        for (std::unique_ptr<ApiLayerManifestFile>& manifest_file : layer_manifest_files) {
-            bool enabled = false;
+    for (std::unique_ptr<ApiLayerManifestFile>& manifest_file : layer_manifest_files) {
+        bool enabled = false;
 
-            // Always add implicit layers.  They would only be in this list if they were enabled
-            // (i.e. the disable environment variable is not set).
-            if (manifest_file->Type() == MANIFEST_TYPE_IMPLICIT_API_LAYER) {
-                enabled = true;
-            } else {
-                // Only add explicit layers if they are called out by the application
-                for (uint32_t layer = 0; layer < enabled_api_layers.size(); ++layer) {
-                    if (enabled_api_layers[layer] == manifest_file->LayerName()) {
-                        layer_found[layer] = true;
-                        enabled = true;
-                        break;
-                    }
+        // Always add implicit layers.  They would only be in this list if they were enabled
+        // (i.e. the disable environment variable is not set).
+        if (manifest_file->Type() == MANIFEST_TYPE_IMPLICIT_API_LAYER) {
+            enabled = true;
+        } else {
+            // Only add explicit layers if they are called out by the application
+            for (uint32_t layer = 0; layer < enabled_api_layers.size(); ++layer) {
+                if (enabled_api_layers[layer] == manifest_file->LayerName()) {
+                    layer_found[layer] = true;
+                    enabled = true;
+                    break;
                 }
             }
-
-            // If this layer isn't enabled, skip it.
-            if (!enabled) {
-                continue;
-            }
-
-            LoaderPlatformLibraryHandle layer_library = LoaderPlatformLibraryOpen(manifest_file->LibraryPath());
-            if (nullptr == layer_library) {
-                if (!any_loaded) {
-                    last_error = XR_ERROR_FILE_ACCESS_ERROR;
-                }
-                std::string library_message = LoaderPlatformLibraryOpenError(manifest_file->LibraryPath());
-                std::string warning_message = "ApiLayerInterface::LoadApiLayers skipping layer ";
-                warning_message += manifest_file->LayerName();
-                warning_message += ", failed to load with message \"";
-                warning_message += library_message;
-                warning_message += "\"";
-                LoaderLogger::LogWarningMessage(openxr_command, warning_message);
-                continue;
-            }
-
-            // Get and settle on an layer interface version (using any provided name if required).
-            std::string function_name = manifest_file->GetFunctionName("xrNegotiateLoaderApiLayerInterface");
-            PFN_xrNegotiateLoaderApiLayerInterface negotiate = reinterpret_cast<PFN_xrNegotiateLoaderApiLayerInterface>(
-                LoaderPlatformLibraryGetProcAddr(layer_library, function_name));
-
-            // Loader info for negotiation
-            XrNegotiateLoaderInfo loader_info = {};
-            loader_info.structType = XR_LOADER_INTERFACE_STRUCT_LOADER_INFO;
-            loader_info.structVersion = XR_LOADER_INFO_STRUCT_VERSION;
-            loader_info.structSize = sizeof(XrNegotiateLoaderInfo);
-            loader_info.minInterfaceVersion = 1;
-            loader_info.maxInterfaceVersion = XR_CURRENT_LOADER_API_LAYER_VERSION;
-            loader_info.minXrVersion = XR_MAKE_VERSION(0, 1, 0);
-            loader_info.maxXrVersion = XR_MAKE_VERSION(1, 0, 0);
-
-            // Set up the layer return structure
-            XrNegotiateApiLayerRequest api_layer_info = {};
-            api_layer_info.structType = XR_LOADER_INTERFACE_STRUCT_API_LAYER_REQUEST;
-            api_layer_info.structVersion = XR_API_LAYER_INFO_STRUCT_VERSION;
-            api_layer_info.structSize = sizeof(XrNegotiateApiLayerRequest);
-
-            XrResult res = negotiate(&loader_info, manifest_file->LayerName().c_str(), &api_layer_info);
-            // If we supposedly succeeded, but got a nullptr for getInstanceProcAddr
-            // then something still went wrong, so return with an error.
-            if (XR_SUCCESS == res && nullptr == api_layer_info.getInstanceProcAddr) {
-                std::string warning_message = "ApiLayerInterface::LoadApiLayers skipping layer ";
-                warning_message += manifest_file->LayerName();
-                warning_message += ", negotiation did not return a valid getInstanceProcAddr";
-                LoaderLogger::LogWarningMessage(openxr_command, warning_message);
-                res = XR_ERROR_FILE_CONTENTS_INVALID;
-            }
-            if (XR_SUCCESS != res) {
-                if (!any_loaded) {
-                    last_error = res;
-                }
-                std::ostringstream oss;
-                oss << "ApiLayerInterface::LoadApiLayers skipping layer " << manifest_file->LayerName()
-                    << " due to failed negotiation with error " << res;
-                LoaderLogger::LogWarningMessage(openxr_command, oss.str());
-                LoaderPlatformLibraryClose(layer_library);
-                continue;
-            }
-
-            {
-                std::ostringstream oss;
-                oss << "ApiLayerInterface::LoadApiLayers succeeded loading layer " << manifest_file->LayerName()
-                    << " using interface version " << api_layer_info.layerInterfaceVersion << " and OpenXR API version "
-                    << XR_VERSION_MAJOR(api_layer_info.layerXrVersion) << "." << XR_VERSION_MINOR(api_layer_info.layerXrVersion);
-                LoaderLogger::LogInfoMessage(openxr_command, oss.str());
-            }
-
-            // Grab the list of extensions this layer supports for easy filtering after the
-            // xrCreateInstance call
-            std::vector<std::string> supported_extensions;
-            std::vector<XrExtensionProperties> extension_properties;
-            manifest_file->GetInstanceExtensionProperties(extension_properties);
-            for (XrExtensionProperties& ext_prop : extension_properties) {
-                supported_extensions.push_back(ext_prop.extensionName);
-            }
-
-            // Add this runtime to the vector
-            api_layer_interfaces.emplace_back(new ApiLayerInterface(manifest_file->LayerName(), layer_library, supported_extensions,
-                                                                    api_layer_info.getInstanceProcAddr,
-                                                                    api_layer_info.createApiLayerInstance));
-
-            // If we load one, clear all errors.
-            any_loaded = true;
-            last_error = XR_SUCCESS;
         }
 
-        // If even one of the layers wasn't found, we want to return an error
-        for (uint32_t layer = 0; layer < layer_found.size(); ++layer) {
-            if (!layer_found[layer]) {
-                std::string error_message = "ApiLayerInterface::LoadApiLayers - failed to find layer ";
-                error_message += enabled_api_layers[layer];
-                LoaderLogger::LogErrorMessage(openxr_command, error_message);
-                last_error = XR_ERROR_API_LAYER_NOT_PRESENT;
-            }
+        // If this layer isn't enabled, skip it.
+        if (!enabled) {
+            continue;
         }
 
-        // Always clear the manifest file list.  Either we use them or we don't.
-        layer_manifest_files.clear();
+        LoaderPlatformLibraryHandle layer_library = LoaderPlatformLibraryOpen(manifest_file->LibraryPath());
+        if (nullptr == layer_library) {
+            if (!any_loaded) {
+                last_error = XR_ERROR_FILE_ACCESS_ERROR;
+            }
+            std::string library_message = LoaderPlatformLibraryOpenError(manifest_file->LibraryPath());
+            std::string warning_message = "ApiLayerInterface::LoadApiLayers skipping layer ";
+            warning_message += manifest_file->LayerName();
+            warning_message += ", failed to load with message \"";
+            warning_message += library_message;
+            warning_message += "\"";
+            LoaderLogger::LogWarningMessage(openxr_command, warning_message);
+            continue;
+        }
+
+        // Get and settle on an layer interface version (using any provided name if required).
+        std::string function_name = manifest_file->GetFunctionName("xrNegotiateLoaderApiLayerInterface");
+        PFN_xrNegotiateLoaderApiLayerInterface negotiate = reinterpret_cast<PFN_xrNegotiateLoaderApiLayerInterface>(
+            LoaderPlatformLibraryGetProcAddr(layer_library, function_name));
+
+        // Loader info for negotiation
+        XrNegotiateLoaderInfo loader_info = {};
+        loader_info.structType = XR_LOADER_INTERFACE_STRUCT_LOADER_INFO;
+        loader_info.structVersion = XR_LOADER_INFO_STRUCT_VERSION;
+        loader_info.structSize = sizeof(XrNegotiateLoaderInfo);
+        loader_info.minInterfaceVersion = 1;
+        loader_info.maxInterfaceVersion = XR_CURRENT_LOADER_API_LAYER_VERSION;
+        loader_info.minXrVersion = XR_MAKE_VERSION(0, 1, 0);
+        loader_info.maxXrVersion = XR_MAKE_VERSION(1, 0, 0);
+
+        // Set up the layer return structure
+        XrNegotiateApiLayerRequest api_layer_info = {};
+        api_layer_info.structType = XR_LOADER_INTERFACE_STRUCT_API_LAYER_REQUEST;
+        api_layer_info.structVersion = XR_API_LAYER_INFO_STRUCT_VERSION;
+        api_layer_info.structSize = sizeof(XrNegotiateApiLayerRequest);
+
+        XrResult res = negotiate(&loader_info, manifest_file->LayerName().c_str(), &api_layer_info);
+        // If we supposedly succeeded, but got a nullptr for getInstanceProcAddr
+        // then something still went wrong, so return with an error.
+        if (XR_SUCCESS == res && nullptr == api_layer_info.getInstanceProcAddr) {
+            std::string warning_message = "ApiLayerInterface::LoadApiLayers skipping layer ";
+            warning_message += manifest_file->LayerName();
+            warning_message += ", negotiation did not return a valid getInstanceProcAddr";
+            LoaderLogger::LogWarningMessage(openxr_command, warning_message);
+            res = XR_ERROR_FILE_CONTENTS_INVALID;
+        }
+        if (XR_SUCCESS != res) {
+            if (!any_loaded) {
+                last_error = res;
+            }
+            std::ostringstream oss;
+            oss << "ApiLayerInterface::LoadApiLayers skipping layer " << manifest_file->LayerName()
+                << " due to failed negotiation with error " << res;
+            LoaderLogger::LogWarningMessage(openxr_command, oss.str());
+            LoaderPlatformLibraryClose(layer_library);
+            continue;
+        }
+
+        {
+            std::ostringstream oss;
+            oss << "ApiLayerInterface::LoadApiLayers succeeded loading layer " << manifest_file->LayerName()
+                << " using interface version " << api_layer_info.layerInterfaceVersion << " and OpenXR API version "
+                << XR_VERSION_MAJOR(api_layer_info.layerXrVersion) << "." << XR_VERSION_MINOR(api_layer_info.layerXrVersion);
+            LoaderLogger::LogInfoMessage(openxr_command, oss.str());
+        }
+
+        // Grab the list of extensions this layer supports for easy filtering after the
+        // xrCreateInstance call
+        std::vector<std::string> supported_extensions;
+        std::vector<XrExtensionProperties> extension_properties;
+        manifest_file->GetInstanceExtensionProperties(extension_properties);
+        for (XrExtensionProperties& ext_prop : extension_properties) {
+            supported_extensions.push_back(ext_prop.extensionName);
+        }
+
+        // Add this runtime to the vector
+        api_layer_interfaces.emplace_back(new ApiLayerInterface(manifest_file->LayerName(), layer_library, supported_extensions,
+                                                                api_layer_info.getInstanceProcAddr,
+                                                                api_layer_info.createApiLayerInstance));
+
+        // If we load one, clear all errors.
+        any_loaded = true;
+        last_error = XR_SUCCESS;
+    }
+
+    // If even one of the layers wasn't found, we want to return an error
+    for (uint32_t layer = 0; layer < layer_found.size(); ++layer) {
+        if (!layer_found[layer]) {
+            std::string error_message = "ApiLayerInterface::LoadApiLayers - failed to find layer ";
+            error_message += enabled_api_layers[layer];
+            LoaderLogger::LogErrorMessage(openxr_command, error_message);
+            last_error = XR_ERROR_API_LAYER_NOT_PRESENT;
+        }
+    }
+
+    // Always clear the manifest file list.  Either we use them or we don't.
+    layer_manifest_files.clear();
     } catch (std::bad_alloc&) {
         LoaderLogger::LogErrorMessage(openxr_command, "ApiLayerInterface::LoadApiLayers - failed to allocate memory");
         last_error = XR_ERROR_OUT_OF_MEMORY;
@@ -396,12 +396,12 @@ ApiLayerInterface::~ApiLayerInterface() {
 bool ApiLayerInterface::SupportsExtension(const std::string& extension_name) {
     bool found_prop = false;
     try {
-        for (std::string supported_extension : _supported_extensions) {
-            if (supported_extension == extension_name) {
-                found_prop = true;
-                break;
-            }
+    for (std::string supported_extension : _supported_extensions) {
+        if (supported_extension == extension_name) {
+            found_prop = true;
+            break;
         }
+    }
     } catch (...) {
     }
     return found_prop;

--- a/src/loader/api_layer_interface.cpp
+++ b/src/loader/api_layer_interface.cpp
@@ -32,7 +32,6 @@
 
 // Add any layers defined in the loader layer environment variable.
 static void AddEnvironmentApiLayers(const std::string& openxr_command, std::vector<std::string>& enabled_layers) {
-    try {
     char* layer_environment_variable = PlatformUtilsGetEnv(OPENXR_ENABLE_LAYERS_ENV_VAR);
     if (nullptr != layer_environment_variable) {
         std::string layers = layer_environment_variable;
@@ -56,15 +55,10 @@ static void AddEnvironmentApiLayers(const std::string& openxr_command, std::vect
             enabled_layers.push_back(cur_search);
         }
     }
-    } catch (...) {
-        LoaderLogger::LogErrorMessage(openxr_command, "AddEnvironmentApiLayers - unknown error occurred");
-        throw;
-    }
 }
 
 XrResult ApiLayerInterface::GetApiLayerProperties(const std::string& openxr_command, uint32_t incoming_count,
                                                   uint32_t* outgoing_count, XrApiLayerProperties* api_layer_properties) {
-    try {
     std::vector<std::unique_ptr<ApiLayerManifestFile>> manifest_files;
     uint32_t manifest_count = 0;
 
@@ -117,15 +111,10 @@ XrResult ApiLayerInterface::GetApiLayerProperties(const std::string& openxr_comm
         }
     }
     return XR_SUCCESS;
-    } catch (...) {
-        LoaderLogger::LogErrorMessage(openxr_command, "ApiLayerInterface::GetApiLayerProperties - unknown error occurred");
-        return XR_ERROR_VALIDATION_FAILURE;
-    }
 }
 
 XrResult ApiLayerInterface::GetInstanceExtensionProperties(const std::string& openxr_command, const char* layer_name,
                                                            std::vector<XrExtensionProperties>& extension_properties) {
-    try {
     std::vector<std::unique_ptr<ApiLayerManifestFile>> manifest_files;
 
     // If a layer name is supplied, only use the information out of that one layer
@@ -192,17 +181,12 @@ XrResult ApiLayerInterface::GetInstanceExtensionProperties(const std::string& op
         }
     }
     return XR_SUCCESS;
-    } catch (...) {
-        LoaderLogger::LogErrorMessage(openxr_command, "ApiLayerInterface::GetInstanceExtensionProperties - unknown error occurred");
-        return XR_ERROR_INITIALIZATION_FAILED;
-    }
 }
 
 XrResult ApiLayerInterface::LoadApiLayers(const std::string& openxr_command, uint32_t enabled_api_layer_count,
                                           const char* const* enabled_api_layer_names,
                                           std::vector<std::unique_ptr<ApiLayerInterface>>& api_layer_interfaces) {
     XrResult last_error = XR_SUCCESS;
-    try {
     bool any_loaded = false;
     std::vector<bool> layer_found;
     std::vector<std::unique_ptr<ApiLayerManifestFile>> layer_manifest_files = {};
@@ -360,13 +344,6 @@ XrResult ApiLayerInterface::LoadApiLayers(const std::string& openxr_command, uin
 
     // Always clear the manifest file list.  Either we use them or we don't.
     layer_manifest_files.clear();
-    } catch (std::bad_alloc&) {
-        LoaderLogger::LogErrorMessage(openxr_command, "ApiLayerInterface::LoadApiLayers - failed to allocate memory");
-        last_error = XR_ERROR_OUT_OF_MEMORY;
-    } catch (...) {
-        LoaderLogger::LogErrorMessage(openxr_command, "ApiLayerInterface::LoadApiLayers - unknown error");
-        last_error = XR_ERROR_FILE_ACCESS_ERROR;
-    }
 
     // If we failed catastrophically for some reason, clean up everything.
     if (XR_SUCCESS != last_error) {
@@ -395,14 +372,11 @@ ApiLayerInterface::~ApiLayerInterface() {
 
 bool ApiLayerInterface::SupportsExtension(const std::string& extension_name) {
     bool found_prop = false;
-    try {
     for (std::string supported_extension : _supported_extensions) {
         if (supported_extension == extension_name) {
             found_prop = true;
             break;
         }
-    }
-    } catch (...) {
     }
     return found_prop;
 }

--- a/src/loader/loader_core.cpp
+++ b/src/loader/loader_core.cpp
@@ -64,7 +64,6 @@ extern "C" {
 LOADER_EXPORT XRAPI_ATTR XrResult XRAPI_CALL xrEnumerateApiLayerProperties(uint32_t propertyCapacityInput,
                                                                            uint32_t *propertyCountOutput,
                                                                            XrApiLayerProperties *properties) {
-    try {
     LoaderLogger::LogVerboseMessage("xrEnumerateApiLayerProperties", "Entering loader trampoline");
 
     // Make sure only one thread is attempting to read the JSON files at a time.
@@ -77,19 +76,12 @@ LOADER_EXPORT XRAPI_ATTR XrResult XRAPI_CALL xrEnumerateApiLayerProperties(uint3
     }
 
     return result;
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("xrEnumerateApiLayerProperties", "Unknown error occurred");
-        return XR_ERROR_VALIDATION_FAILURE;
-    }
-
-    return XR_SUCCESS;
 }
 
 LOADER_EXPORT XRAPI_ATTR XrResult XRAPI_CALL xrEnumerateInstanceExtensionProperties(const char *layerName,
                                                                                     uint32_t propertyCapacityInput,
                                                                                     uint32_t *propertyCountOutput,
                                                                                     XrExtensionProperties *properties) {
-    try {
     bool just_layer_properties = false;
     LoaderLogger::LogVerboseMessage("xrEnumerateInstanceExtensionProperties", "Entering loader trampoline");
 
@@ -191,16 +183,11 @@ LOADER_EXPORT XRAPI_ATTR XrResult XRAPI_CALL xrEnumerateInstanceExtensionPropert
     }
     LoaderLogger::LogVerboseMessage("xrEnumerateInstanceExtensionProperties", "Completed loader trampoline");
     return XR_SUCCESS;
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("xrEnumerateInstanceExtensionProperties", "Unknown error occurred");
-        return XR_ERROR_INITIALIZATION_FAILED;
-    }
 }
 
 LOADER_EXPORT XRAPI_ATTR XrResult XRAPI_CALL xrCreateInstance(const XrInstanceCreateInfo *info, XrInstance *instance) {
     bool runtime_loaded = false;
 
-    try {
     LoaderLogger::LogVerboseMessage("xrCreateInstance", "Entering loader trampoline");
     if (nullptr == info) {
         LoaderLogger::LogValidationErrorMessage("VUID-xrCreateInstance-info-parameter", "xrCreateInstance", "must be non-NULL");
@@ -286,23 +273,10 @@ LOADER_EXPORT XRAPI_ATTR XrResult XRAPI_CALL xrCreateInstance(const XrInstanceCr
 
     LoaderLogger::LogVerboseMessage("xrCreateInstance", "Completed loader trampoline");
     return result;
-    } catch (std::bad_alloc &) {
-        if (runtime_loaded) {
-            RuntimeInterface::UnloadRuntime("xrCreateInstance");
-        }
-        LoaderLogger::LogErrorMessage("xrCreateInstance", "Failed to allocate memory");
-        return XR_ERROR_OUT_OF_MEMORY;
-    } catch (...) {
-        if (runtime_loaded) {
-            RuntimeInterface::UnloadRuntime("xrCreateInstance");
-        }
-        LoaderLogger::LogErrorMessage("xrCreateInstance", "Unknown error occurred");
-        return XR_ERROR_INITIALIZATION_FAILED;
-    }
 }
 
 LOADER_EXPORT XRAPI_ATTR XrResult XRAPI_CALL xrDestroyInstance(XrInstance instance) {
-    try {
+
     LoaderLogger::LogVerboseMessage("xrDestroyInstance", "Entering loader trampoline");
     // XR_NULL_HANDLE is ignored, but valid, in a delete operation.
     if (XR_NULL_HANDLE == instance) {
@@ -336,9 +310,6 @@ LOADER_EXPORT XRAPI_ATTR XrResult XRAPI_CALL xrDestroyInstance(XrInstance instan
     std::unique_lock<std::mutex> loader_instance_lock(g_loader_instance_mutex);
     delete loader_instance;
     LoaderLogger::LogVerboseMessage("xrDestroyInstance", "Completed loader trampoline");
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("xrDestroyInstance", "Unknown error occurred");
-    }
 
     // Finally, unload the runtime if necessary
     RuntimeInterface::UnloadRuntime("xrDestroyInstance");
@@ -425,7 +396,6 @@ XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermDestroyInstance(XrInstance instance) 
 XRAPI_ATTR XrResult XRAPI_CALL xrCreateDebugUtilsMessengerEXT(XrInstance instance,
                                                               const XrDebugUtilsMessengerCreateInfoEXT *createInfo,
                                                               XrDebugUtilsMessengerEXT *messenger) {
-    try {
     LoaderLogger::LogVerboseMessage("xrCreateDebugUtilsMessengerEXT", "Entering loader trampoline");
 
     LoaderInstance *loader_instance = g_instance_map.Get(instance);
@@ -457,21 +427,11 @@ XRAPI_ATTR XrResult XRAPI_CALL xrCreateDebugUtilsMessengerEXT(XrInstance instanc
     }
     LoaderLogger::LogVerboseMessage("xrCreateDebugUtilsMessengerEXT", "Completed loader trampoline");
     return result;
-    } catch (std::bad_alloc &) {
-        LoaderLogger::LogErrorMessage("xrCreateDebugUtilsMessengerEXT",
-                                      "xrCreateDebugUtilsMessengerEXT trampoline failed allocating memory");
-        return XR_ERROR_OUT_OF_MEMORY;
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("xrCreateDebugUtilsMessengerEXT",
-                                      "xrCreateDebugUtilsMessengerEXT trampoline encountered an unknown error");
-        return XR_ERROR_INITIALIZATION_FAILED;
-    }
 }
 
 XRAPI_ATTR XrResult XRAPI_CALL xrDestroyDebugUtilsMessengerEXT(XrDebugUtilsMessengerEXT messenger) {
     // TODO: get instance from messenger in loader
     // Also, is the loader really doing all this every call?
-    try {
     LoaderLogger::LogVerboseMessage("xrDestroyDebugUtilsMessengerEXT", "Entering loader trampoline");
 
     if (XR_NULL_HANDLE == messenger) {
@@ -499,13 +459,6 @@ XRAPI_ATTR XrResult XRAPI_CALL xrDestroyDebugUtilsMessengerEXT(XrDebugUtilsMesse
     XrResult result = dispatch_table->DestroyDebugUtilsMessengerEXT(messenger);
     LoaderLogger::LogVerboseMessage("xrDestroyDebugUtilsMessengerEXT", "Completed loader trampoline");
     return result;
-    } catch (...) {
-        LoaderLogger::LogErrorMessage(
-            "xrDestroyDebugUtilsMessengerEXT",
-            "xrDestroyDebugUtilsMessengerEXT trampoline encountered an unknown error.  Likely XrDebugUtilsMessengerEXT " +
-                HandleToHexString(messenger) + " is invalid");
-        return XR_ERROR_HANDLE_INVALID;
-    }
 }
 
 // ---- Extension manual loader terminator functions
@@ -513,7 +466,6 @@ XRAPI_ATTR XrResult XRAPI_CALL xrDestroyDebugUtilsMessengerEXT(XrDebugUtilsMesse
 XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermCreateDebugUtilsMessengerEXT(XrInstance instance,
                                                                         const XrDebugUtilsMessengerCreateInfoEXT *createInfo,
                                                                         XrDebugUtilsMessengerEXT *messenger) {
-    try {
     LoaderLogger::LogVerboseMessage("xrCreateDebugUtilsMessengerEXT", "Entering loader terminator");
     if (nullptr == messenger) {
         LoaderLogger::LogValidationErrorMessage("VUID-xrCreateDebugUtilsMessengerEXT-messenger-parameter",
@@ -536,17 +488,9 @@ XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermCreateDebugUtilsMessengerEXT(XrInstan
     }
     LoaderLogger::LogVerboseMessage("xrCreateDebugUtilsMessengerEXT", "Completed loader terminator");
     return result;
-    } catch (std::bad_alloc &) {
-        LoaderLogger::LogErrorMessage("xrCreateDebugUtilsMessengerEXT", "Terminator failed allocating memory");
-        return XR_ERROR_OUT_OF_MEMORY;
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("xrCreateDebugUtilsMessengerEXT", "Terminator encountered an unknown error");
-        return XR_ERROR_INITIALIZATION_FAILED;
-    }
 }
 
 XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermDestroyDebugUtilsMessengerEXT(XrDebugUtilsMessengerEXT messenger) {
-    try {
     LoaderLogger::LogVerboseMessage("xrDestroyDebugUtilsMessengerEXT", "Entering loader terminator");
     const XrGeneratedDispatchTable *dispatch_table =
         RuntimeInterface::GetRuntime().GetDebugUtilsMessengerDispatchTable(messenger);
@@ -562,19 +506,12 @@ XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermDestroyDebugUtilsMessengerEXT(XrDebug
     LoaderLogger::GetInstance().RemoveLogRecorder(MakeHandleGeneric(messenger));
     RuntimeInterface::GetRuntime().ForgetDebugMessenger(messenger);
     return result;
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("xrDestroyDebugUtilsMessengerEXT",
-                                      "Terminator encountered an unknown error.  Likely XrDebugUtilsMessengerEXT " +
-                                          HandleToHexString(messenger) + " is invalid");
-        return XR_ERROR_DEBUG_UTILS_MESSENGER_INVALID_EXT;
-    }
 }
 
 XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermSubmitDebugUtilsMessageEXT(XrInstance instance,
                                                                       XrDebugUtilsMessageSeverityFlagsEXT messageSeverity,
                                                                       XrDebugUtilsMessageTypeFlagsEXT messageTypes,
                                                                       const XrDebugUtilsMessengerCallbackDataEXT *callbackData) {
-    try {
     LoaderLogger::LogVerboseMessage("xrSubmitDebugUtilsMessageEXT", "Entering loader terminator");
     const XrGeneratedDispatchTable *dispatch_table = RuntimeInterface::GetRuntime().GetDispatchTable(instance);
     XrResult result = XR_SUCCESS;
@@ -587,17 +524,10 @@ XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermSubmitDebugUtilsMessageEXT(XrInstance
     }
     LoaderLogger::LogVerboseMessage("xrSubmitDebugUtilsMessageEXT", "Completed loader terminator");
     return result;
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("xrSubmitDebugUtilsMessageEXT",
-                                      "xrSubmitDebugUtilsMessageEXT terminator encountered an unknown error.  Likely XrInstance " +
-                                          HandleToHexString(instance) + " is invalid");
-        return XR_ERROR_HANDLE_INVALID;
-    }
 }
 
 XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermSetDebugUtilsObjectNameEXT(XrInstance instance,
                                                                       const XrDebugUtilsObjectNameInfoEXT *nameInfo) {
-    try {
     LoaderLogger::LogVerboseMessage("xrSetDebugUtilsObjectNameEXT", "Entering loader terminator");
     const XrGeneratedDispatchTable *dispatch_table = RuntimeInterface::GetRuntime().GetDispatchTable(instance);
     XrResult result = XR_SUCCESS;
@@ -607,16 +537,9 @@ XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermSetDebugUtilsObjectNameEXT(XrInstance
     LoaderLogger::GetInstance().AddObjectName(nameInfo->objectHandle, nameInfo->objectType, nameInfo->objectName);
     LoaderLogger::LogVerboseMessage("xrSetDebugUtilsObjectNameEXT", "Completed loader terminator");
     return result;
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("xrSetDebugUtilsObjectNameEXT",
-                                      "xrSetDebugUtilsObjectNameEXT terminator encountered an unknown error.  Likely XrInstance " +
-                                          HandleToHexString(instance) + "is invalid");
-        return XR_ERROR_HANDLE_INVALID;
-    }
 }
 
 XRAPI_ATTR XrResult XRAPI_CALL xrSessionBeginDebugUtilsLabelRegionEXT(XrSession session, const XrDebugUtilsLabelEXT *labelInfo) {
-    try {
     LoaderInstance *loader_instance = g_session_map.Get(session);
     if (nullptr == loader_instance) {
         LoaderLogger::LogValidationErrorMessage("VUID-xrSessionBeginDebugUtilsLabelRegionEXT-session-parameter",
@@ -641,16 +564,10 @@ XRAPI_ATTR XrResult XRAPI_CALL xrSessionBeginDebugUtilsLabelRegionEXT(XrSession 
     if (nullptr != dispatch_table->SessionBeginDebugUtilsLabelRegionEXT) {
         return dispatch_table->SessionBeginDebugUtilsLabelRegionEXT(session, labelInfo);
     }
-    return XR_SUCCESS;
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("xrSessionBeginDebugUtilsLabelRegionEXT",
-                                      "xrSessionBeginDebugUtilsLabelRegionEXT trampoline encountered an unknown error");
-        return XR_ERROR_VALIDATION_FAILURE;
-    }
+    return XR_SUCCESS; 
 }
 
 XRAPI_ATTR XrResult XRAPI_CALL xrSessionEndDebugUtilsLabelRegionEXT(XrSession session) {
-    try {
     LoaderInstance *loader_instance = g_session_map.Get(session);
     if (nullptr == loader_instance) {
         LoaderLogger::LogValidationErrorMessage("VUID-xrSessionEndDebugUtilsLabelRegionEXT-session-parameter",
@@ -666,15 +583,9 @@ XRAPI_ATTR XrResult XRAPI_CALL xrSessionEndDebugUtilsLabelRegionEXT(XrSession se
         return dispatch_table->SessionEndDebugUtilsLabelRegionEXT(session);
     }
     return XR_SUCCESS;
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("xrSessionEndDebugUtilsLabelRegionEXT",
-                                      "xrSessionEndDebugUtilsLabelRegionEXT trampoline encountered an unknown error");
-        return XR_ERROR_VALIDATION_FAILURE;
-    }
 }
 
 XRAPI_ATTR XrResult XRAPI_CALL xrSessionInsertDebugUtilsLabelEXT(XrSession session, const XrDebugUtilsLabelEXT *labelInfo) {
-    try {
     LoaderInstance *loader_instance = g_session_map.Get(session);
     if (nullptr == loader_instance) {
         LoaderLogger::LogValidationErrorMessage("VUID-xrSessionInsertDebugUtilsLabelEXT-session-parameter",
@@ -700,11 +611,6 @@ XRAPI_ATTR XrResult XRAPI_CALL xrSessionInsertDebugUtilsLabelEXT(XrSession sessi
         return dispatch_table->SessionInsertDebugUtilsLabelEXT(session, labelInfo);
     }
     return XR_SUCCESS;
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("xrSessionInsertDebugUtilsLabelEXT",
-                                      "xrSessionInsertDebugUtilsLabelEXT trampoline encountered an unknown error");
-        return XR_ERROR_VALIDATION_FAILURE;
-    }
 }
 
 }  // extern "C"

--- a/src/loader/loader_core.cpp
+++ b/src/loader/loader_core.cpp
@@ -65,18 +65,18 @@ LOADER_EXPORT XRAPI_ATTR XrResult XRAPI_CALL xrEnumerateApiLayerProperties(uint3
                                                                            uint32_t *propertyCountOutput,
                                                                            XrApiLayerProperties *properties) {
     try {
-        LoaderLogger::LogVerboseMessage("xrEnumerateApiLayerProperties", "Entering loader trampoline");
+    LoaderLogger::LogVerboseMessage("xrEnumerateApiLayerProperties", "Entering loader trampoline");
 
-        // Make sure only one thread is attempting to read the JSON files at a time.
-        std::unique_lock<std::mutex> json_lock(g_loader_json_mutex);
+    // Make sure only one thread is attempting to read the JSON files at a time.
+    std::unique_lock<std::mutex> json_lock(g_loader_json_mutex);
 
-        XrResult result = ApiLayerInterface::GetApiLayerProperties("xrEnumerateApiLayerProperties", propertyCapacityInput,
-                                                                   propertyCountOutput, properties);
-        if (XR_SUCCESS != result) {
-            LoaderLogger::LogErrorMessage("xrEnumerateApiLayerProperties", "Failed ApiLayerInterface::GetApiLayerProperties");
-        }
+    XrResult result = ApiLayerInterface::GetApiLayerProperties("xrEnumerateApiLayerProperties", propertyCapacityInput,
+                                                               propertyCountOutput, properties);
+    if (XR_SUCCESS != result) {
+        LoaderLogger::LogErrorMessage("xrEnumerateApiLayerProperties", "Failed ApiLayerInterface::GetApiLayerProperties");
+    }
 
-        return result;
+    return result;
     } catch (...) {
         LoaderLogger::LogErrorMessage("xrEnumerateApiLayerProperties", "Unknown error occurred");
         return XR_ERROR_VALIDATION_FAILURE;
@@ -90,107 +90,107 @@ LOADER_EXPORT XRAPI_ATTR XrResult XRAPI_CALL xrEnumerateInstanceExtensionPropert
                                                                                     uint32_t *propertyCountOutput,
                                                                                     XrExtensionProperties *properties) {
     try {
-        bool just_layer_properties = false;
-        LoaderLogger::LogVerboseMessage("xrEnumerateInstanceExtensionProperties", "Entering loader trampoline");
+    bool just_layer_properties = false;
+    LoaderLogger::LogVerboseMessage("xrEnumerateInstanceExtensionProperties", "Entering loader trampoline");
 
-        if (nullptr != layerName && 0 != strlen(layerName)) {
-            // Application is only interested in layer's properties, not all of them.
-            just_layer_properties = true;
-        }
+    if (nullptr != layerName && 0 != strlen(layerName)) {
+        // Application is only interested in layer's properties, not all of them.
+        just_layer_properties = true;
+    }
 
-        std::vector<XrExtensionProperties> extension_properties = {};
-        XrResult result;
+    std::vector<XrExtensionProperties> extension_properties = {};
+    XrResult result;
 
-        {
-            // Make sure only one thread is attempting to read the JSON files at a time.
-            std::unique_lock<std::mutex> json_lock(g_loader_json_mutex);
+    {
+        // Make sure only one thread is attempting to read the JSON files at a time.
+        std::unique_lock<std::mutex> json_lock(g_loader_json_mutex);
 
-            // Get the layer extension properties
-            result = ApiLayerInterface::GetInstanceExtensionProperties("xrEnumerateInstanceExtensionProperties", layerName,
-                                                                       extension_properties);
-            if (XR_SUCCESS == result && !just_layer_properties) {
-                // If not specific to a layer, get the runtime extension properties
-                result = RuntimeInterface::LoadRuntime("xrEnumerateInstanceExtensionProperties");
-                if (XR_SUCCESS == result) {
-                    RuntimeInterface::GetRuntime().GetInstanceExtensionProperties(extension_properties);
-                    RuntimeInterface::UnloadRuntime("xrEnumerateInstanceExtensionProperties");
-                } else {
-                    LoaderLogger::LogErrorMessage("xrEnumerateInstanceExtensionProperties",
-                                                  "Failed to find default runtime with RuntimeInterface::LoadRuntime()");
-                }
+        // Get the layer extension properties
+        result = ApiLayerInterface::GetInstanceExtensionProperties("xrEnumerateInstanceExtensionProperties", layerName,
+                                                                   extension_properties);
+        if (XR_SUCCESS == result && !just_layer_properties) {
+            // If not specific to a layer, get the runtime extension properties
+            result = RuntimeInterface::LoadRuntime("xrEnumerateInstanceExtensionProperties");
+            if (XR_SUCCESS == result) {
+                RuntimeInterface::GetRuntime().GetInstanceExtensionProperties(extension_properties);
+                RuntimeInterface::UnloadRuntime("xrEnumerateInstanceExtensionProperties");
+            } else {
+                LoaderLogger::LogErrorMessage("xrEnumerateInstanceExtensionProperties",
+                                              "Failed to find default runtime with RuntimeInterface::LoadRuntime()");
             }
         }
+    }
 
-        if (XR_SUCCESS != result) {
-            LoaderLogger::LogErrorMessage("xrEnumerateInstanceExtensionProperties", "Failed querying extension properties");
-            return result;
-        }
+    if (XR_SUCCESS != result) {
+        LoaderLogger::LogErrorMessage("xrEnumerateInstanceExtensionProperties", "Failed querying extension properties");
+        return result;
+    }
 
-        // If this is not in reference to a specific layer, then add the loader-specific extension properties as well.
-        // These are extensions that the loader directly supports.
-        if (!just_layer_properties) {
-            auto loader_extension_props = LoaderInstance::LoaderSpecificExtensions();
-            for (XrExtensionProperties &loader_prop : loader_extension_props) {
-                bool found_prop = false;
-                for (XrExtensionProperties &existing_prop : extension_properties) {
-                    if (0 == strcmp(existing_prop.extensionName, loader_prop.extensionName)) {
-                        found_prop = true;
-                        // Use the loader version if it is newer
-                        if (existing_prop.specVersion < loader_prop.specVersion) {
-                            existing_prop.specVersion = loader_prop.specVersion;
-                        }
-                        break;
+    // If this is not in reference to a specific layer, then add the loader-specific extension properties as well.
+    // These are extensions that the loader directly supports.
+    if (!just_layer_properties) {
+        auto loader_extension_props = LoaderInstance::LoaderSpecificExtensions();
+        for (XrExtensionProperties &loader_prop : loader_extension_props) {
+            bool found_prop = false;
+            for (XrExtensionProperties &existing_prop : extension_properties) {
+                if (0 == strcmp(existing_prop.extensionName, loader_prop.extensionName)) {
+                    found_prop = true;
+                    // Use the loader version if it is newer
+                    if (existing_prop.specVersion < loader_prop.specVersion) {
+                        existing_prop.specVersion = loader_prop.specVersion;
                     }
-                }
-                // Only add extensions not supported by the loader
-                if (!found_prop) {
-                    extension_properties.push_back(loader_prop);
+                    break;
                 }
             }
+            // Only add extensions not supported by the loader
+            if (!found_prop) {
+                extension_properties.push_back(loader_prop);
+            }
         }
+    }
 
-        uint32_t num_extension_properties = static_cast<uint32_t>(extension_properties.size());
-        if (propertyCapacityInput == 0) {
+    uint32_t num_extension_properties = static_cast<uint32_t>(extension_properties.size());
+    if (propertyCapacityInput == 0) {
+        *propertyCountOutput = num_extension_properties;
+    } else if (nullptr != properties) {
+        if (propertyCapacityInput < num_extension_properties) {
             *propertyCountOutput = num_extension_properties;
-        } else if (nullptr != properties) {
-            if (propertyCapacityInput < num_extension_properties) {
-                *propertyCountOutput = num_extension_properties;
-                LoaderLogger::LogValidationErrorMessage("VUID-xrEnumerateInstanceExtensionProperties-propertyCountOutput-parameter",
-                                                        "xrEnumerateInstanceExtensionProperties", "insufficient space in array");
-                return XR_ERROR_SIZE_INSUFFICIENT;
-            }
+            LoaderLogger::LogValidationErrorMessage("VUID-xrEnumerateInstanceExtensionProperties-propertyCountOutput-parameter",
+                                                    "xrEnumerateInstanceExtensionProperties", "insufficient space in array");
+            return XR_ERROR_SIZE_INSUFFICIENT;
+        }
 
-            uint32_t num_to_copy = num_extension_properties;
-            // Determine how many extension properties we can copy over
-            if (propertyCapacityInput < num_to_copy) {
-                num_to_copy = propertyCapacityInput;
+        uint32_t num_to_copy = num_extension_properties;
+        // Determine how many extension properties we can copy over
+        if (propertyCapacityInput < num_to_copy) {
+            num_to_copy = propertyCapacityInput;
+        }
+        bool properties_valid = true;
+        for (uint32_t prop = 0; prop < propertyCapacityInput && prop < extension_properties.size(); ++prop) {
+            if (XR_TYPE_EXTENSION_PROPERTIES != properties[prop].type) {
+                properties_valid = false;
+                LoaderLogger::LogValidationErrorMessage("VUID-XrExtensionProperties-type-type",
+                                                        "xrEnumerateInstanceExtensionProperties", "unknown type in properties");
             }
-            bool properties_valid = true;
-            for (uint32_t prop = 0; prop < propertyCapacityInput && prop < extension_properties.size(); ++prop) {
-                if (XR_TYPE_EXTENSION_PROPERTIES != properties[prop].type) {
-                    properties_valid = false;
-                    LoaderLogger::LogValidationErrorMessage("VUID-XrExtensionProperties-type-type",
-                                                            "xrEnumerateInstanceExtensionProperties", "unknown type in properties");
-                }
-                if (nullptr != properties[prop].next) {
-                    LoaderLogger::LogValidationErrorMessage("VUID-XrExtensionProperties-next-next",
-                                                            "xrEnumerateInstanceExtensionProperties", "expected NULL");
-                    properties_valid = false;
-                }
-                if (properties_valid) {
-                    properties[prop] = extension_properties[prop];
-                }
+            if (nullptr != properties[prop].next) {
+                LoaderLogger::LogValidationErrorMessage("VUID-XrExtensionProperties-next-next",
+                                                        "xrEnumerateInstanceExtensionProperties", "expected NULL");
+                properties_valid = false;
             }
-            if (!properties_valid) {
-                LoaderLogger::LogValidationErrorMessage("VUID-xrEnumerateInstanceExtensionProperties-properties-parameter",
-                                                        "xrEnumerateInstanceExtensionProperties", "invalid properties");
-                return XR_ERROR_VALIDATION_FAILURE;
-            } else if (nullptr != propertyCountOutput) {
-                *propertyCountOutput = num_to_copy;
+            if (properties_valid) {
+                properties[prop] = extension_properties[prop];
             }
         }
-        LoaderLogger::LogVerboseMessage("xrEnumerateInstanceExtensionProperties", "Completed loader trampoline");
-        return XR_SUCCESS;
+        if (!properties_valid) {
+            LoaderLogger::LogValidationErrorMessage("VUID-xrEnumerateInstanceExtensionProperties-properties-parameter",
+                                                    "xrEnumerateInstanceExtensionProperties", "invalid properties");
+            return XR_ERROR_VALIDATION_FAILURE;
+        } else if (nullptr != propertyCountOutput) {
+            *propertyCountOutput = num_to_copy;
+        }
+    }
+    LoaderLogger::LogVerboseMessage("xrEnumerateInstanceExtensionProperties", "Completed loader trampoline");
+    return XR_SUCCESS;
     } catch (...) {
         LoaderLogger::LogErrorMessage("xrEnumerateInstanceExtensionProperties", "Unknown error occurred");
         return XR_ERROR_INITIALIZATION_FAILED;
@@ -201,91 +201,91 @@ LOADER_EXPORT XRAPI_ATTR XrResult XRAPI_CALL xrCreateInstance(const XrInstanceCr
     bool runtime_loaded = false;
 
     try {
-        LoaderLogger::LogVerboseMessage("xrCreateInstance", "Entering loader trampoline");
-        if (nullptr == info) {
-            LoaderLogger::LogValidationErrorMessage("VUID-xrCreateInstance-info-parameter", "xrCreateInstance", "must be non-NULL");
-            return XR_ERROR_VALIDATION_FAILURE;
+    LoaderLogger::LogVerboseMessage("xrCreateInstance", "Entering loader trampoline");
+    if (nullptr == info) {
+        LoaderLogger::LogValidationErrorMessage("VUID-xrCreateInstance-info-parameter", "xrCreateInstance", "must be non-NULL");
+        return XR_ERROR_VALIDATION_FAILURE;
+    } else {
+        // If application requested OpenXR API version is higher than the loader version, then we need to throw
+        // an error.
+        uint16_t app_major = XR_VERSION_MAJOR(info->applicationInfo.apiVersion);
+        uint16_t app_minor = XR_VERSION_MINOR(info->applicationInfo.apiVersion);
+        uint16_t loader_major = XR_VERSION_MAJOR(XR_CURRENT_API_VERSION);
+        uint16_t loader_minor = XR_VERSION_MINOR(XR_CURRENT_API_VERSION);
+        if (app_major > loader_major || (app_major == loader_major && app_minor > loader_minor)) {
+            std::ostringstream oss;
+            oss << "xrCreateInstance called with invalid API version " << app_major << "." << app_minor
+                << ".  Max supported version is " << loader_major << "." << loader_minor;
+            LoaderLogger::LogErrorMessage("xrCreateInstance", oss.str());
+            return XR_ERROR_DRIVER_INCOMPATIBLE;
+        }
+    }
+    if (nullptr == instance) {
+        LoaderLogger::LogValidationErrorMessage("VUID-xrCreateInstance-instance-parameter", "xrCreateInstance",
+                                                "must be non-NULL");
+        return XR_ERROR_VALIDATION_FAILURE;
+    }
+
+    std::vector<std::unique_ptr<ApiLayerInterface>> api_layer_interfaces;
+
+    // Make sure only one thread is attempting to read the JSON files and use the instance.
+    XrResult result;
+    {
+        std::unique_lock<std::mutex> json_lock(g_loader_json_mutex);
+        // Load the available runtime
+        result = RuntimeInterface::LoadRuntime("xrCreateInstance");
+        if (XR_SUCCESS != result) {
+            LoaderLogger::LogErrorMessage("xrCreateInstance", "Failed loading runtime information");
         } else {
-            // If application requested OpenXR API version is higher than the loader version, then we need to throw
-            // an error.
-            uint16_t app_major = XR_VERSION_MAJOR(info->applicationInfo.apiVersion);
-            uint16_t app_minor = XR_VERSION_MINOR(info->applicationInfo.apiVersion);
-            uint16_t loader_major = XR_VERSION_MAJOR(XR_CURRENT_API_VERSION);
-            uint16_t loader_minor = XR_VERSION_MINOR(XR_CURRENT_API_VERSION);
-            if (app_major > loader_major || (app_major == loader_major && app_minor > loader_minor)) {
-                std::ostringstream oss;
-                oss << "xrCreateInstance called with invalid API version " << app_major << "." << app_minor
-                    << ".  Max supported version is " << loader_major << "." << loader_minor;
-                LoaderLogger::LogErrorMessage("xrCreateInstance", oss.str());
-                return XR_ERROR_DRIVER_INCOMPATIBLE;
-            }
-        }
-        if (nullptr == instance) {
-            LoaderLogger::LogValidationErrorMessage("VUID-xrCreateInstance-instance-parameter", "xrCreateInstance",
-                                                    "must be non-NULL");
-            return XR_ERROR_VALIDATION_FAILURE;
-        }
-
-        std::vector<std::unique_ptr<ApiLayerInterface>> api_layer_interfaces;
-
-        // Make sure only one thread is attempting to read the JSON files and use the instance.
-        XrResult result;
-        {
-            std::unique_lock<std::mutex> json_lock(g_loader_json_mutex);
-            // Load the available runtime
-            result = RuntimeInterface::LoadRuntime("xrCreateInstance");
+            runtime_loaded = true;
+            // Load the appropriate layers
+            result = ApiLayerInterface::LoadApiLayers("xrCreateInstance", info->enabledApiLayerCount,
+                                                      info->enabledApiLayerNames, api_layer_interfaces);
             if (XR_SUCCESS != result) {
-                LoaderLogger::LogErrorMessage("xrCreateInstance", "Failed loading runtime information");
-            } else {
-                runtime_loaded = true;
-                // Load the appropriate layers
-                result = ApiLayerInterface::LoadApiLayers("xrCreateInstance", info->enabledApiLayerCount,
-                                                          info->enabledApiLayerNames, api_layer_interfaces);
-                if (XR_SUCCESS != result) {
-                    LoaderLogger::LogErrorMessage("xrCreateInstance", "Failed loading layer information");
-                }
+                LoaderLogger::LogErrorMessage("xrCreateInstance", "Failed loading layer information");
             }
         }
+    }
 
-        if (XR_FAILED(result)) {
-            if (runtime_loaded) {
-                RuntimeInterface::UnloadRuntime("xrCreateInstance");
-            }
-            return result;
+    if (XR_FAILED(result)) {
+        if (runtime_loaded) {
+            RuntimeInterface::UnloadRuntime("xrCreateInstance");
         }
-
-        std::unique_lock<std::mutex> instance_lock(g_loader_instance_mutex);
-
-        // Create the loader instance (only send down first runtime interface)
-        XrInstance created_instance = XR_NULL_HANDLE;
-        result = LoaderInstance::CreateInstance(std::move(api_layer_interfaces), info, &created_instance);
-
-        if (XR_SUCCEEDED(result)) {
-            *instance = created_instance;
-
-            LoaderInstance *loader_instance = g_instance_map.Get(created_instance);
-
-            // Create a debug utils messenger if the create structure is in the "next" chain
-            const XrBaseInStructure *next_header = reinterpret_cast<const XrBaseInStructure *>(info->next);
-            const XrDebugUtilsMessengerCreateInfoEXT *dbg_utils_create_info = nullptr;
-            while (next_header != nullptr) {
-                if (next_header->type == XR_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT) {
-                    LoaderLogger::LogInfoMessage("xrCreateInstance", "Found XrDebugUtilsMessengerCreateInfoEXT in \'next\' chain.");
-                    dbg_utils_create_info = reinterpret_cast<const XrDebugUtilsMessengerCreateInfoEXT *>(next_header);
-                    XrDebugUtilsMessengerEXT messenger;
-                    result = xrCreateDebugUtilsMessengerEXT(*instance, dbg_utils_create_info, &messenger);
-                    if (XR_SUCCESS != result) {
-                        return XR_ERROR_VALIDATION_FAILURE;
-                    }
-                    loader_instance->SetDefaultDebugUtilsMessenger(messenger);
-                    break;
-                }
-                next_header = reinterpret_cast<const XrBaseInStructure *>(next_header->next);
-            }
-        }
-
-        LoaderLogger::LogVerboseMessage("xrCreateInstance", "Completed loader trampoline");
         return result;
+    }
+
+    std::unique_lock<std::mutex> instance_lock(g_loader_instance_mutex);
+
+    // Create the loader instance (only send down first runtime interface)
+    XrInstance created_instance = XR_NULL_HANDLE;
+    result = LoaderInstance::CreateInstance(std::move(api_layer_interfaces), info, &created_instance);
+
+    if (XR_SUCCEEDED(result)) {
+        *instance = created_instance;
+
+        LoaderInstance *loader_instance = g_instance_map.Get(created_instance);
+
+        // Create a debug utils messenger if the create structure is in the "next" chain
+        const XrBaseInStructure *next_header = reinterpret_cast<const XrBaseInStructure *>(info->next);
+        const XrDebugUtilsMessengerCreateInfoEXT *dbg_utils_create_info = nullptr;
+        while (next_header != nullptr) {
+            if (next_header->type == XR_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT) {
+                LoaderLogger::LogInfoMessage("xrCreateInstance", "Found XrDebugUtilsMessengerCreateInfoEXT in \'next\' chain.");
+                dbg_utils_create_info = reinterpret_cast<const XrDebugUtilsMessengerCreateInfoEXT *>(next_header);
+                XrDebugUtilsMessengerEXT messenger;
+                result = xrCreateDebugUtilsMessengerEXT(*instance, dbg_utils_create_info, &messenger);
+                if (XR_SUCCESS != result) {
+                    return XR_ERROR_VALIDATION_FAILURE;
+                }
+                loader_instance->SetDefaultDebugUtilsMessenger(messenger);
+                break;
+            }
+            next_header = reinterpret_cast<const XrBaseInStructure *>(next_header->next);
+        }
+    }
+
+    LoaderLogger::LogVerboseMessage("xrCreateInstance", "Completed loader trampoline");
+    return result;
     } catch (std::bad_alloc &) {
         if (runtime_loaded) {
             RuntimeInterface::UnloadRuntime("xrCreateInstance");
@@ -303,39 +303,39 @@ LOADER_EXPORT XRAPI_ATTR XrResult XRAPI_CALL xrCreateInstance(const XrInstanceCr
 
 LOADER_EXPORT XRAPI_ATTR XrResult XRAPI_CALL xrDestroyInstance(XrInstance instance) {
     try {
-        LoaderLogger::LogVerboseMessage("xrDestroyInstance", "Entering loader trampoline");
-        // XR_NULL_HANDLE is ignored, but valid, in a delete operation.
-        if (XR_NULL_HANDLE == instance) {
-            return XR_SUCCESS;
-        }
+    LoaderLogger::LogVerboseMessage("xrDestroyInstance", "Entering loader trampoline");
+    // XR_NULL_HANDLE is ignored, but valid, in a delete operation.
+    if (XR_NULL_HANDLE == instance) {
+        return XR_SUCCESS;
+    }
 
-        LoaderInstance *const loader_instance = g_instance_map.Get(instance);
-        if (loader_instance == nullptr) {
-            LoaderLogger::LogValidationErrorMessage("VUID-xrDestroyInstance-instance-parameter", "xrDestroyInstance",
-                                                    "invalid instance");
-            return XR_ERROR_HANDLE_INVALID;
-        }
+    LoaderInstance *const loader_instance = g_instance_map.Get(instance);
+    if (loader_instance == nullptr) {
+        LoaderLogger::LogValidationErrorMessage("VUID-xrDestroyInstance-instance-parameter", "xrDestroyInstance",
+                                                "invalid instance");
+        return XR_ERROR_HANDLE_INVALID;
+    }
 
-        const std::unique_ptr<XrGeneratedDispatchTable> &dispatch_table = loader_instance->DispatchTable();
+    const std::unique_ptr<XrGeneratedDispatchTable> &dispatch_table = loader_instance->DispatchTable();
 
-        // If we allocated a default debug utils messenger, free it
-        XrDebugUtilsMessengerEXT messenger = loader_instance->DefaultDebugUtilsMessenger();
-        if (messenger != XR_NULL_HANDLE) {
-            xrDestroyDebugUtilsMessengerEXT(messenger);
-        }
+    // If we allocated a default debug utils messenger, free it
+    XrDebugUtilsMessengerEXT messenger = loader_instance->DefaultDebugUtilsMessenger();
+    if (messenger != XR_NULL_HANDLE) {
+        xrDestroyDebugUtilsMessengerEXT(messenger);
+    }
 
-        // Now destroy the instance
-        if (XR_SUCCESS != dispatch_table->DestroyInstance(instance)) {
-            LoaderLogger::LogErrorMessage("xrDestroyInstance", "Unknown error occurred calling down chain");
-        }
+    // Now destroy the instance
+    if (XR_SUCCESS != dispatch_table->DestroyInstance(instance)) {
+        LoaderLogger::LogErrorMessage("xrDestroyInstance", "Unknown error occurred calling down chain");
+    }
 
-        // Cleanup any map entries that may still be using this instance
-        LoaderCleanUpMapsForInstance(loader_instance);
+    // Cleanup any map entries that may still be using this instance
+    LoaderCleanUpMapsForInstance(loader_instance);
 
-        // Lock the instance create/destroy mutex
-        std::unique_lock<std::mutex> loader_instance_lock(g_loader_instance_mutex);
-        delete loader_instance;
-        LoaderLogger::LogVerboseMessage("xrDestroyInstance", "Completed loader trampoline");
+    // Lock the instance create/destroy mutex
+    std::unique_lock<std::mutex> loader_instance_lock(g_loader_instance_mutex);
+    delete loader_instance;
+    LoaderLogger::LogVerboseMessage("xrDestroyInstance", "Completed loader trampoline");
     } catch (...) {
         LoaderLogger::LogErrorMessage("xrDestroyInstance", "Unknown error occurred");
     }
@@ -426,37 +426,37 @@ XRAPI_ATTR XrResult XRAPI_CALL xrCreateDebugUtilsMessengerEXT(XrInstance instanc
                                                               const XrDebugUtilsMessengerCreateInfoEXT *createInfo,
                                                               XrDebugUtilsMessengerEXT *messenger) {
     try {
-        LoaderLogger::LogVerboseMessage("xrCreateDebugUtilsMessengerEXT", "Entering loader trampoline");
+    LoaderLogger::LogVerboseMessage("xrCreateDebugUtilsMessengerEXT", "Entering loader trampoline");
 
-        LoaderInstance *loader_instance = g_instance_map.Get(instance);
-        if (loader_instance == nullptr) {
-            LoaderLogger::LogValidationErrorMessage("VUID-xrCreateDebugUtilsMessengerEXT-instance-parameter",
-                                                    "xrCreateDebugUtilsMessengerEXT", "invalid instance");
-            return XR_ERROR_HANDLE_INVALID;
-        }
+    LoaderInstance *loader_instance = g_instance_map.Get(instance);
+    if (loader_instance == nullptr) {
+        LoaderLogger::LogValidationErrorMessage("VUID-xrCreateDebugUtilsMessengerEXT-instance-parameter",
+                                                "xrCreateDebugUtilsMessengerEXT", "invalid instance");
+        return XR_ERROR_HANDLE_INVALID;
+    }
 
-        if (!loader_instance->ExtensionIsEnabled(XR_EXT_DEBUG_UTILS_EXTENSION_NAME)) {
-            std::string error_str = "The ";
-            error_str += XR_EXT_DEBUG_UTILS_EXTENSION_NAME;
-            error_str += " extension has not been enabled prior to calling xrCreateDebugUtilsMessengerEXT";
-            LoaderLogger::LogValidationErrorMessage("VUID-xrCreateDebugUtilsMessengerEXT-extension-notenabled",
-                                                    "xrCreateDebugUtilsMessengerEXT", error_str);
-            return XR_ERROR_FUNCTION_UNSUPPORTED;
-        }
+    if (!loader_instance->ExtensionIsEnabled(XR_EXT_DEBUG_UTILS_EXTENSION_NAME)) {
+        std::string error_str = "The ";
+        error_str += XR_EXT_DEBUG_UTILS_EXTENSION_NAME;
+        error_str += " extension has not been enabled prior to calling xrCreateDebugUtilsMessengerEXT";
+        LoaderLogger::LogValidationErrorMessage("VUID-xrCreateDebugUtilsMessengerEXT-extension-notenabled",
+                                                "xrCreateDebugUtilsMessengerEXT", error_str);
+        return XR_ERROR_FUNCTION_UNSUPPORTED;
+    }
 
-        const std::unique_ptr<XrGeneratedDispatchTable> &dispatch_table = loader_instance->DispatchTable();
-        XrResult result = XR_SUCCESS;
-        result = dispatch_table->CreateDebugUtilsMessengerEXT(instance, createInfo, messenger);
-        if (XR_SUCCESS == result && nullptr != messenger) {
-            result = g_debugutilsmessengerext_map.Insert(*messenger, *loader_instance);
-            if (XR_FAILED(result)) {
-                LoaderLogger::LogErrorMessage("xrCreateDebugUtilsMessengerEXT",
-                                              "Failed inserting new messenger into map: may be null or not unique");
-                return result;
-            }
+    const std::unique_ptr<XrGeneratedDispatchTable> &dispatch_table = loader_instance->DispatchTable();
+    XrResult result = XR_SUCCESS;
+    result = dispatch_table->CreateDebugUtilsMessengerEXT(instance, createInfo, messenger);
+    if (XR_SUCCESS == result && nullptr != messenger) {
+        result = g_debugutilsmessengerext_map.Insert(*messenger, *loader_instance);
+        if (XR_FAILED(result)) {
+            LoaderLogger::LogErrorMessage("xrCreateDebugUtilsMessengerEXT",
+                                          "Failed inserting new messenger into map: may be null or not unique");
+            return result;
         }
-        LoaderLogger::LogVerboseMessage("xrCreateDebugUtilsMessengerEXT", "Completed loader trampoline");
-        return result;
+    }
+    LoaderLogger::LogVerboseMessage("xrCreateDebugUtilsMessengerEXT", "Completed loader trampoline");
+    return result;
     } catch (std::bad_alloc &) {
         LoaderLogger::LogErrorMessage("xrCreateDebugUtilsMessengerEXT",
                                       "xrCreateDebugUtilsMessengerEXT trampoline failed allocating memory");
@@ -472,33 +472,33 @@ XRAPI_ATTR XrResult XRAPI_CALL xrDestroyDebugUtilsMessengerEXT(XrDebugUtilsMesse
     // TODO: get instance from messenger in loader
     // Also, is the loader really doing all this every call?
     try {
-        LoaderLogger::LogVerboseMessage("xrDestroyDebugUtilsMessengerEXT", "Entering loader trampoline");
+    LoaderLogger::LogVerboseMessage("xrDestroyDebugUtilsMessengerEXT", "Entering loader trampoline");
 
-        if (XR_NULL_HANDLE == messenger) {
-            return XR_SUCCESS;
-        }
+    if (XR_NULL_HANDLE == messenger) {
+        return XR_SUCCESS;
+    }
 
-        LoaderInstance *loader_instance = g_debugutilsmessengerext_map.Get(messenger);
-        if (loader_instance == nullptr) {
-            LoaderLogger::LogValidationErrorMessage("VUID-xrDestroyDebugUtilsMessengerEXT-messenger-parameter",
-                                                    "xrDestroyDebugUtilsMessengerEXT", "invalid messenger");
+    LoaderInstance *loader_instance = g_debugutilsmessengerext_map.Get(messenger);
+    if (loader_instance == nullptr) {
+        LoaderLogger::LogValidationErrorMessage("VUID-xrDestroyDebugUtilsMessengerEXT-messenger-parameter",
+                                                "xrDestroyDebugUtilsMessengerEXT", "invalid messenger");
 
-            return XR_ERROR_DEBUG_UTILS_MESSENGER_INVALID_EXT;
-        }
+        return XR_ERROR_DEBUG_UTILS_MESSENGER_INVALID_EXT;
+    }
 
-        if (!loader_instance->ExtensionIsEnabled(XR_EXT_DEBUG_UTILS_EXTENSION_NAME)) {
-            std::string error_str = "The ";
-            error_str += XR_EXT_DEBUG_UTILS_EXTENSION_NAME;
-            error_str += " extension has not been enabled prior to calling xrDestroyDebugUtilsMessengerEXT";
-            LoaderLogger::LogValidationErrorMessage("VUID-xrDestroyDebugUtilsMessengerEXT-extension-notenabled",
-                                                    "xrDestroyDebugUtilsMessengerEXT", error_str);
-            return XR_ERROR_FUNCTION_UNSUPPORTED;
-        }
+    if (!loader_instance->ExtensionIsEnabled(XR_EXT_DEBUG_UTILS_EXTENSION_NAME)) {
+        std::string error_str = "The ";
+        error_str += XR_EXT_DEBUG_UTILS_EXTENSION_NAME;
+        error_str += " extension has not been enabled prior to calling xrDestroyDebugUtilsMessengerEXT";
+        LoaderLogger::LogValidationErrorMessage("VUID-xrDestroyDebugUtilsMessengerEXT-extension-notenabled",
+                                                "xrDestroyDebugUtilsMessengerEXT", error_str);
+        return XR_ERROR_FUNCTION_UNSUPPORTED;
+    }
 
-        const std::unique_ptr<XrGeneratedDispatchTable> &dispatch_table = loader_instance->DispatchTable();
-        XrResult result = dispatch_table->DestroyDebugUtilsMessengerEXT(messenger);
-        LoaderLogger::LogVerboseMessage("xrDestroyDebugUtilsMessengerEXT", "Completed loader trampoline");
-        return result;
+    const std::unique_ptr<XrGeneratedDispatchTable> &dispatch_table = loader_instance->DispatchTable();
+    XrResult result = dispatch_table->DestroyDebugUtilsMessengerEXT(messenger);
+    LoaderLogger::LogVerboseMessage("xrDestroyDebugUtilsMessengerEXT", "Completed loader trampoline");
+    return result;
     } catch (...) {
         LoaderLogger::LogErrorMessage(
             "xrDestroyDebugUtilsMessengerEXT",
@@ -514,28 +514,28 @@ XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermCreateDebugUtilsMessengerEXT(XrInstan
                                                                         const XrDebugUtilsMessengerCreateInfoEXT *createInfo,
                                                                         XrDebugUtilsMessengerEXT *messenger) {
     try {
-        LoaderLogger::LogVerboseMessage("xrCreateDebugUtilsMessengerEXT", "Entering loader terminator");
-        if (nullptr == messenger) {
-            LoaderLogger::LogValidationErrorMessage("VUID-xrCreateDebugUtilsMessengerEXT-messenger-parameter",
-                                                    "xrCreateDebugUtilsMessengerEXT", "invalid messenger pointer");
-            return XR_ERROR_VALIDATION_FAILURE;
-        }
-        const XrGeneratedDispatchTable *dispatch_table = RuntimeInterface::GetRuntime().GetDispatchTable(instance);
-        XrResult result = XR_SUCCESS;
-        // This extension is supported entirely by the loader which means the runtime may or may not support it.
-        if (nullptr != dispatch_table->CreateDebugUtilsMessengerEXT) {
-            result = dispatch_table->CreateDebugUtilsMessengerEXT(instance, createInfo, messenger);
-        } else {
-            // Just allocate a character so we have a unique value
-            char *temp_mess_ptr = new char;
-            *messenger = reinterpret_cast<XrDebugUtilsMessengerEXT>(temp_mess_ptr);
-        }
-        if (XR_SUCCESS == result) {
-            LoaderLogger::GetInstance().AddLogRecorder(MakeDebugUtilsLoaderLogRecorder(createInfo, *messenger));
-            RuntimeInterface::GetRuntime().TrackDebugMessenger(instance, *messenger);
-        }
-        LoaderLogger::LogVerboseMessage("xrCreateDebugUtilsMessengerEXT", "Completed loader terminator");
-        return result;
+    LoaderLogger::LogVerboseMessage("xrCreateDebugUtilsMessengerEXT", "Entering loader terminator");
+    if (nullptr == messenger) {
+        LoaderLogger::LogValidationErrorMessage("VUID-xrCreateDebugUtilsMessengerEXT-messenger-parameter",
+                                                "xrCreateDebugUtilsMessengerEXT", "invalid messenger pointer");
+        return XR_ERROR_VALIDATION_FAILURE;
+    }
+    const XrGeneratedDispatchTable *dispatch_table = RuntimeInterface::GetRuntime().GetDispatchTable(instance);
+    XrResult result = XR_SUCCESS;
+    // This extension is supported entirely by the loader which means the runtime may or may not support it.
+    if (nullptr != dispatch_table->CreateDebugUtilsMessengerEXT) {
+        result = dispatch_table->CreateDebugUtilsMessengerEXT(instance, createInfo, messenger);
+    } else {
+        // Just allocate a character so we have a unique value
+        char *temp_mess_ptr = new char;
+        *messenger = reinterpret_cast<XrDebugUtilsMessengerEXT>(temp_mess_ptr);
+    }
+    if (XR_SUCCESS == result) {
+        LoaderLogger::GetInstance().AddLogRecorder(MakeDebugUtilsLoaderLogRecorder(createInfo, *messenger));
+        RuntimeInterface::GetRuntime().TrackDebugMessenger(instance, *messenger);
+    }
+    LoaderLogger::LogVerboseMessage("xrCreateDebugUtilsMessengerEXT", "Completed loader terminator");
+    return result;
     } catch (std::bad_alloc &) {
         LoaderLogger::LogErrorMessage("xrCreateDebugUtilsMessengerEXT", "Terminator failed allocating memory");
         return XR_ERROR_OUT_OF_MEMORY;
@@ -547,21 +547,21 @@ XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermCreateDebugUtilsMessengerEXT(XrInstan
 
 XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermDestroyDebugUtilsMessengerEXT(XrDebugUtilsMessengerEXT messenger) {
     try {
-        LoaderLogger::LogVerboseMessage("xrDestroyDebugUtilsMessengerEXT", "Entering loader terminator");
-        const XrGeneratedDispatchTable *dispatch_table =
-            RuntimeInterface::GetRuntime().GetDebugUtilsMessengerDispatchTable(messenger);
-        XrResult result = XR_SUCCESS;
-        // This extension is supported entirely by the loader which means the runtime may or may not support it.
-        if (nullptr != dispatch_table->DestroyDebugUtilsMessengerEXT) {
-            result = dispatch_table->DestroyDebugUtilsMessengerEXT(messenger);
-        } else {
-            // Delete the character we would've created
-            delete (reinterpret_cast<char *>(MakeHandleGeneric(messenger)));
-        }
-        LoaderLogger::LogVerboseMessage("xrDestroyDebugUtilsMessengerEXT", "Completed loader terminator");
-        LoaderLogger::GetInstance().RemoveLogRecorder(MakeHandleGeneric(messenger));
-        RuntimeInterface::GetRuntime().ForgetDebugMessenger(messenger);
-        return result;
+    LoaderLogger::LogVerboseMessage("xrDestroyDebugUtilsMessengerEXT", "Entering loader terminator");
+    const XrGeneratedDispatchTable *dispatch_table =
+        RuntimeInterface::GetRuntime().GetDebugUtilsMessengerDispatchTable(messenger);
+    XrResult result = XR_SUCCESS;
+    // This extension is supported entirely by the loader which means the runtime may or may not support it.
+    if (nullptr != dispatch_table->DestroyDebugUtilsMessengerEXT) {
+        result = dispatch_table->DestroyDebugUtilsMessengerEXT(messenger);
+    } else {
+        // Delete the character we would've created
+        delete (reinterpret_cast<char *>(MakeHandleGeneric(messenger)));
+    }
+    LoaderLogger::LogVerboseMessage("xrDestroyDebugUtilsMessengerEXT", "Completed loader terminator");
+    LoaderLogger::GetInstance().RemoveLogRecorder(MakeHandleGeneric(messenger));
+    RuntimeInterface::GetRuntime().ForgetDebugMessenger(messenger);
+    return result;
     } catch (...) {
         LoaderLogger::LogErrorMessage("xrDestroyDebugUtilsMessengerEXT",
                                       "Terminator encountered an unknown error.  Likely XrDebugUtilsMessengerEXT " +
@@ -575,18 +575,18 @@ XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermSubmitDebugUtilsMessageEXT(XrInstance
                                                                       XrDebugUtilsMessageTypeFlagsEXT messageTypes,
                                                                       const XrDebugUtilsMessengerCallbackDataEXT *callbackData) {
     try {
-        LoaderLogger::LogVerboseMessage("xrSubmitDebugUtilsMessageEXT", "Entering loader terminator");
-        const XrGeneratedDispatchTable *dispatch_table = RuntimeInterface::GetRuntime().GetDispatchTable(instance);
-        XrResult result = XR_SUCCESS;
-        if (nullptr != dispatch_table->SubmitDebugUtilsMessageEXT) {
-            result = dispatch_table->SubmitDebugUtilsMessageEXT(instance, messageSeverity, messageTypes, callbackData);
-        } else {
-            // Only log the message from the loader if the runtime doesn't support this extension.  If we did,
-            // then the user would receive multiple instances of the same message.
-            LoaderLogger::GetInstance().LogDebugUtilsMessage(messageSeverity, messageTypes, callbackData);
-        }
-        LoaderLogger::LogVerboseMessage("xrSubmitDebugUtilsMessageEXT", "Completed loader terminator");
-        return result;
+    LoaderLogger::LogVerboseMessage("xrSubmitDebugUtilsMessageEXT", "Entering loader terminator");
+    const XrGeneratedDispatchTable *dispatch_table = RuntimeInterface::GetRuntime().GetDispatchTable(instance);
+    XrResult result = XR_SUCCESS;
+    if (nullptr != dispatch_table->SubmitDebugUtilsMessageEXT) {
+        result = dispatch_table->SubmitDebugUtilsMessageEXT(instance, messageSeverity, messageTypes, callbackData);
+    } else {
+        // Only log the message from the loader if the runtime doesn't support this extension.  If we did,
+        // then the user would receive multiple instances of the same message.
+        LoaderLogger::GetInstance().LogDebugUtilsMessage(messageSeverity, messageTypes, callbackData);
+    }
+    LoaderLogger::LogVerboseMessage("xrSubmitDebugUtilsMessageEXT", "Completed loader terminator");
+    return result;
     } catch (...) {
         LoaderLogger::LogErrorMessage("xrSubmitDebugUtilsMessageEXT",
                                       "xrSubmitDebugUtilsMessageEXT terminator encountered an unknown error.  Likely XrInstance " +
@@ -598,15 +598,15 @@ XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermSubmitDebugUtilsMessageEXT(XrInstance
 XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermSetDebugUtilsObjectNameEXT(XrInstance instance,
                                                                       const XrDebugUtilsObjectNameInfoEXT *nameInfo) {
     try {
-        LoaderLogger::LogVerboseMessage("xrSetDebugUtilsObjectNameEXT", "Entering loader terminator");
-        const XrGeneratedDispatchTable *dispatch_table = RuntimeInterface::GetRuntime().GetDispatchTable(instance);
-        XrResult result = XR_SUCCESS;
-        if (nullptr != dispatch_table->SetDebugUtilsObjectNameEXT) {
-            result = dispatch_table->SetDebugUtilsObjectNameEXT(instance, nameInfo);
-        }
-        LoaderLogger::GetInstance().AddObjectName(nameInfo->objectHandle, nameInfo->objectType, nameInfo->objectName);
-        LoaderLogger::LogVerboseMessage("xrSetDebugUtilsObjectNameEXT", "Completed loader terminator");
-        return result;
+    LoaderLogger::LogVerboseMessage("xrSetDebugUtilsObjectNameEXT", "Entering loader terminator");
+    const XrGeneratedDispatchTable *dispatch_table = RuntimeInterface::GetRuntime().GetDispatchTable(instance);
+    XrResult result = XR_SUCCESS;
+    if (nullptr != dispatch_table->SetDebugUtilsObjectNameEXT) {
+        result = dispatch_table->SetDebugUtilsObjectNameEXT(instance, nameInfo);
+    }
+    LoaderLogger::GetInstance().AddObjectName(nameInfo->objectHandle, nameInfo->objectType, nameInfo->objectName);
+    LoaderLogger::LogVerboseMessage("xrSetDebugUtilsObjectNameEXT", "Completed loader terminator");
+    return result;
     } catch (...) {
         LoaderLogger::LogErrorMessage("xrSetDebugUtilsObjectNameEXT",
                                       "xrSetDebugUtilsObjectNameEXT terminator encountered an unknown error.  Likely XrInstance " +
@@ -617,31 +617,31 @@ XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermSetDebugUtilsObjectNameEXT(XrInstance
 
 XRAPI_ATTR XrResult XRAPI_CALL xrSessionBeginDebugUtilsLabelRegionEXT(XrSession session, const XrDebugUtilsLabelEXT *labelInfo) {
     try {
-        LoaderInstance *loader_instance = g_session_map.Get(session);
-        if (nullptr == loader_instance) {
-            LoaderLogger::LogValidationErrorMessage("VUID-xrSessionBeginDebugUtilsLabelRegionEXT-session-parameter",
-                                                    "xrSessionBeginDebugUtilsLabelRegionEXT", "session is not a valid XrSession",
-                                                    {XrLoaderLogObjectInfo{session, XR_OBJECT_TYPE_SESSION}});
-            return XR_ERROR_HANDLE_INVALID;
-        }
-        if (!loader_instance->ExtensionIsEnabled(XR_EXT_DEBUG_UTILS_EXTENSION_NAME)) {
-            LoaderLogger::LogValidationErrorMessage("TBD", "xrSessionBeginDebugUtilsLabelRegionEXT",
-                                                    "Extension entrypoint called without enabling appropriate extension",
-                                                    {XrLoaderLogObjectInfo{session, XR_OBJECT_TYPE_SESSION}});
-            return XR_ERROR_FUNCTION_UNSUPPORTED;
-        } else if (nullptr == labelInfo) {
-            LoaderLogger::LogValidationErrorMessage("VUID-xrSessionBeginDebugUtilsLabelRegionEXT-labelInfo-parameter",
-                                                    "xrSessionBeginDebugUtilsLabelRegionEXT", "labelInfo must be non-NULL",
-                                                    {XrLoaderLogObjectInfo{session, XR_OBJECT_TYPE_SESSION}});
-            return XR_ERROR_VALIDATION_FAILURE;
-        }
+    LoaderInstance *loader_instance = g_session_map.Get(session);
+    if (nullptr == loader_instance) {
+        LoaderLogger::LogValidationErrorMessage("VUID-xrSessionBeginDebugUtilsLabelRegionEXT-session-parameter",
+                                                "xrSessionBeginDebugUtilsLabelRegionEXT", "session is not a valid XrSession",
+                                                {XrLoaderLogObjectInfo{session, XR_OBJECT_TYPE_SESSION}});
+        return XR_ERROR_HANDLE_INVALID;
+    }
+    if (!loader_instance->ExtensionIsEnabled(XR_EXT_DEBUG_UTILS_EXTENSION_NAME)) {
+        LoaderLogger::LogValidationErrorMessage("TBD", "xrSessionBeginDebugUtilsLabelRegionEXT",
+                                                "Extension entrypoint called without enabling appropriate extension",
+                                                {XrLoaderLogObjectInfo{session, XR_OBJECT_TYPE_SESSION}});
+        return XR_ERROR_FUNCTION_UNSUPPORTED;
+    } else if (nullptr == labelInfo) {
+        LoaderLogger::LogValidationErrorMessage("VUID-xrSessionBeginDebugUtilsLabelRegionEXT-labelInfo-parameter",
+                                                "xrSessionBeginDebugUtilsLabelRegionEXT", "labelInfo must be non-NULL",
+                                                {XrLoaderLogObjectInfo{session, XR_OBJECT_TYPE_SESSION}});
+        return XR_ERROR_VALIDATION_FAILURE;
+    }
 
-        LoaderLogger::GetInstance().BeginLabelRegion(session, labelInfo);
-        const std::unique_ptr<XrGeneratedDispatchTable> &dispatch_table = loader_instance->DispatchTable();
-        if (nullptr != dispatch_table->SessionBeginDebugUtilsLabelRegionEXT) {
-            return dispatch_table->SessionBeginDebugUtilsLabelRegionEXT(session, labelInfo);
-        }
-        return XR_SUCCESS;
+    LoaderLogger::GetInstance().BeginLabelRegion(session, labelInfo);
+    const std::unique_ptr<XrGeneratedDispatchTable> &dispatch_table = loader_instance->DispatchTable();
+    if (nullptr != dispatch_table->SessionBeginDebugUtilsLabelRegionEXT) {
+        return dispatch_table->SessionBeginDebugUtilsLabelRegionEXT(session, labelInfo);
+    }
+    return XR_SUCCESS;
     } catch (...) {
         LoaderLogger::LogErrorMessage("xrSessionBeginDebugUtilsLabelRegionEXT",
                                       "xrSessionBeginDebugUtilsLabelRegionEXT trampoline encountered an unknown error");
@@ -651,21 +651,21 @@ XRAPI_ATTR XrResult XRAPI_CALL xrSessionBeginDebugUtilsLabelRegionEXT(XrSession 
 
 XRAPI_ATTR XrResult XRAPI_CALL xrSessionEndDebugUtilsLabelRegionEXT(XrSession session) {
     try {
-        LoaderInstance *loader_instance = g_session_map.Get(session);
-        if (nullptr == loader_instance) {
-            LoaderLogger::LogValidationErrorMessage("VUID-xrSessionEndDebugUtilsLabelRegionEXT-session-parameter",
-                                                    "xrSessionEndDebugUtilsLabelRegionEXT", "session is not a valid XrSession",
-                                                    {XrLoaderLogObjectInfo{session, XR_OBJECT_TYPE_SESSION}});
-            return XR_ERROR_HANDLE_INVALID;
-        } else if (!loader_instance->ExtensionIsEnabled(XR_EXT_DEBUG_UTILS_EXTENSION_NAME)) {
-            return XR_ERROR_FUNCTION_UNSUPPORTED;
-        }
-        LoaderLogger::GetInstance().EndLabelRegion(session);
-        const std::unique_ptr<XrGeneratedDispatchTable> &dispatch_table = loader_instance->DispatchTable();
-        if (nullptr != dispatch_table->SessionBeginDebugUtilsLabelRegionEXT) {
-            return dispatch_table->SessionEndDebugUtilsLabelRegionEXT(session);
-        }
-        return XR_SUCCESS;
+    LoaderInstance *loader_instance = g_session_map.Get(session);
+    if (nullptr == loader_instance) {
+        LoaderLogger::LogValidationErrorMessage("VUID-xrSessionEndDebugUtilsLabelRegionEXT-session-parameter",
+                                                "xrSessionEndDebugUtilsLabelRegionEXT", "session is not a valid XrSession",
+                                                {XrLoaderLogObjectInfo{session, XR_OBJECT_TYPE_SESSION}});
+        return XR_ERROR_HANDLE_INVALID;
+    } else if (!loader_instance->ExtensionIsEnabled(XR_EXT_DEBUG_UTILS_EXTENSION_NAME)) {
+        return XR_ERROR_FUNCTION_UNSUPPORTED;
+    }
+    LoaderLogger::GetInstance().EndLabelRegion(session);
+    const std::unique_ptr<XrGeneratedDispatchTable> &dispatch_table = loader_instance->DispatchTable();
+    if (nullptr != dispatch_table->SessionBeginDebugUtilsLabelRegionEXT) {
+        return dispatch_table->SessionEndDebugUtilsLabelRegionEXT(session);
+    }
+    return XR_SUCCESS;
     } catch (...) {
         LoaderLogger::LogErrorMessage("xrSessionEndDebugUtilsLabelRegionEXT",
                                       "xrSessionEndDebugUtilsLabelRegionEXT trampoline encountered an unknown error");
@@ -675,31 +675,31 @@ XRAPI_ATTR XrResult XRAPI_CALL xrSessionEndDebugUtilsLabelRegionEXT(XrSession se
 
 XRAPI_ATTR XrResult XRAPI_CALL xrSessionInsertDebugUtilsLabelEXT(XrSession session, const XrDebugUtilsLabelEXT *labelInfo) {
     try {
-        LoaderInstance *loader_instance = g_session_map.Get(session);
-        if (nullptr == loader_instance) {
-            LoaderLogger::LogValidationErrorMessage("VUID-xrSessionInsertDebugUtilsLabelEXT-session-parameter",
-                                                    "xrSessionInsertDebugUtilsLabelEXT", "session is not a valid XrSession",
-                                                    {XrLoaderLogObjectInfo{session, XR_OBJECT_TYPE_SESSION}});
-            return XR_ERROR_HANDLE_INVALID;
-        }
-        if (!loader_instance->ExtensionIsEnabled(XR_EXT_DEBUG_UTILS_EXTENSION_NAME)) {
-            LoaderLogger::LogValidationErrorMessage("TBD", "xrSessionInsertDebugUtilsLabelEXT",
-                                                    "Extension entrypoint called without enabling appropriate extension",
-                                                    {XrLoaderLogObjectInfo{session, XR_OBJECT_TYPE_SESSION}});
-            return XR_ERROR_FUNCTION_UNSUPPORTED;
-        } else if (nullptr == labelInfo) {
-            LoaderLogger::LogValidationErrorMessage("VUID-xrSessionInsertDebugUtilsLabelEXT-labelInfo-parameter",
-                                                    "xrSessionInsertDebugUtilsLabelEXT", "labelInfo must be non-NULL",
-                                                    {XrLoaderLogObjectInfo{session, XR_OBJECT_TYPE_SESSION}});
-            return XR_ERROR_VALIDATION_FAILURE;
-        }
+    LoaderInstance *loader_instance = g_session_map.Get(session);
+    if (nullptr == loader_instance) {
+        LoaderLogger::LogValidationErrorMessage("VUID-xrSessionInsertDebugUtilsLabelEXT-session-parameter",
+                                                "xrSessionInsertDebugUtilsLabelEXT", "session is not a valid XrSession",
+                                                {XrLoaderLogObjectInfo{session, XR_OBJECT_TYPE_SESSION}});
+        return XR_ERROR_HANDLE_INVALID;
+    }
+    if (!loader_instance->ExtensionIsEnabled(XR_EXT_DEBUG_UTILS_EXTENSION_NAME)) {
+        LoaderLogger::LogValidationErrorMessage("TBD", "xrSessionInsertDebugUtilsLabelEXT",
+                                                "Extension entrypoint called without enabling appropriate extension",
+                                                {XrLoaderLogObjectInfo{session, XR_OBJECT_TYPE_SESSION}});
+        return XR_ERROR_FUNCTION_UNSUPPORTED;
+    } else if (nullptr == labelInfo) {
+        LoaderLogger::LogValidationErrorMessage("VUID-xrSessionInsertDebugUtilsLabelEXT-labelInfo-parameter",
+                                                "xrSessionInsertDebugUtilsLabelEXT", "labelInfo must be non-NULL",
+                                                {XrLoaderLogObjectInfo{session, XR_OBJECT_TYPE_SESSION}});
+        return XR_ERROR_VALIDATION_FAILURE;
+    }
 
-        LoaderLogger::GetInstance().InsertLabel(session, labelInfo);
-        const std::unique_ptr<XrGeneratedDispatchTable> &dispatch_table = loader_instance->DispatchTable();
-        if (nullptr != dispatch_table->SessionInsertDebugUtilsLabelEXT) {
-            return dispatch_table->SessionInsertDebugUtilsLabelEXT(session, labelInfo);
-        }
-        return XR_SUCCESS;
+    LoaderLogger::GetInstance().InsertLabel(session, labelInfo);
+    const std::unique_ptr<XrGeneratedDispatchTable> &dispatch_table = loader_instance->DispatchTable();
+    if (nullptr != dispatch_table->SessionInsertDebugUtilsLabelEXT) {
+        return dispatch_table->SessionInsertDebugUtilsLabelEXT(session, labelInfo);
+    }
+    return XR_SUCCESS;
     } catch (...) {
         LoaderLogger::LogErrorMessage("xrSessionInsertDebugUtilsLabelEXT",
                                       "xrSessionInsertDebugUtilsLabelEXT trampoline encountered an unknown error");

--- a/src/loader/loader_instance.cpp
+++ b/src/loader/loader_instance.cpp
@@ -46,140 +46,140 @@ XrResult LoaderInstance::CreateInstance(std::vector<std::unique_ptr<ApiLayerInte
                                         const XrInstanceCreateInfo* info, XrInstance* instance) {
     XrResult last_error = XR_SUCCESS;
     try {
-        LoaderLogger::LogVerboseMessage("xrCreateInstance", "Entering LoaderInstance::CreateInstance");
+    LoaderLogger::LogVerboseMessage("xrCreateInstance", "Entering LoaderInstance::CreateInstance");
 
-        // Topmost means "closest to the application"
-        PFN_xrCreateInstance topmost_ci_fp = LoaderXrTermCreateInstance;
-        PFN_xrCreateApiLayerInstance topmost_cali_fp = LoaderXrTermCreateApiLayerInstance;
+    // Topmost means "closest to the application"
+    PFN_xrCreateInstance topmost_ci_fp = LoaderXrTermCreateInstance;
+    PFN_xrCreateApiLayerInstance topmost_cali_fp = LoaderXrTermCreateApiLayerInstance;
 
-        // Create the loader instance
-        std::unique_ptr<LoaderInstance> loader_instance(new LoaderInstance(std::move(api_layer_interfaces)));
-        *instance = reinterpret_cast<XrInstance>(loader_instance.get());
+    // Create the loader instance
+    std::unique_ptr<LoaderInstance> loader_instance(new LoaderInstance(std::move(api_layer_interfaces)));
+    *instance = reinterpret_cast<XrInstance>(loader_instance.get());
 
-        // Only start the xrCreateApiLayerInstance stack if we have layers.
-        std::vector<std::unique_ptr<ApiLayerInterface>>& layer_interfaces = loader_instance->LayerInterfaces();
-        if (layer_interfaces.size() > 0) {
-            // Initialize an array of ApiLayerNextInfo structs
-            XrApiLayerNextInfo* next_info_list = new XrApiLayerNextInfo[layer_interfaces.size()];
-            uint32_t ni_index = static_cast<uint32_t>(layer_interfaces.size() - 1);
-            for (uint32_t i = 0; i <= ni_index; i++) {
-                next_info_list[i].structType = XR_LOADER_INTERFACE_STRUCT_API_LAYER_NEXT_INFO;
-                next_info_list[i].structVersion = XR_API_LAYER_NEXT_INFO_STRUCT_VERSION;
-                next_info_list[i].structSize = sizeof(XrApiLayerNextInfo);
-            }
-
-            // Go through all layers, and override the instance pointers with the layer version.  However,
-            // go backwards through the layer list so we replace in reverse order so the layers can call their next function
-            // appropriately.
-            XrApiLayerNextInfo* prev_nextinfo = nullptr;
-            PFN_xrGetInstanceProcAddr prev_gipa_fp = LoaderXrTermGetInstanceProcAddr;
-            PFN_xrCreateApiLayerInstance prev_cali_fp = LoaderXrTermCreateApiLayerInstance;
-            for (auto layer_interface = layer_interfaces.rbegin(); layer_interface != layer_interfaces.rend(); ++layer_interface) {
-                // Collect current layer's function pointers
-                PFN_xrGetInstanceProcAddr cur_gipa_fp = (*layer_interface)->GetInstanceProcAddrFuncPointer();
-                PFN_xrCreateApiLayerInstance cur_cali_fp = (*layer_interface)->GetCreateApiLayerInstanceFuncPointer();
-                // Update topmosts
-                cur_gipa_fp(XR_NULL_HANDLE, "xrCreateInstance", reinterpret_cast<PFN_xrVoidFunction*>(&topmost_ci_fp));
-                topmost_cali_fp = cur_cali_fp;
-
-                // Fill in layer info and link previous (lower) layer fxn pointers
-                strncpy(next_info_list[ni_index].layerName, (*layer_interface)->LayerName().c_str(),
-                        XR_MAX_API_LAYER_NAME_SIZE - 1);
-                next_info_list[ni_index].layerName[XR_MAX_API_LAYER_NAME_SIZE - 1] = '\0';
-                next_info_list[ni_index].next = prev_nextinfo;
-                next_info_list[ni_index].nextGetInstanceProcAddr = prev_gipa_fp;
-                next_info_list[ni_index].nextCreateApiLayerInstance = prev_cali_fp;
-
-                // Update saved pointers for next iteration
-                prev_nextinfo = &next_info_list[ni_index];
-                prev_gipa_fp = cur_gipa_fp;
-                prev_cali_fp = cur_cali_fp;
-                ni_index--;
-            }
-
-            // Populate the ApiLayerCreateInfo struct and pass to topmost CreateApiLayerInstance()
-            XrApiLayerCreateInfo api_layer_ci = {};
-            api_layer_ci.structType = XR_LOADER_INTERFACE_STRUCT_API_LAYER_CREATE_INFO;
-            api_layer_ci.structVersion = XR_API_LAYER_CREATE_INFO_STRUCT_VERSION;
-            api_layer_ci.structSize = sizeof(XrApiLayerCreateInfo);
-            api_layer_ci.loaderInstance = reinterpret_cast<void*>(loader_instance.get());
-            api_layer_ci.settings_file_location[0] = '\0';
-            api_layer_ci.nextInfo = next_info_list;
-            last_error = topmost_cali_fp(info, &api_layer_ci, instance);
-
-            delete[] next_info_list;
-        } else {
-            last_error = topmost_ci_fp(info, instance);
+    // Only start the xrCreateApiLayerInstance stack if we have layers.
+    std::vector<std::unique_ptr<ApiLayerInterface>>& layer_interfaces = loader_instance->LayerInterfaces();
+    if (layer_interfaces.size() > 0) {
+        // Initialize an array of ApiLayerNextInfo structs
+        XrApiLayerNextInfo* next_info_list = new XrApiLayerNextInfo[layer_interfaces.size()];
+        uint32_t ni_index = static_cast<uint32_t>(layer_interfaces.size() - 1);
+        for (uint32_t i = 0; i <= ni_index; i++) {
+            next_info_list[i].structType = XR_LOADER_INTERFACE_STRUCT_API_LAYER_NEXT_INFO;
+            next_info_list[i].structVersion = XR_API_LAYER_NEXT_INFO_STRUCT_VERSION;
+            next_info_list[i].structSize = sizeof(XrApiLayerNextInfo);
         }
 
-        if (XR_SUCCEEDED(last_error)) {
-            // Check the list of enabled extensions to make sure something supports them, and, if we do,
-            // add it to the list of enabled extensions
-            for (uint32_t ext = 0; ext < info->enabledExtensionCount; ++ext) {
-                bool found = false;
-                // First check the runtime
-                if (RuntimeInterface::GetRuntime().SupportsExtension(info->enabledExtensionNames[ext])) {
-                    found = true;
-                }
-                // Next check the loader
-                if (!found) {
-                    for (auto loader_extension : LoaderInstance::_loader_supported_extensions) {
-                        if (!strcmp(loader_extension.extensionName, info->enabledExtensionNames[ext])) {
-                            found = true;
-                            break;
-                        }
-                    }
-                }
-                // Finally, check the enabled layers
-                if (!found) {
-                    for (auto layer_interface = layer_interfaces.begin(); layer_interface != layer_interfaces.end();
-                         ++layer_interface) {
-                        if ((*layer_interface)->SupportsExtension(info->enabledExtensionNames[ext])) {
-                            found = true;
-                            break;
-                        }
-                    }
-                }
-                if (!found) {
-                    std::string msg = "LoaderInstance::CreateInstance, no support found for requested extension: ";
-                    msg += info->enabledExtensionNames[ext];
-                    LoaderLogger::LogErrorMessage("xrCreateInstance", msg);
-                    last_error = XR_ERROR_EXTENSION_NOT_PRESENT;
-                    break;
-                }
-                loader_instance->AddEnabledExtension(info->enabledExtensionNames[ext]);
-            }
-        } else {
-            LoaderLogger::LogErrorMessage("xrCreateInstance", "LoaderInstance::CreateInstance chained CreateInstance call failed");
+        // Go through all layers, and override the instance pointers with the layer version.  However,
+        // go backwards through the layer list so we replace in reverse order so the layers can call their next function
+        // appropriately.
+        XrApiLayerNextInfo* prev_nextinfo = nullptr;
+        PFN_xrGetInstanceProcAddr prev_gipa_fp = LoaderXrTermGetInstanceProcAddr;
+        PFN_xrCreateApiLayerInstance prev_cali_fp = LoaderXrTermCreateApiLayerInstance;
+        for (auto layer_interface = layer_interfaces.rbegin(); layer_interface != layer_interfaces.rend(); ++layer_interface) {
+            // Collect current layer's function pointers
+            PFN_xrGetInstanceProcAddr cur_gipa_fp = (*layer_interface)->GetInstanceProcAddrFuncPointer();
+            PFN_xrCreateApiLayerInstance cur_cali_fp = (*layer_interface)->GetCreateApiLayerInstanceFuncPointer();
+            // Update topmosts
+            cur_gipa_fp(XR_NULL_HANDLE, "xrCreateInstance", reinterpret_cast<PFN_xrVoidFunction*>(&topmost_ci_fp));
+            topmost_cali_fp = cur_cali_fp;
+
+            // Fill in layer info and link previous (lower) layer fxn pointers
+            strncpy(next_info_list[ni_index].layerName, (*layer_interface)->LayerName().c_str(),
+                    XR_MAX_API_LAYER_NAME_SIZE - 1);
+            next_info_list[ni_index].layerName[XR_MAX_API_LAYER_NAME_SIZE - 1] = '\0';
+            next_info_list[ni_index].next = prev_nextinfo;
+            next_info_list[ni_index].nextGetInstanceProcAddr = prev_gipa_fp;
+            next_info_list[ni_index].nextCreateApiLayerInstance = prev_cali_fp;
+
+            // Update saved pointers for next iteration
+            prev_nextinfo = &next_info_list[ni_index];
+            prev_gipa_fp = cur_gipa_fp;
+            prev_cali_fp = cur_cali_fp;
+            ni_index--;
         }
 
-        if (XR_SUCCEEDED(last_error)) {
-            // Create the top-level dispatch table for the instance.  This will contain the function pointers to the
-            // first instantiation of every command, whether that is in a layer, or a runtime.
-            last_error = loader_instance->CreateDispatchTable(*instance);
+        // Populate the ApiLayerCreateInfo struct and pass to topmost CreateApiLayerInstance()
+        XrApiLayerCreateInfo api_layer_ci = {};
+        api_layer_ci.structType = XR_LOADER_INTERFACE_STRUCT_API_LAYER_CREATE_INFO;
+        api_layer_ci.structVersion = XR_API_LAYER_CREATE_INFO_STRUCT_VERSION;
+        api_layer_ci.structSize = sizeof(XrApiLayerCreateInfo);
+        api_layer_ci.loaderInstance = reinterpret_cast<void*>(loader_instance.get());
+        api_layer_ci.settings_file_location[0] = '\0';
+        api_layer_ci.nextInfo = next_info_list;
+        last_error = topmost_cali_fp(info, &api_layer_ci, instance);
+
+        delete[] next_info_list;
+    } else {
+        last_error = topmost_ci_fp(info, instance);
+    }
+
+    if (XR_SUCCEEDED(last_error)) {
+        // Check the list of enabled extensions to make sure something supports them, and, if we do,
+        // add it to the list of enabled extensions
+        for (uint32_t ext = 0; ext < info->enabledExtensionCount; ++ext) {
+            bool found = false;
+            // First check the runtime
+            if (RuntimeInterface::GetRuntime().SupportsExtension(info->enabledExtensionNames[ext])) {
+                found = true;
+            }
+            // Next check the loader
+            if (!found) {
+                for (auto loader_extension : LoaderInstance::_loader_supported_extensions) {
+                    if (!strcmp(loader_extension.extensionName, info->enabledExtensionNames[ext])) {
+                        found = true;
+                        break;
+                    }
+                }
+            }
+            // Finally, check the enabled layers
+            if (!found) {
+                for (auto layer_interface = layer_interfaces.begin(); layer_interface != layer_interfaces.end();
+                     ++layer_interface) {
+                    if ((*layer_interface)->SupportsExtension(info->enabledExtensionNames[ext])) {
+                        found = true;
+                        break;
+                    }
+                }
+            }
+            if (!found) {
+                std::string msg = "LoaderInstance::CreateInstance, no support found for requested extension: ";
+                msg += info->enabledExtensionNames[ext];
+                LoaderLogger::LogErrorMessage("xrCreateInstance", msg);
+                last_error = XR_ERROR_EXTENSION_NOT_PRESENT;
+                break;
+            }
+            loader_instance->AddEnabledExtension(info->enabledExtensionNames[ext]);
+        }
+    } else {
+        LoaderLogger::LogErrorMessage("xrCreateInstance", "LoaderInstance::CreateInstance chained CreateInstance call failed");
+    }
+
+    if (XR_SUCCEEDED(last_error)) {
+        // Create the top-level dispatch table for the instance.  This will contain the function pointers to the
+        // first instantiation of every command, whether that is in a layer, or a runtime.
+        last_error = loader_instance->CreateDispatchTable(*instance);
+        if (XR_FAILED(last_error)) {
+            LoaderLogger::LogErrorMessage("xrCreateInstance",
+                                          "LoaderInstance::CreateInstance failed creating top-level dispatch table");
+        } else {
+            last_error = g_instance_map.Insert(*instance, *loader_instance);
             if (XR_FAILED(last_error)) {
-                LoaderLogger::LogErrorMessage("xrCreateInstance",
-                                              "LoaderInstance::CreateInstance failed creating top-level dispatch table");
-            } else {
-                last_error = g_instance_map.Insert(*instance, *loader_instance);
-                if (XR_FAILED(last_error)) {
-                    LoaderLogger::LogErrorMessage(
-                        "xrCreateInstance",
-                        "LoaderInstance::CreateInstance failed inserting new instance into map: may be null or not unique");
-                }
+                LoaderLogger::LogErrorMessage(
+                    "xrCreateInstance",
+                    "LoaderInstance::CreateInstance failed inserting new instance into map: may be null or not unique");
             }
         }
+    }
 
-        if (XR_SUCCEEDED(last_error)) {
-            std::ostringstream oss;
-            oss << "LoaderInstance::CreateInstance succeeded with ";
-            oss << loader_instance->LayerInterfaces().size();
-            oss << " layers enabled and runtime interface - created instance = ";
-            oss << HandleToHexString(*instance);
-            LoaderLogger::LogInfoMessage("xrCreateInstance", oss.str());
-            // Make the unique_ptr no longer delete this.
-            loader_instance.release();
-        }
+    if (XR_SUCCEEDED(last_error)) {
+        std::ostringstream oss;
+        oss << "LoaderInstance::CreateInstance succeeded with ";
+        oss << loader_instance->LayerInterfaces().size();
+        oss << " layers enabled and runtime interface - created instance = ";
+        oss << HandleToHexString(*instance);
+        LoaderLogger::LogInfoMessage("xrCreateInstance", oss.str());
+        // Make the unique_ptr no longer delete this.
+        loader_instance.release();
+    }
     } catch (std::bad_alloc&) {
         LoaderLogger::LogErrorMessage("xrCreateInstance", "LoaderInstance::CreateInstance - failed to allocate memory");
         last_error = XR_ERROR_OUT_OF_MEMORY;
@@ -215,22 +215,22 @@ LoaderInstance::~LoaderInstance() {
 XrResult LoaderInstance::CreateDispatchTable(XrInstance instance) {
     XrResult res = XR_SUCCESS;
     try {
-        // Create the top-level dispatch table.  First, we want to start with a dispatch table generated
-        // using the commands from the runtime, with the exception of commands that we need a terminator
-        // for.  The loaderGenInitInstanceDispatchTable utility function handles that automatically for us.
-        std::unique_ptr<XrGeneratedDispatchTable> new_instance_dispatch_table(new XrGeneratedDispatchTable());
-        LoaderGenInitInstanceDispatchTable(_runtime_instance, new_instance_dispatch_table);
+    // Create the top-level dispatch table.  First, we want to start with a dispatch table generated
+    // using the commands from the runtime, with the exception of commands that we need a terminator
+    // for.  The loaderGenInitInstanceDispatchTable utility function handles that automatically for us.
+    std::unique_ptr<XrGeneratedDispatchTable> new_instance_dispatch_table(new XrGeneratedDispatchTable());
+    LoaderGenInitInstanceDispatchTable(_runtime_instance, new_instance_dispatch_table);
 
-        // Go through all layers, and override the instance pointers with the layer version.  However,
-        // go backwards through the layer list so we replace in reverse order so the layers can call their next function
-        // appropriately.
-        if (_api_layer_interfaces.size() > 0) {
-            (*_api_layer_interfaces.begin())->GenUpdateInstanceDispatchTable(instance, new_instance_dispatch_table);
-        }
+    // Go through all layers, and override the instance pointers with the layer version.  However,
+    // go backwards through the layer list so we replace in reverse order so the layers can call their next function
+    // appropriately.
+    if (_api_layer_interfaces.size() > 0) {
+        (*_api_layer_interfaces.begin())->GenUpdateInstanceDispatchTable(instance, new_instance_dispatch_table);
+    }
 
-        // Set the top-level instance dispatch table to the top-most commands now that we've figured them out.
-        _dispatch_table = std::move(new_instance_dispatch_table);
-        _dispatch_valid = true;
+    // Set the top-level instance dispatch table to the top-most commands now that we've figured them out.
+    _dispatch_table = std::move(new_instance_dispatch_table);
+    _dispatch_valid = true;
     } catch (std::bad_alloc&) {
         LoaderLogger::LogErrorMessage("xrCreateInstance", "LoaderInstance::CreateDispatchTable - failed to allocate memory");
         res = XR_ERROR_OUT_OF_MEMORY;

--- a/src/loader/loader_instance.cpp
+++ b/src/loader/loader_instance.cpp
@@ -45,7 +45,6 @@ const std::vector<XrExtensionProperties> LoaderInstance::_loader_supported_exten
 XrResult LoaderInstance::CreateInstance(std::vector<std::unique_ptr<ApiLayerInterface>>&& api_layer_interfaces,
                                         const XrInstanceCreateInfo* info, XrInstance* instance) {
     XrResult last_error = XR_SUCCESS;
-    try {
     LoaderLogger::LogVerboseMessage("xrCreateInstance", "Entering LoaderInstance::CreateInstance");
 
     // Topmost means "closest to the application"
@@ -180,13 +179,6 @@ XrResult LoaderInstance::CreateInstance(std::vector<std::unique_ptr<ApiLayerInte
         // Make the unique_ptr no longer delete this.
         loader_instance.release();
     }
-    } catch (std::bad_alloc&) {
-        LoaderLogger::LogErrorMessage("xrCreateInstance", "LoaderInstance::CreateInstance - failed to allocate memory");
-        last_error = XR_ERROR_OUT_OF_MEMORY;
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("xrCreateInstance", "LoaderInstance::CreateInstance - unknown error occurred");
-        last_error = XR_ERROR_INITIALIZATION_FAILED;
-    }
 
     // Always clear the input lists.  Either we use them or we don't.
     api_layer_interfaces.clear();
@@ -194,16 +186,12 @@ XrResult LoaderInstance::CreateInstance(std::vector<std::unique_ptr<ApiLayerInte
     return last_error;
 }
 
-LoaderInstance::LoaderInstance(std::vector<std::unique_ptr<ApiLayerInterface>>&& api_layer_interfaces) try
+LoaderInstance::LoaderInstance(std::vector<std::unique_ptr<ApiLayerInterface>>&& api_layer_interfaces)
     : _unique_id(0xDECAFBAD),
       _api_version(XR_CURRENT_API_VERSION),
       _api_layer_interfaces(std::move(api_layer_interfaces)),
       _dispatch_valid(false),
-      _messenger(XR_NULL_HANDLE) {
-} catch (...) {
-    LoaderLogger::LogErrorMessage("xrCreateInstance", "LoaderInstance::LoaderInstance - Unknown error occurred");
-    throw;
-}
+      _messenger(XR_NULL_HANDLE) {}
 
 LoaderInstance::~LoaderInstance() {
     std::ostringstream oss;
@@ -214,7 +202,6 @@ LoaderInstance::~LoaderInstance() {
 
 XrResult LoaderInstance::CreateDispatchTable(XrInstance instance) {
     XrResult res = XR_SUCCESS;
-    try {
     // Create the top-level dispatch table.  First, we want to start with a dispatch table generated
     // using the commands from the runtime, with the exception of commands that we need a terminator
     // for.  The loaderGenInitInstanceDispatchTable utility function handles that automatically for us.
@@ -231,13 +218,6 @@ XrResult LoaderInstance::CreateDispatchTable(XrInstance instance) {
     // Set the top-level instance dispatch table to the top-most commands now that we've figured them out.
     _dispatch_table = std::move(new_instance_dispatch_table);
     _dispatch_valid = true;
-    } catch (std::bad_alloc&) {
-        LoaderLogger::LogErrorMessage("xrCreateInstance", "LoaderInstance::CreateDispatchTable - failed to allocate memory");
-        res = XR_ERROR_OUT_OF_MEMORY;
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("xrCreateInstance", "LoaderInstance::CreateDispatchTable - unknown error occurred");
-        res = XR_ERROR_INITIALIZATION_FAILED;
-    }
     return res;
 }
 

--- a/src/loader/manifest_file.cpp
+++ b/src/loader/manifest_file.cpp
@@ -61,10 +61,10 @@ static inline bool StringEndsWith(std::string const &value, std::string const &e
 // If the file found is a manifest file name, add it to the out_files manifest list.
 static void AddIfJson(ManifestFileType type, const std::string &full_file, std::vector<std::string> &manifest_files) {
     try {
-        if (0 == full_file.size() || !StringEndsWith(full_file, ".json")) {
-            return;
-        }
-        manifest_files.push_back(full_file);
+    if (0 == full_file.size() || !StringEndsWith(full_file, ".json")) {
+        return;
+    }
+    manifest_files.push_back(full_file);
     } catch (...) {
         LoaderLogger::LogErrorMessage("", "AddIfJson - unknown error occurred");
         throw;
@@ -77,28 +77,28 @@ static void AddIfJson(ManifestFileType type, const std::string &full_file, std::
 static void CheckAllFilesInThePath(ManifestFileType type, const std::string &search_path, bool is_directory_list,
                                    std::vector<std::string> &manifest_files) {
     try {
-        if (FileSysUtilsPathExists(search_path)) {
-            std::string absolute_path;
-            if (!is_directory_list) {
-                // If the file exists, try to add it
-                if (FileSysUtilsIsRegularFile(search_path)) {
-                    FileSysUtilsGetAbsolutePath(search_path, absolute_path);
-                    AddIfJson(type, absolute_path, manifest_files);
-                }
-            } else {
-                std::vector<std::string> files;
-                if (FileSysUtilsFindFilesInPath(search_path, files)) {
-                    for (std::string &cur_file : files) {
-                        std::string relative_path;
-                        FileSysUtilsCombinePaths(search_path, cur_file, relative_path);
-                        if (!FileSysUtilsGetAbsolutePath(relative_path, absolute_path)) {
-                            continue;
-                        }
-                        AddIfJson(type, absolute_path, manifest_files);
+    if (FileSysUtilsPathExists(search_path)) {
+        std::string absolute_path;
+        if (!is_directory_list) {
+            // If the file exists, try to add it
+            if (FileSysUtilsIsRegularFile(search_path)) {
+                FileSysUtilsGetAbsolutePath(search_path, absolute_path);
+                AddIfJson(type, absolute_path, manifest_files);
+            }
+        } else {
+            std::vector<std::string> files;
+            if (FileSysUtilsFindFilesInPath(search_path, files)) {
+                for (std::string &cur_file : files) {
+                    std::string relative_path;
+                    FileSysUtilsCombinePaths(search_path, cur_file, relative_path);
+                    if (!FileSysUtilsGetAbsolutePath(relative_path, absolute_path)) {
+                        continue;
                     }
+                    AddIfJson(type, absolute_path, manifest_files);
                 }
             }
         }
+    }
     } catch (...) {
         LoaderLogger::LogErrorMessage("", "CheckAllFilesInThePath - unknown error occurred");
         throw;
@@ -115,27 +115,27 @@ static void AddFilesInPath(ManifestFileType type, const std::string &search_path
     std::string cur_search;
 
     try {
-        // Handle any path listings in the string (separated by the appropriate path separator)
-        while (found != std::string::npos) {
-            // substr takes a start index and length.
-            std::size_t length = found - last_found;
-            cur_search = search_path.substr(last_found, length);
+    // Handle any path listings in the string (separated by the appropriate path separator)
+    while (found != std::string::npos) {
+        // substr takes a start index and length.
+        std::size_t length = found - last_found;
+        cur_search = search_path.substr(last_found, length);
 
-            CheckAllFilesInThePath(type, cur_search, is_directory_list, manifest_files);
+        CheckAllFilesInThePath(type, cur_search, is_directory_list, manifest_files);
 
-            // This works around issue if multiple path separator follow each other directly.
-            last_found = found;
-            while (found == last_found) {
-                last_found = found + 1;
-                found = search_path.find_first_of(PATH_SEPARATOR, last_found);
-            }
+        // This works around issue if multiple path separator follow each other directly.
+        last_found = found;
+        while (found == last_found) {
+            last_found = found + 1;
+            found = search_path.find_first_of(PATH_SEPARATOR, last_found);
         }
+    }
 
-        // If there's something remaining in the string, copy it over
-        if (last_found < search_path.size()) {
-            cur_search = search_path.substr(last_found);
-            CheckAllFilesInThePath(type, cur_search, is_directory_list, manifest_files);
-        }
+    // If there's something remaining in the string, copy it over
+    if (last_found < search_path.size()) {
+        cur_search = search_path.substr(last_found);
+        CheckAllFilesInThePath(type, cur_search, is_directory_list, manifest_files);
+    }
     } catch (...) {
         LoaderLogger::LogErrorMessage("", "AddFilesInPath - unknown error occurred");
         throw;
@@ -150,30 +150,30 @@ static void CopyIncludedPaths(bool is_directory_list, const std::string &cur_pat
         std::size_t found = cur_path.find_first_of(PATH_SEPARATOR);
 
         try {
-            // Handle any path listings in the string (separated by the appropriate path separator)
-            while (found != std::string::npos) {
-                std::size_t length = found - last_found;
-                output_path += cur_path.substr(last_found, length);
-                if (is_directory_list && (cur_path[found - 1] != '\\' && cur_path[found - 1] != '/')) {
-                    output_path += DIRECTORY_SYMBOL;
-                }
-                output_path += relative_path;
-                output_path += PATH_SEPARATOR;
-
-                last_found = found;
-                found = cur_path.find_first_of(PATH_SEPARATOR, found + 1);
+        // Handle any path listings in the string (separated by the appropriate path separator)
+        while (found != std::string::npos) {
+            std::size_t length = found - last_found;
+            output_path += cur_path.substr(last_found, length);
+            if (is_directory_list && (cur_path[found - 1] != '\\' && cur_path[found - 1] != '/')) {
+                output_path += DIRECTORY_SYMBOL;
             }
+            output_path += relative_path;
+            output_path += PATH_SEPARATOR;
 
-            // If there's something remaining in the string, copy it over
-            size_t last_char = cur_path.size() - 1;
-            if (last_found != last_char) {
-                output_path += cur_path.substr(last_found);
-                if (is_directory_list && (cur_path[last_char] != '\\' && cur_path[last_char] != '/')) {
-                    output_path += DIRECTORY_SYMBOL;
-                }
-                output_path += relative_path;
-                output_path += PATH_SEPARATOR;
+            last_found = found;
+            found = cur_path.find_first_of(PATH_SEPARATOR, found + 1);
+        }
+
+        // If there's something remaining in the string, copy it over
+        size_t last_char = cur_path.size() - 1;
+        if (last_found != last_char) {
+            output_path += cur_path.substr(last_found);
+            if (is_directory_list && (cur_path[last_char] != '\\' && cur_path[last_char] != '/')) {
+                output_path += DIRECTORY_SYMBOL;
             }
+            output_path += relative_path;
+            output_path += PATH_SEPARATOR;
+        }
         } catch (...) {
             LoaderLogger::LogErrorMessage("", "CopyIncludedPaths - unknown error occurred");
             throw;
@@ -191,92 +191,92 @@ static void ReadDataFilesInSearchPaths(ManifestFileType type, const std::string 
     std::string search_path = "";
 
     try {
-        if (override_env_var.size() != 0) {
+    if (override_env_var.size() != 0) {
 #ifndef XR_OS_WINDOWS
-            if (geteuid() != getuid() || getegid() != getgid()) {
-                // Don't allow setuid apps to use the env var:
-                override_env = nullptr;
-            } else
+        if (geteuid() != getuid() || getegid() != getgid()) {
+            // Don't allow setuid apps to use the env var:
+            override_env = nullptr;
+        } else
 #endif
-            {
-                override_env = PlatformUtilsGetSecureEnv(override_env_var.c_str());
-                if (nullptr != override_env) {
-                    // The runtime override is actually a specific list of filenames, not directories
-                    if (is_runtime) {
-                        is_directory_list = false;
-                    }
-                    override_path = override_env;
+        {
+            override_env = PlatformUtilsGetSecureEnv(override_env_var.c_str());
+            if (nullptr != override_env) {
+                // The runtime override is actually a specific list of filenames, not directories
+                if (is_runtime) {
+                    is_directory_list = false;
                 }
+                override_path = override_env;
             }
         }
+    }
 
-        if (nullptr != override_env && override_path.size() != 0) {
-            CopyIncludedPaths(is_directory_list, override_path, "", search_path);
-            PlatformUtilsFreeEnv(override_env);
-            override_active = true;
-        } else {
-            override_active = false;
+    if (nullptr != override_env && override_path.size() != 0) {
+        CopyIncludedPaths(is_directory_list, override_path, "", search_path);
+        PlatformUtilsFreeEnv(override_env);
+        override_active = true;
+    } else {
+        override_active = false;
 #ifndef XR_OS_WINDOWS
-            bool xdg_conf_dirs_alloc = true;
-            bool xdg_data_dirs_alloc = true;
-            const char home_additional[] = ".local/share/";
+        bool xdg_conf_dirs_alloc = true;
+        bool xdg_data_dirs_alloc = true;
+        const char home_additional[] = ".local/share/";
 
-            // Determine how much space is needed to generate the full search path
-            // for the current manifest files.
-            char *xdg_conf_dirs = PlatformUtilsGetSecureEnv("XDG_CONFIG_DIRS");
-            char *xdg_data_dirs = PlatformUtilsGetSecureEnv("XDG_DATA_DIRS");
-            char *xdg_data_home = PlatformUtilsGetSecureEnv("XDG_DATA_HOME");
-            char *home = PlatformUtilsGetSecureEnv("HOME");
+        // Determine how much space is needed to generate the full search path
+        // for the current manifest files.
+        char *xdg_conf_dirs = PlatformUtilsGetSecureEnv("XDG_CONFIG_DIRS");
+        char *xdg_data_dirs = PlatformUtilsGetSecureEnv("XDG_DATA_DIRS");
+        char *xdg_data_home = PlatformUtilsGetSecureEnv("XDG_DATA_HOME");
+        char *home = PlatformUtilsGetSecureEnv("HOME");
 
-            if (nullptr == xdg_conf_dirs) {
-                xdg_conf_dirs_alloc = false;
-            }
-            if (nullptr == xdg_data_dirs) {
-                xdg_data_dirs_alloc = false;
-            }
-
-            if (nullptr == xdg_conf_dirs || xdg_conf_dirs[0] == '\0') {
-                CopyIncludedPaths(true, FALLBACK_CONFIG_DIRS, relative_path, search_path);
-            } else {
-                CopyIncludedPaths(true, xdg_conf_dirs, relative_path, search_path);
-            }
-
-            CopyIncludedPaths(true, SYSCONFDIR, relative_path, search_path);
-#if defined(EXTRASYSCONFDIR)
-            CopyIncludedPaths(true, EXTRASYSCONFDIR, relative_path, search_path);
-#endif
-
-            if (xdg_data_dirs == nullptr || xdg_data_dirs[0] == '\0') {
-                CopyIncludedPaths(true, FALLBACK_DATA_DIRS, relative_path, search_path);
-            } else {
-                CopyIncludedPaths(true, xdg_data_dirs, relative_path, search_path);
-            }
-
-            if (nullptr != xdg_data_home) {
-                CopyIncludedPaths(true, xdg_data_home, relative_path, search_path);
-            } else if (nullptr != home) {
-                std::string relative_home_path = home_additional;
-                relative_home_path += relative_path;
-                CopyIncludedPaths(true, home, relative_home_path, search_path);
-            }
-
-            if (xdg_conf_dirs_alloc) {
-                PlatformUtilsFreeEnv(xdg_conf_dirs);
-            }
-            if (xdg_data_dirs_alloc) {
-                PlatformUtilsFreeEnv(xdg_data_dirs);
-            }
-            if (nullptr != xdg_data_home) {
-                PlatformUtilsFreeEnv(xdg_data_home);
-            }
-            if (nullptr != home) {
-                PlatformUtilsFreeEnv(home);
-            }
-#endif
+        if (nullptr == xdg_conf_dirs) {
+            xdg_conf_dirs_alloc = false;
+        }
+        if (nullptr == xdg_data_dirs) {
+            xdg_data_dirs_alloc = false;
         }
 
-        // Now, parse the paths and add any manifest files found in them.
-        AddFilesInPath(type, search_path, is_directory_list, manifest_files);
+        if (nullptr == xdg_conf_dirs || xdg_conf_dirs[0] == '\0') {
+            CopyIncludedPaths(true, FALLBACK_CONFIG_DIRS, relative_path, search_path);
+        } else {
+            CopyIncludedPaths(true, xdg_conf_dirs, relative_path, search_path);
+        }
+
+        CopyIncludedPaths(true, SYSCONFDIR, relative_path, search_path);
+#if defined(EXTRASYSCONFDIR)
+        CopyIncludedPaths(true, EXTRASYSCONFDIR, relative_path, search_path);
+#endif
+
+        if (xdg_data_dirs == nullptr || xdg_data_dirs[0] == '\0') {
+            CopyIncludedPaths(true, FALLBACK_DATA_DIRS, relative_path, search_path);
+        } else {
+            CopyIncludedPaths(true, xdg_data_dirs, relative_path, search_path);
+        }
+
+        if (nullptr != xdg_data_home) {
+            CopyIncludedPaths(true, xdg_data_home, relative_path, search_path);
+        } else if (nullptr != home) {
+            std::string relative_home_path = home_additional;
+            relative_home_path += relative_path;
+            CopyIncludedPaths(true, home, relative_home_path, search_path);
+        }
+
+        if (xdg_conf_dirs_alloc) {
+            PlatformUtilsFreeEnv(xdg_conf_dirs);
+        }
+        if (xdg_data_dirs_alloc) {
+            PlatformUtilsFreeEnv(xdg_data_dirs);
+        }
+        if (nullptr != xdg_data_home) {
+            PlatformUtilsFreeEnv(xdg_data_home);
+        }
+        if (nullptr != home) {
+            PlatformUtilsFreeEnv(home);
+        }
+#endif
+    }
+
+    // Now, parse the paths and add any manifest files found in them.
+    AddFilesInPath(type, search_path, is_directory_list, manifest_files);
     } catch (...) {
         LoaderLogger::LogErrorMessage("", "ReadDataFilesInSearchPaths - unknown error occurred");
         throw;
@@ -364,36 +364,36 @@ static void ReadRuntimeDataFilesInRegistry(ManifestFileType type, const std::str
                                            const std::string &default_runtime_value_name,
                                            std::vector<std::string> &manifest_files) {
     try {
-        HKEY hkey;
-        DWORD access_flags;
-        wchar_t value_w[1024];
-        DWORD value_size_w = sizeof(value_w);  // byte size of the buffer.
+    HKEY hkey;
+    DWORD access_flags;
+    wchar_t value_w[1024];
+    DWORD value_size_w = sizeof(value_w);  // byte size of the buffer.
 
-        // Generate the full registry location for the registry information
-        std::string full_registry_location = OPENXR_REGISTRY_LOCATION;
-        full_registry_location += std::to_string(XR_VERSION_MAJOR(XR_CURRENT_API_VERSION));
-        full_registry_location += runtime_registry_location;
+    // Generate the full registry location for the registry information
+    std::string full_registry_location = OPENXR_REGISTRY_LOCATION;
+    full_registry_location += std::to_string(XR_VERSION_MAJOR(XR_CURRENT_API_VERSION));
+    full_registry_location += runtime_registry_location;
 
-        const std::wstring full_registry_location_w = utf8_to_wide(full_registry_location);
-        const std::wstring default_runtime_value_name_w = utf8_to_wide(default_runtime_value_name);
+    const std::wstring full_registry_location_w = utf8_to_wide(full_registry_location);
+    const std::wstring default_runtime_value_name_w = utf8_to_wide(default_runtime_value_name);
 
-        // Use 64 bit regkey for 64bit application, and use 32 bit regkey in WOW for 32bit application.
-        access_flags = KEY_QUERY_VALUE;
-        LONG open_value = RegOpenKeyExW(HKEY_LOCAL_MACHINE, full_registry_location_w.c_str(), 0, access_flags, &hkey);
+    // Use 64 bit regkey for 64bit application, and use 32 bit regkey in WOW for 32bit application.
+    access_flags = KEY_QUERY_VALUE;
+    LONG open_value = RegOpenKeyExW(HKEY_LOCAL_MACHINE, full_registry_location_w.c_str(), 0, access_flags, &hkey);
 
-        if (ERROR_SUCCESS != open_value) {
-            std::string warning_message = "ReadLayerDataFilesInRegistry - failed to open registry key ";
-            warning_message += full_registry_location;
-            LoaderLogger::LogWarningMessage("", warning_message);
-        } else if (ERROR_SUCCESS != RegGetValueW(hkey, nullptr, default_runtime_value_name_w.c_str(),
-                                                 RRF_RT_REG_SZ | REG_EXPAND_SZ | RRF_ZEROONFAILURE, NULL,
-                                                 reinterpret_cast<LPBYTE>(&value_w), &value_size_w)) {
-            std::string warning_message = "ReadLayerDataFilesInRegistry - failed to read registry value ";
-            warning_message += default_runtime_value_name;
-            LoaderLogger::LogWarningMessage("", warning_message);
-        } else {
-            AddFilesInPath(type, wide_to_utf8(value_w), false, manifest_files);
-        }
+    if (ERROR_SUCCESS != open_value) {
+        std::string warning_message = "ReadLayerDataFilesInRegistry - failed to open registry key ";
+        warning_message += full_registry_location;
+        LoaderLogger::LogWarningMessage("", warning_message);
+    } else if (ERROR_SUCCESS != RegGetValueW(hkey, nullptr, default_runtime_value_name_w.c_str(),
+                                             RRF_RT_REG_SZ | REG_EXPAND_SZ | RRF_ZEROONFAILURE, NULL,
+                                             reinterpret_cast<LPBYTE>(&value_w), &value_size_w)) {
+        std::string warning_message = "ReadLayerDataFilesInRegistry - failed to read registry value ";
+        warning_message += default_runtime_value_name;
+        LoaderLogger::LogWarningMessage("", warning_message);
+    } else {
+        AddFilesInPath(type, wide_to_utf8(value_w), false, manifest_files);
+    }
     } catch (...) {
         LoaderLogger::LogErrorMessage("", "ReadLayerDataFilesInRegistry - unknown error occurred");
         throw;
@@ -405,45 +405,45 @@ static void ReadRuntimeDataFilesInRegistry(ManifestFileType type, const std::str
 static void ReadLayerDataFilesInRegistry(ManifestFileType type, const std::string &registry_location,
                                          std::vector<std::string> &manifest_files) {
     try {
-        HKEY hive[2] = {HKEY_LOCAL_MACHINE, HKEY_CURRENT_USER};
-        bool found[2] = {false, false};
-        HKEY hkey;
-        DWORD access_flags;
-        LONG rtn_value;
-        wchar_t name_w[1024]{};
-        DWORD value;
-        DWORD name_size = 1023;
-        DWORD value_size = sizeof(value);
+    HKEY hive[2] = {HKEY_LOCAL_MACHINE, HKEY_CURRENT_USER};
+    bool found[2] = {false, false};
+    HKEY hkey;
+    DWORD access_flags;
+    LONG rtn_value;
+    wchar_t name_w[1024]{};
+    DWORD value;
+    DWORD name_size = 1023;
+    DWORD value_size = sizeof(value);
 
-        for (uint8_t hive_index = 0; hive_index < 2; ++hive_index) {
-            DWORD key_index = 0;
-            std::string full_registry_location = OPENXR_REGISTRY_LOCATION;
-            full_registry_location += std::to_string(XR_VERSION_MAJOR(XR_CURRENT_API_VERSION));
-            full_registry_location += registry_location;
+    for (uint8_t hive_index = 0; hive_index < 2; ++hive_index) {
+        DWORD key_index = 0;
+        std::string full_registry_location = OPENXR_REGISTRY_LOCATION;
+        full_registry_location += std::to_string(XR_VERSION_MAJOR(XR_CURRENT_API_VERSION));
+        full_registry_location += registry_location;
 
-            access_flags = KEY_QUERY_VALUE;
-            std::wstring full_registry_location_w = utf8_to_wide(full_registry_location);
-            LONG open_value = RegOpenKeyExW(hive[hive_index], full_registry_location_w.c_str(), 0, access_flags, &hkey);
-            if (ERROR_SUCCESS != open_value) {
-                if (hive_index == 1 && !found[0]) {
-                    std::string warning_message = "ReadLayerDataFilesInRegistry - failed to read registry location ";
-                    warning_message += registry_location;
-                    warning_message += " in either HKEY_LOCAL_MACHINE or KHEY_CURRENT_USER";
-                    LoaderLogger::LogWarningMessage("", warning_message);
-                }
-                continue;
+        access_flags = KEY_QUERY_VALUE;
+        std::wstring full_registry_location_w = utf8_to_wide(full_registry_location);
+        LONG open_value = RegOpenKeyExW(hive[hive_index], full_registry_location_w.c_str(), 0, access_flags, &hkey);
+        if (ERROR_SUCCESS != open_value) {
+            if (hive_index == 1 && !found[0]) {
+                std::string warning_message = "ReadLayerDataFilesInRegistry - failed to read registry location ";
+                warning_message += registry_location;
+                warning_message += " in either HKEY_LOCAL_MACHINE or KHEY_CURRENT_USER";
+                LoaderLogger::LogWarningMessage("", warning_message);
             }
-            found[hive_index] = true;
-            while (ERROR_SUCCESS ==
-                   (rtn_value = RegEnumValueW(hkey, key_index++, name_w, &name_size, NULL, NULL, (LPBYTE)&value, &value_size))) {
-                if (value_size == sizeof(value) && value == 0) {
-                    const std::string filename = wide_to_utf8(name_w);
-                    AddFilesInPath(type, filename, false, manifest_files);
-                }
-                // Reset some items for the next loop
-                name_size = 1023;
-            }
+            continue;
         }
+        found[hive_index] = true;
+        while (ERROR_SUCCESS ==
+               (rtn_value = RegEnumValueW(hkey, key_index++, name_w, &name_size, NULL, NULL, (LPBYTE)&value, &value_size))) {
+            if (value_size == sizeof(value) && value == 0) {
+                const std::string filename = wide_to_utf8(name_w);
+                AddFilesInPath(type, filename, false, manifest_files);
+            }
+            // Reset some items for the next loop
+            name_size = 1023;
+        }
+    }
     } catch (...) {
         LoaderLogger::LogErrorMessage("", "ReadLayerDataFilesInRegistry - unknown error occurred");
         throw;
@@ -459,26 +459,26 @@ ManifestFile::~ManifestFile() {}
 
 bool ManifestFile::IsValidJson(Json::Value &root_node, JsonVersion &version) {
     try {
-        if (root_node["file_format_version"].isNull() || !root_node["file_format_version"].isString()) {
-            LoaderLogger::LogErrorMessage("", "ManifestFile::IsValidJson - JSON file missing \"file_format_version\"");
-            return false;
-        }
-        std::string file_format = root_node["file_format_version"].asString();
-        sscanf(file_format.c_str(), "%d.%d.%d", &version.major, &version.minor, &version.patch);
+    if (root_node["file_format_version"].isNull() || !root_node["file_format_version"].isString()) {
+        LoaderLogger::LogErrorMessage("", "ManifestFile::IsValidJson - JSON file missing \"file_format_version\"");
+        return false;
+    }
+    std::string file_format = root_node["file_format_version"].asString();
+    sscanf(file_format.c_str(), "%d.%d.%d", &version.major, &version.minor, &version.patch);
 
-        // Only version 1.0.0 is defined currently.  Eventually we may have more version, but
-        // some of the versions may only be valid for layers or runtimes specifically.
-        if (version.major != 1 || version.minor != 0 || version.patch != 0) {
-            std::string error_message = "ManifestFile::IsValidJson - JSON \"file_format_version\" ";
-            error_message += std::to_string(version.major);
-            error_message += ".";
-            error_message += std::to_string(version.minor);
-            error_message += ".";
-            error_message += std::to_string(version.patch);
-            error_message += " is not supported";
-            LoaderLogger::LogErrorMessage("", error_message);
-            return false;
-        }
+    // Only version 1.0.0 is defined currently.  Eventually we may have more version, but
+    // some of the versions may only be valid for layers or runtimes specifically.
+    if (version.major != 1 || version.minor != 0 || version.patch != 0) {
+        std::string error_message = "ManifestFile::IsValidJson - JSON \"file_format_version\" ";
+        error_message += std::to_string(version.major);
+        error_message += ".";
+        error_message += std::to_string(version.minor);
+        error_message += ".";
+        error_message += std::to_string(version.patch);
+        error_message += " is not supported";
+        LoaderLogger::LogErrorMessage("", error_message);
+        return false;
+    }
     } catch (...) {
         LoaderLogger::LogErrorMessage("", "ManifestFile::IsValidJson - unknown error occurred");
         throw;
@@ -491,29 +491,29 @@ bool ManifestFile::IsValidJson(Json::Value &root_node, JsonVersion &version) {
 // OpenXR (XrExtensionProperties).
 void ManifestFile::GetInstanceExtensionProperties(std::vector<XrExtensionProperties> &props) {
     try {
-        size_t ext_count = _instance_extensions.size();
-        size_t props_count = props.size();
-        bool found = false;
-        for (size_t ext = 0; ext < ext_count; ++ext) {
-            for (size_t prop = 0; prop < props_count; ++prop) {
-                if (!strcmp(props[prop].extensionName, _instance_extensions[ext].name.c_str())) {
-                    if (props[prop].specVersion < _instance_extensions[ext].spec_version) {
-                        props[prop].specVersion = _instance_extensions[ext].spec_version;
-                        found = true;
-                        break;
-                    }
+    size_t ext_count = _instance_extensions.size();
+    size_t props_count = props.size();
+    bool found = false;
+    for (size_t ext = 0; ext < ext_count; ++ext) {
+        for (size_t prop = 0; prop < props_count; ++prop) {
+            if (!strcmp(props[prop].extensionName, _instance_extensions[ext].name.c_str())) {
+                if (props[prop].specVersion < _instance_extensions[ext].spec_version) {
+                    props[prop].specVersion = _instance_extensions[ext].spec_version;
+                    found = true;
+                    break;
                 }
             }
-            if (!found) {
-                XrExtensionProperties prop = {};
-                prop.type = XR_TYPE_EXTENSION_PROPERTIES;
-                prop.next = nullptr;
-                strncpy(prop.extensionName, _instance_extensions[ext].name.c_str(), XR_MAX_EXTENSION_NAME_SIZE - 1);
-                prop.extensionName[XR_MAX_EXTENSION_NAME_SIZE - 1] = '\0';
-                prop.specVersion = _instance_extensions[ext].spec_version;
-                props.push_back(prop);
-            }
         }
+        if (!found) {
+            XrExtensionProperties prop = {};
+            prop.type = XR_TYPE_EXTENSION_PROPERTIES;
+            prop.next = nullptr;
+            strncpy(prop.extensionName, _instance_extensions[ext].name.c_str(), XR_MAX_EXTENSION_NAME_SIZE - 1);
+            prop.extensionName[XR_MAX_EXTENSION_NAME_SIZE - 1] = '\0';
+            prop.specVersion = _instance_extensions[ext].spec_version;
+            props.push_back(prop);
+        }
+    }
     } catch (...) {
         LoaderLogger::LogErrorMessage("", "ManifestFile::GetInstanceExtensionProperties - unknown error occurred");
         throw;
@@ -524,29 +524,29 @@ void ManifestFile::GetInstanceExtensionProperties(std::vector<XrExtensionPropert
 // OpenXR (XrExtensionProperties).
 void ManifestFile::GetDeviceExtensionProperties(std::vector<XrExtensionProperties> &props) {
     try {
-        size_t ext_count = _device_extensions.size();
-        size_t props_count = props.size();
-        bool found = false;
-        for (size_t ext = 0; ext < ext_count; ++ext) {
-            for (size_t prop = 0; prop < props_count; ++prop) {
-                if (!strcmp(props[prop].extensionName, _device_extensions[ext].name.c_str())) {
-                    if (props[prop].specVersion < _device_extensions[ext].spec_version) {
-                        props[prop].specVersion = _device_extensions[ext].spec_version;
-                        found = true;
-                        break;
-                    }
+    size_t ext_count = _device_extensions.size();
+    size_t props_count = props.size();
+    bool found = false;
+    for (size_t ext = 0; ext < ext_count; ++ext) {
+        for (size_t prop = 0; prop < props_count; ++prop) {
+            if (!strcmp(props[prop].extensionName, _device_extensions[ext].name.c_str())) {
+                if (props[prop].specVersion < _device_extensions[ext].spec_version) {
+                    props[prop].specVersion = _device_extensions[ext].spec_version;
+                    found = true;
+                    break;
                 }
             }
-            if (!found) {
-                XrExtensionProperties prop = {};
-                prop.type = XR_TYPE_EXTENSION_PROPERTIES;
-                prop.next = nullptr;
-                strncpy(prop.extensionName, _device_extensions[ext].name.c_str(), XR_MAX_EXTENSION_NAME_SIZE - 1);
-                prop.extensionName[XR_MAX_EXTENSION_NAME_SIZE - 1] = '\0';
-                prop.specVersion = _device_extensions[ext].spec_version;
-                props.push_back(prop);
-            }
         }
+        if (!found) {
+            XrExtensionProperties prop = {};
+            prop.type = XR_TYPE_EXTENSION_PROPERTIES;
+            prop.next = nullptr;
+            strncpy(prop.extensionName, _device_extensions[ext].name.c_str(), XR_MAX_EXTENSION_NAME_SIZE - 1);
+            prop.extensionName[XR_MAX_EXTENSION_NAME_SIZE - 1] = '\0';
+            prop.specVersion = _device_extensions[ext].spec_version;
+            props.push_back(prop);
+        }
+    }
     } catch (...) {
         LoaderLogger::LogErrorMessage("", "ManifestFile::GetDeviceExtensionProperties - unknown error occurred");
         throw;
@@ -555,12 +555,12 @@ void ManifestFile::GetDeviceExtensionProperties(std::vector<XrExtensionPropertie
 
 const std::string &ManifestFile::GetFunctionName(const std::string &func_name) {
     try {
-        if (_functions_renamed.size() > 0) {
-            auto found = _functions_renamed.find(func_name);
-            if (found != _functions_renamed.end()) {
-                return found->second;
-            }
+    if (_functions_renamed.size() > 0) {
+        auto found = _functions_renamed.find(func_name);
+        if (found != _functions_renamed.end()) {
+            return found->second;
         }
+    }
     } catch (...) {
         LoaderLogger::LogErrorMessage("", "ManifestFile::GetFunctionName - unknown error occurred");
         throw;
@@ -575,136 +575,136 @@ RuntimeManifestFile::~RuntimeManifestFile() {}
 
 void RuntimeManifestFile::CreateIfValid(std::string filename, std::vector<std::unique_ptr<RuntimeManifestFile>> &manifest_files) {
     try {
-        std::ifstream json_stream = std::ifstream(filename, std::ifstream::in);
-        if (!json_stream.is_open()) {
-            std::string error_message = "RuntimeManifestFile::createIfValid failed to open ";
-            error_message += filename;
-            error_message += ".  Does it exist?";
-            LoaderLogger::LogErrorMessage("", error_message);
-            return;
-        }
-        Json::Reader reader;
-        Json::Value root_node = Json::nullValue;
-        Json::Value runtime_root_node = Json::nullValue;
-        JsonVersion file_version = {};
-        if (!reader.parse(json_stream, root_node, false) || root_node.isNull()) {
-            std::string error_message = "RuntimeManifestFile::CreateIfValid failed to parse ";
-            error_message += filename;
-            error_message += ".  Is it a valid runtime manifest file?";
-            LoaderLogger::LogErrorMessage("", error_message);
-            return;
-        }
-        if (!ManifestFile::IsValidJson(root_node, file_version)) {
-            std::string error_message = "RuntimeManifestFile::CreateIfValid isValidJson indicates ";
-            error_message += filename;
-            error_message += " is not a valid manifest file.";
-            LoaderLogger::LogErrorMessage("", error_message);
-            return;
-        }
-        runtime_root_node = root_node["runtime"];
-        // The Runtime manifest file needs the "runtime" root as well as sub-nodes for "api_version" and
-        // "library_path".  If any of those aren't there, fail.
-        if (runtime_root_node.isNull() || runtime_root_node["library_path"].isNull() ||
-            !runtime_root_node["library_path"].isString()) {
-            std::string error_message = "RuntimeManifestFile::CreateIfValid ";
-            error_message += filename;
-            error_message += " is missing required fields.  Verify all proper fields exist.";
-            LoaderLogger::LogErrorMessage("", error_message);
-            return;
-        }
+    std::ifstream json_stream = std::ifstream(filename, std::ifstream::in);
+    if (!json_stream.is_open()) {
+        std::string error_message = "RuntimeManifestFile::createIfValid failed to open ";
+        error_message += filename;
+        error_message += ".  Does it exist?";
+        LoaderLogger::LogErrorMessage("", error_message);
+        return;
+    }
+    Json::Reader reader;
+    Json::Value root_node = Json::nullValue;
+    Json::Value runtime_root_node = Json::nullValue;
+    JsonVersion file_version = {};
+    if (!reader.parse(json_stream, root_node, false) || root_node.isNull()) {
+        std::string error_message = "RuntimeManifestFile::CreateIfValid failed to parse ";
+        error_message += filename;
+        error_message += ".  Is it a valid runtime manifest file?";
+        LoaderLogger::LogErrorMessage("", error_message);
+        return;
+    }
+    if (!ManifestFile::IsValidJson(root_node, file_version)) {
+        std::string error_message = "RuntimeManifestFile::CreateIfValid isValidJson indicates ";
+        error_message += filename;
+        error_message += " is not a valid manifest file.";
+        LoaderLogger::LogErrorMessage("", error_message);
+        return;
+    }
+    runtime_root_node = root_node["runtime"];
+    // The Runtime manifest file needs the "runtime" root as well as sub-nodes for "api_version" and
+    // "library_path".  If any of those aren't there, fail.
+    if (runtime_root_node.isNull() || runtime_root_node["library_path"].isNull() ||
+        !runtime_root_node["library_path"].isString()) {
+        std::string error_message = "RuntimeManifestFile::CreateIfValid ";
+        error_message += filename;
+        error_message += " is missing required fields.  Verify all proper fields exist.";
+        LoaderLogger::LogErrorMessage("", error_message);
+        return;
+    }
 
-        std::string lib_path = runtime_root_node["library_path"].asString();
+    std::string lib_path = runtime_root_node["library_path"].asString();
 
-        // If the library_path variable has no directory symbol, it's just a file name and should be accessible on the
-        // global library path.
-        if (lib_path.find("\\") != lib_path.npos || lib_path.find("/") != lib_path.npos) {
-            // If the library_path is an absolute path, just use that if it exists
-            if (FileSysUtilsIsAbsolutePath(lib_path)) {
-                if (!FileSysUtilsPathExists(lib_path)) {
-                    std::string error_message = "RuntimeManifestFile::CreateIfValid ";
-                    error_message += filename;
-                    error_message += " library ";
-                    error_message += lib_path;
-                    error_message += " does not appear to exist";
-                    LoaderLogger::LogErrorMessage("", error_message);
-                    return;
-                }
-            } else {
-                // Otherwise, treat the library path as a relative path based on the JSON file.
-                std::string combined_path;
-                std::string file_parent;
-                if (!FileSysUtilsGetParentPath(filename, file_parent) ||
-                    !FileSysUtilsCombinePaths(file_parent, lib_path, combined_path) || !FileSysUtilsPathExists(combined_path)) {
-                    std::string error_message = "RuntimeManifestFile::CreateIfValid ";
-                    error_message += filename;
-                    error_message += " library ";
-                    error_message += combined_path;
-                    error_message += " does not appear to exist";
-                    LoaderLogger::LogErrorMessage("", error_message);
-                    return;
-                }
-                lib_path = combined_path;
+    // If the library_path variable has no directory symbol, it's just a file name and should be accessible on the
+    // global library path.
+    if (lib_path.find("\\") != lib_path.npos || lib_path.find("/") != lib_path.npos) {
+        // If the library_path is an absolute path, just use that if it exists
+        if (FileSysUtilsIsAbsolutePath(lib_path)) {
+            if (!FileSysUtilsPathExists(lib_path)) {
+                std::string error_message = "RuntimeManifestFile::CreateIfValid ";
+                error_message += filename;
+                error_message += " library ";
+                error_message += lib_path;
+                error_message += " does not appear to exist";
+                LoaderLogger::LogErrorMessage("", error_message);
+                return;
             }
+        } else {
+            // Otherwise, treat the library path as a relative path based on the JSON file.
+            std::string combined_path;
+            std::string file_parent;
+            if (!FileSysUtilsGetParentPath(filename, file_parent) ||
+                !FileSysUtilsCombinePaths(file_parent, lib_path, combined_path) || !FileSysUtilsPathExists(combined_path)) {
+                std::string error_message = "RuntimeManifestFile::CreateIfValid ";
+                error_message += filename;
+                error_message += " library ";
+                error_message += combined_path;
+                error_message += " does not appear to exist";
+                LoaderLogger::LogErrorMessage("", error_message);
+                return;
+            }
+            lib_path = combined_path;
         }
+    }
 
-        // Add this runtime manifest file
-        manifest_files.emplace_back(new RuntimeManifestFile(filename, lib_path));
+    // Add this runtime manifest file
+    manifest_files.emplace_back(new RuntimeManifestFile(filename, lib_path));
 
-        // Add any extensions to it after the fact.
-        Json::Value dev_exts = runtime_root_node["device_extensions"];
-        if (!dev_exts.isNull() && dev_exts.isArray()) {
-            for (Json::ValueIterator dev_ext_it = dev_exts.begin(); dev_ext_it != dev_exts.end(); ++dev_ext_it) {
-                Json::Value dev_ext = (*dev_ext_it);
-                Json::Value dev_ext_name = dev_ext["name"];
-                Json::Value dev_ext_version = dev_ext["spec_version"];
-                Json::Value dev_ext_entries = dev_ext["entrypoints"];
-                if (!dev_ext_name.isNull() && dev_ext_name.isString() && !dev_ext_version.isNull() && dev_ext_version.isUInt() &&
-                    !dev_ext_entries.isNull() && dev_ext_entries.isArray()) {
-                    ExtensionListing ext = {};
-                    ext.name = dev_ext_name.asString();
-                    ext.spec_version = dev_ext_version.asUInt();
-                    for (Json::ValueIterator entry_it = dev_ext_entries.begin(); entry_it != dev_ext_entries.end(); ++entry_it) {
-                        Json::Value entry = (*entry_it);
-                        if (!entry.isNull() && entry.isString()) {
-                            ext.entrypoints.push_back(entry.asString());
-                        }
+    // Add any extensions to it after the fact.
+    Json::Value dev_exts = runtime_root_node["device_extensions"];
+    if (!dev_exts.isNull() && dev_exts.isArray()) {
+        for (Json::ValueIterator dev_ext_it = dev_exts.begin(); dev_ext_it != dev_exts.end(); ++dev_ext_it) {
+            Json::Value dev_ext = (*dev_ext_it);
+            Json::Value dev_ext_name = dev_ext["name"];
+            Json::Value dev_ext_version = dev_ext["spec_version"];
+            Json::Value dev_ext_entries = dev_ext["entrypoints"];
+            if (!dev_ext_name.isNull() && dev_ext_name.isString() && !dev_ext_version.isNull() && dev_ext_version.isUInt() &&
+                !dev_ext_entries.isNull() && dev_ext_entries.isArray()) {
+                ExtensionListing ext = {};
+                ext.name = dev_ext_name.asString();
+                ext.spec_version = dev_ext_version.asUInt();
+                for (Json::ValueIterator entry_it = dev_ext_entries.begin(); entry_it != dev_ext_entries.end(); ++entry_it) {
+                    Json::Value entry = (*entry_it);
+                    if (!entry.isNull() && entry.isString()) {
+                        ext.entrypoints.push_back(entry.asString());
                     }
-                    manifest_files.back()->_device_extensions.push_back(ext);
                 }
+                manifest_files.back()->_device_extensions.push_back(ext);
             }
         }
+    }
 
-        Json::Value inst_exts = runtime_root_node["instance_extensions"];
-        if (!inst_exts.isNull() && inst_exts.isArray()) {
-            for (Json::ValueIterator inst_ext_it = inst_exts.begin(); inst_ext_it != inst_exts.end(); ++inst_ext_it) {
-                Json::Value inst_ext = (*inst_ext_it);
-                Json::Value inst_ext_name = inst_ext["name"];
-                Json::Value inst_ext_version = inst_ext["spec_version"];
-                if (!inst_ext_name.isNull() && inst_ext_name.isString() && !inst_ext_version.isNull() &&
-                    inst_ext_version.isUInt()) {
-                    ExtensionListing ext = {};
-                    ext.name = inst_ext_name.asString();
-                    ext.spec_version = inst_ext_version.asUInt();
-                    manifest_files.back()->_instance_extensions.push_back(ext);
-                }
+    Json::Value inst_exts = runtime_root_node["instance_extensions"];
+    if (!inst_exts.isNull() && inst_exts.isArray()) {
+        for (Json::ValueIterator inst_ext_it = inst_exts.begin(); inst_ext_it != inst_exts.end(); ++inst_ext_it) {
+            Json::Value inst_ext = (*inst_ext_it);
+            Json::Value inst_ext_name = inst_ext["name"];
+            Json::Value inst_ext_version = inst_ext["spec_version"];
+            if (!inst_ext_name.isNull() && inst_ext_name.isString() && !inst_ext_version.isNull() &&
+                inst_ext_version.isUInt()) {
+                ExtensionListing ext = {};
+                ext.name = inst_ext_name.asString();
+                ext.spec_version = inst_ext_version.asUInt();
+                manifest_files.back()->_instance_extensions.push_back(ext);
             }
         }
+    }
 
-        Json::Value funcs_renamed = runtime_root_node["functions"];
-        if (!funcs_renamed.isNull() && funcs_renamed.size() > 0) {
-            for (Json::ValueIterator func_it = funcs_renamed.begin(); func_it != funcs_renamed.end(); ++func_it) {
-                if (!(*func_it).isString()) {
-                    std::string warning_message = "RuntimeManifestFile::CreateIfValid ";
-                    warning_message += filename;
-                    warning_message += " \"functions\" section contains non-string values.";
-                    LoaderLogger::LogWarningMessage("", warning_message);
-                    continue;
-                }
-                std::string original_name = func_it.key().asString();
-                std::string new_name = (*func_it).asString();
-                manifest_files.back()->_functions_renamed.insert(std::make_pair(original_name, new_name));
+    Json::Value funcs_renamed = runtime_root_node["functions"];
+    if (!funcs_renamed.isNull() && funcs_renamed.size() > 0) {
+        for (Json::ValueIterator func_it = funcs_renamed.begin(); func_it != funcs_renamed.end(); ++func_it) {
+            if (!(*func_it).isString()) {
+                std::string warning_message = "RuntimeManifestFile::CreateIfValid ";
+                warning_message += filename;
+                warning_message += " \"functions\" section contains non-string values.";
+                LoaderLogger::LogWarningMessage("", warning_message);
+                continue;
             }
+            std::string original_name = func_it.key().asString();
+            std::string new_name = (*func_it).asString();
+            manifest_files.back()->_functions_renamed.insert(std::make_pair(original_name, new_name));
         }
+    }
     } catch (...) {
         LoaderLogger::LogErrorMessage("", "RuntimeManifestFile::CreateIfValid - unknown error occurred");
         throw;
@@ -716,56 +716,56 @@ XrResult RuntimeManifestFile::FindManifestFiles(ManifestFileType type,
                                                 std::vector<std::unique_ptr<RuntimeManifestFile>> &manifest_files) {
     XrResult result = XR_SUCCESS;
     try {
-        if (MANIFEST_TYPE_RUNTIME != type) {
-            LoaderLogger::LogErrorMessage("", "RuntimeManifestFile::FindManifestFiles - unknown manifest file requested");
-            throw std::runtime_error("invalid manifest type");
-        }
-        std::string filename;
-        char *override_path = PlatformUtilsGetSecureEnv(OPENXR_RUNTIME_JSON_ENV_VAR);
-        if (override_path != nullptr && *override_path != '\0') {
-            filename = override_path;
-            PlatformUtilsFreeEnv(override_path);
-            std::string info_message = "RuntimeManifestFile::FindManifestFiles - using environment variable override runtime file ";
-            info_message += filename;
-            LoaderLogger::LogInfoMessage("", info_message);
-        } else {
-            PlatformUtilsFreeEnv(override_path);
+    if (MANIFEST_TYPE_RUNTIME != type) {
+        LoaderLogger::LogErrorMessage("", "RuntimeManifestFile::FindManifestFiles - unknown manifest file requested");
+        throw std::runtime_error("invalid manifest type");
+    }
+    std::string filename;
+    char *override_path = PlatformUtilsGetSecureEnv(OPENXR_RUNTIME_JSON_ENV_VAR);
+    if (override_path != nullptr && *override_path != '\0') {
+        filename = override_path;
+        PlatformUtilsFreeEnv(override_path);
+        std::string info_message = "RuntimeManifestFile::FindManifestFiles - using environment variable override runtime file ";
+        info_message += filename;
+        LoaderLogger::LogInfoMessage("", info_message);
+    } else {
+        PlatformUtilsFreeEnv(override_path);
 #ifdef XR_OS_WINDOWS
-            std::vector<std::string> filenames;
-            ReadRuntimeDataFilesInRegistry(type, "", "ActiveRuntime", filenames);
-            if (filenames.size() == 0) {
-                LoaderLogger::LogErrorMessage(
-                    "", "RuntimeManifestFile::FindManifestFiles - failed to find active runtime file in registry");
-                return XR_ERROR_FILE_ACCESS_ERROR;
-            }
-            if (filenames.size() > 1) {
-                LoaderLogger::LogWarningMessage(
-                    "", "RuntimeManifestFile::FindManifestFiles - found too many default runtime files in registry");
-            }
-            filename = filenames[0];
-#elif defined(XR_OS_LINUX)
-            const std::string relative_path = "openxr/"
-                + std::to_string(XR_VERSION_MAJOR(XR_CURRENT_API_VERSION))
-                + "/active_runtime.json";
-            if (!FindXDGConfigFile(relative_path, filename)) {
-                LoaderLogger::LogErrorMessage(
-                    "",
-                    "RuntimeManifestFile::FindManifestFiles - failed to determine active runtime file path for this environment");
-                return XR_ERROR_FILE_ACCESS_ERROR;
-            }
-#else
-            if (!PlatformGetGlobalRuntimeFileName(XR_VERSION_MAJOR(XR_CURRENT_API_VERSION), filename)) {
-                LoaderLogger::LogErrorMessage(
-                    "",
-                    "RuntimeManifestFile::FindManifestFiles - failed to determine active runtime file path for this environment");
-                return XR_ERROR_FILE_ACCESS_ERROR;
-            }
-#endif
-            std::string info_message = "RuntimeManifestFile::FindManifestFiles - using global runtime file ";
-            info_message += filename;
-            LoaderLogger::LogInfoMessage("", info_message);
+        std::vector<std::string> filenames;
+        ReadRuntimeDataFilesInRegistry(type, "", "ActiveRuntime", filenames);
+        if (filenames.size() == 0) {
+            LoaderLogger::LogErrorMessage(
+                "", "RuntimeManifestFile::FindManifestFiles - failed to find active runtime file in registry");
+            return XR_ERROR_FILE_ACCESS_ERROR;
         }
-        RuntimeManifestFile::CreateIfValid(filename, manifest_files);
+        if (filenames.size() > 1) {
+            LoaderLogger::LogWarningMessage(
+                "", "RuntimeManifestFile::FindManifestFiles - found too many default runtime files in registry");
+        }
+        filename = filenames[0];
+#elif defined(XR_OS_LINUX)
+        const std::string relative_path = "openxr/"
+            + std::to_string(XR_VERSION_MAJOR(XR_CURRENT_API_VERSION))
+            + "/active_runtime.json";
+        if (!FindXDGConfigFile(relative_path, filename)) {
+            LoaderLogger::LogErrorMessage(
+                "",
+                "RuntimeManifestFile::FindManifestFiles - failed to determine active runtime file path for this environment");
+            return XR_ERROR_FILE_ACCESS_ERROR;
+        }
+#else
+        if (!PlatformGetGlobalRuntimeFileName(XR_VERSION_MAJOR(XR_CURRENT_API_VERSION), filename)) {
+            LoaderLogger::LogErrorMessage(
+                "",
+                "RuntimeManifestFile::FindManifestFiles - failed to determine active runtime file path for this environment");
+            return XR_ERROR_FILE_ACCESS_ERROR;
+        }
+#endif
+        std::string info_message = "RuntimeManifestFile::FindManifestFiles - using global runtime file ";
+        info_message += filename;
+        LoaderLogger::LogInfoMessage("", info_message);
+    }
+    RuntimeManifestFile::CreateIfValid(filename, manifest_files);
     } catch (std::bad_alloc &) {
         LoaderLogger::LogErrorMessage("", "RuntimeManifestFile::FindManifestFiles - failed to allocate memory");
         return XR_ERROR_OUT_OF_MEMORY;
@@ -790,190 +790,190 @@ ApiLayerManifestFile::~ApiLayerManifestFile() {}
 void ApiLayerManifestFile::CreateIfValid(ManifestFileType type, std::string filename,
                                          std::vector<std::unique_ptr<ApiLayerManifestFile>> &manifest_files) {
     try {
-        std::ifstream json_stream = std::ifstream(filename, std::ifstream::in);
-        Json::Reader reader;
-        Json::Value root_node = Json::nullValue;
-        JsonVersion file_version = {};
-        JsonVersion api_version = {};
-        std::string layer_name = "";
-        std::string library_path = "";
-        std::string description = "";
-        if (!reader.parse(json_stream, root_node, false) || root_node.isNull()) {
-            std::string error_message = "ApiLayerManifestFile::CreateIfValid failed to parse ";
-            error_message += filename;
-            error_message += ".  Is it a valid layer manifest file?";
-            LoaderLogger::LogErrorMessage("", error_message);
-            return;
-        }
-        if (!ManifestFile::IsValidJson(root_node, file_version)) {
-            std::string error_message = "ApiLayerManifestFile::CreateIfValid isValidJson indicates ";
-            error_message += filename;
-            error_message += " is not a valid manifest file.";
-            LoaderLogger::LogErrorMessage("", error_message);
-            return;
-        }
+    std::ifstream json_stream = std::ifstream(filename, std::ifstream::in);
+    Json::Reader reader;
+    Json::Value root_node = Json::nullValue;
+    JsonVersion file_version = {};
+    JsonVersion api_version = {};
+    std::string layer_name = "";
+    std::string library_path = "";
+    std::string description = "";
+    if (!reader.parse(json_stream, root_node, false) || root_node.isNull()) {
+        std::string error_message = "ApiLayerManifestFile::CreateIfValid failed to parse ";
+        error_message += filename;
+        error_message += ".  Is it a valid layer manifest file?";
+        LoaderLogger::LogErrorMessage("", error_message);
+        return;
+    }
+    if (!ManifestFile::IsValidJson(root_node, file_version)) {
+        std::string error_message = "ApiLayerManifestFile::CreateIfValid isValidJson indicates ";
+        error_message += filename;
+        error_message += " is not a valid manifest file.";
+        LoaderLogger::LogErrorMessage("", error_message);
+        return;
+    }
 
-        Json::Value layer_root_node = root_node["api_layer"];
+    Json::Value layer_root_node = root_node["api_layer"];
 
-        // The API Layer manifest file needs the "api_layer" root as well as other sub-nodes.
-        // If any of those aren't there, fail.
-        if (layer_root_node.isNull() || layer_root_node["name"].isNull() || !layer_root_node["name"].isString() ||
-            layer_root_node["api_version"].isNull() || !layer_root_node["api_version"].isString() ||
-            layer_root_node["library_path"].isNull() || !layer_root_node["library_path"].isString() ||
-            layer_root_node["implementation_version"].isNull() || !layer_root_node["implementation_version"].isString()) {
-            std::string error_message = "ApiLayerManifestFile::CreateIfValid ";
+    // The API Layer manifest file needs the "api_layer" root as well as other sub-nodes.
+    // If any of those aren't there, fail.
+    if (layer_root_node.isNull() || layer_root_node["name"].isNull() || !layer_root_node["name"].isString() ||
+        layer_root_node["api_version"].isNull() || !layer_root_node["api_version"].isString() ||
+        layer_root_node["library_path"].isNull() || !layer_root_node["library_path"].isString() ||
+        layer_root_node["implementation_version"].isNull() || !layer_root_node["implementation_version"].isString()) {
+        std::string error_message = "ApiLayerManifestFile::CreateIfValid ";
+        error_message += filename;
+        error_message += " is missing required fields.  Verify all proper fields exist.";
+        LoaderLogger::LogErrorMessage("", error_message);
+        return;
+    }
+    if (MANIFEST_TYPE_IMPLICIT_API_LAYER == type) {
+        bool enabled = true;
+        // Implicit layers require the disable environment variable.
+        if (layer_root_node["disable_environment"].isNull() || !layer_root_node["disable_environment"].isString()) {
+            std::string error_message = "ApiLayerManifestFile::CreateIfValid Implicit layer ";
             error_message += filename;
-            error_message += " is missing required fields.  Verify all proper fields exist.";
+            error_message += " is missing \"disable_environment\"";
             LoaderLogger::LogErrorMessage("", error_message);
             return;
         }
-        if (MANIFEST_TYPE_IMPLICIT_API_LAYER == type) {
-            bool enabled = true;
-            // Implicit layers require the disable environment variable.
-            if (layer_root_node["disable_environment"].isNull() || !layer_root_node["disable_environment"].isString()) {
-                std::string error_message = "ApiLayerManifestFile::CreateIfValid Implicit layer ";
+        // Check if there's an enable environment variable provided
+        if (!layer_root_node["enable_environment"].isNull() && layer_root_node["enable_environment"].isString()) {
+            char *enable_val = PlatformUtilsGetEnv(layer_root_node["enable_environment"].asString().c_str());
+            // If it's not set in the environment, disable the layer
+            if (NULL == enable_val) {
+                enabled = false;
+            }
+            PlatformUtilsFreeEnv(enable_val);
+        }
+        // Check for the disable environment variable, which must be provided in the JSON
+        char *disable_val = PlatformUtilsGetEnv(layer_root_node["disable_environment"].asString().c_str());
+        // If the envar is set, disable the layer. Disable envar overrides enable above
+        if (NULL != disable_val) {
+            enabled = false;
+        }
+        PlatformUtilsFreeEnv(disable_val);
+
+        // Not enabled, so pretend like it isn't even there.
+        if (!enabled) {
+            std::string info_message = "ApiLayerManifestFile::CreateIfValid Implicit layer ";
+            info_message += filename;
+            info_message += " is disabled";
+            LoaderLogger::LogInfoMessage("", info_message);
+            return;
+        }
+    }
+    layer_name = layer_root_node["name"].asString();
+    std::string api_version_string = layer_root_node["api_version"].asString();
+    sscanf(api_version_string.c_str(), "%d.%d", &api_version.major, &api_version.minor);
+    api_version.patch = 0;
+
+    if ((api_version.major == 0 && api_version.minor == 0) || api_version.major > XR_VERSION_MAJOR(XR_CURRENT_API_VERSION)) {
+        std::string warning_message = "ApiLayerManifestFile::CreateIfValid layer ";
+        warning_message += filename;
+        warning_message += " has invalid API Version.  Skipping layer.";
+        LoaderLogger::LogWarningMessage("", warning_message);
+        return;
+    }
+
+    uint32_t implementation_version = atoi(layer_root_node["implementation_version"].asString().c_str());
+    library_path = layer_root_node["library_path"].asString();
+
+    // If the library_path variable has no directory symbol, it's just a file name and should be accessible on the
+    // global library path.
+    if (library_path.find("\\") != library_path.npos || library_path.find("/") != library_path.npos) {
+        // If the library_path is an absolute path, just use that if it exists
+        if (FileSysUtilsIsAbsolutePath(library_path)) {
+            if (!FileSysUtilsPathExists(library_path)) {
+                std::string error_message = "ApiLayerManifestFile::CreateIfValid ";
                 error_message += filename;
-                error_message += " is missing \"disable_environment\"";
+                error_message += " library ";
+                error_message += library_path;
+                error_message += " does not appear to exist";
                 LoaderLogger::LogErrorMessage("", error_message);
                 return;
             }
-            // Check if there's an enable environment variable provided
-            if (!layer_root_node["enable_environment"].isNull() && layer_root_node["enable_environment"].isString()) {
-                char *enable_val = PlatformUtilsGetEnv(layer_root_node["enable_environment"].asString().c_str());
-                // If it's not set in the environment, disable the layer
-                if (NULL == enable_val) {
-                    enabled = false;
-                }
-                PlatformUtilsFreeEnv(enable_val);
-            }
-            // Check for the disable environment variable, which must be provided in the JSON
-            char *disable_val = PlatformUtilsGetEnv(layer_root_node["disable_environment"].asString().c_str());
-            // If the envar is set, disable the layer. Disable envar overrides enable above
-            if (NULL != disable_val) {
-                enabled = false;
-            }
-            PlatformUtilsFreeEnv(disable_val);
-
-            // Not enabled, so pretend like it isn't even there.
-            if (!enabled) {
-                std::string info_message = "ApiLayerManifestFile::CreateIfValid Implicit layer ";
-                info_message += filename;
-                info_message += " is disabled";
-                LoaderLogger::LogInfoMessage("", info_message);
+        } else {
+            // Otherwise, treat the library path as a relative path based on the JSON file.
+            std::string combined_path;
+            std::string file_parent;
+            if (!FileSysUtilsGetParentPath(filename, file_parent) ||
+                !FileSysUtilsCombinePaths(file_parent, library_path, combined_path) || !FileSysUtilsPathExists(combined_path)) {
+                std::string error_message = "ApiLayerManifestFile::CreateIfValid ";
+                error_message += filename;
+                error_message += " library ";
+                error_message += combined_path;
+                error_message += " does not appear to exist";
+                LoaderLogger::LogErrorMessage("", error_message);
                 return;
             }
+            library_path = combined_path;
         }
-        layer_name = layer_root_node["name"].asString();
-        std::string api_version_string = layer_root_node["api_version"].asString();
-        sscanf(api_version_string.c_str(), "%d.%d", &api_version.major, &api_version.minor);
-        api_version.patch = 0;
+    }
 
-        if ((api_version.major == 0 && api_version.minor == 0) || api_version.major > XR_VERSION_MAJOR(XR_CURRENT_API_VERSION)) {
-            std::string warning_message = "ApiLayerManifestFile::CreateIfValid layer ";
-            warning_message += filename;
-            warning_message += " has invalid API Version.  Skipping layer.";
-            LoaderLogger::LogWarningMessage("", warning_message);
-            return;
-        }
+    if (!layer_root_node["description"].isNull() && layer_root_node["description"].isString()) {
+        description = layer_root_node["description"].asString();
+    }
 
-        uint32_t implementation_version = atoi(layer_root_node["implementation_version"].asString().c_str());
-        library_path = layer_root_node["library_path"].asString();
+    // Add this layer manifest file
+    manifest_files.emplace_back(
+        new ApiLayerManifestFile(type, filename, layer_name, description, api_version, implementation_version, library_path));
 
-        // If the library_path variable has no directory symbol, it's just a file name and should be accessible on the
-        // global library path.
-        if (library_path.find("\\") != library_path.npos || library_path.find("/") != library_path.npos) {
-            // If the library_path is an absolute path, just use that if it exists
-            if (FileSysUtilsIsAbsolutePath(library_path)) {
-                if (!FileSysUtilsPathExists(library_path)) {
-                    std::string error_message = "ApiLayerManifestFile::CreateIfValid ";
-                    error_message += filename;
-                    error_message += " library ";
-                    error_message += library_path;
-                    error_message += " does not appear to exist";
-                    LoaderLogger::LogErrorMessage("", error_message);
-                    return;
-                }
-            } else {
-                // Otherwise, treat the library path as a relative path based on the JSON file.
-                std::string combined_path;
-                std::string file_parent;
-                if (!FileSysUtilsGetParentPath(filename, file_parent) ||
-                    !FileSysUtilsCombinePaths(file_parent, library_path, combined_path) || !FileSysUtilsPathExists(combined_path)) {
-                    std::string error_message = "ApiLayerManifestFile::CreateIfValid ";
-                    error_message += filename;
-                    error_message += " library ";
-                    error_message += combined_path;
-                    error_message += " does not appear to exist";
-                    LoaderLogger::LogErrorMessage("", error_message);
-                    return;
-                }
-                library_path = combined_path;
-            }
-        }
-
-        if (!layer_root_node["description"].isNull() && layer_root_node["description"].isString()) {
-            description = layer_root_node["description"].asString();
-        }
-
-        // Add this layer manifest file
-        manifest_files.emplace_back(
-            new ApiLayerManifestFile(type, filename, layer_name, description, api_version, implementation_version, library_path));
-
-        // Add any extensions to it after the fact.
-        Json::Value dev_exts = layer_root_node["device_extensions"];
-        if (!dev_exts.isNull() && dev_exts.isArray()) {
-            for (Json::ValueIterator dev_ext_it = dev_exts.begin(); dev_ext_it != dev_exts.end(); ++dev_ext_it) {
-                Json::Value dev_ext = (*dev_ext_it);
-                Json::Value dev_ext_name = dev_ext["name"];
-                Json::Value dev_ext_version = dev_ext["spec_version"];
-                Json::Value dev_ext_entries = dev_ext["entrypoints"];
-                if (!dev_ext_name.isNull() && dev_ext_name.isString() && !dev_ext_version.isNull() && dev_ext_version.isString() &&
-                    !dev_ext_entries.isNull() && dev_ext_entries.isArray()) {
-                    ExtensionListing ext = {};
-                    ext.name = dev_ext_name.asString();
-                    ext.spec_version = atoi(dev_ext_version.asString().c_str());
-                    for (Json::ValueIterator entry_it = dev_ext_entries.begin(); entry_it != dev_ext_entries.end(); ++entry_it) {
-                        Json::Value entry = (*entry_it);
-                        if (!entry.isNull() && entry.isString()) {
-                            ext.entrypoints.push_back(entry.asString());
-                        }
+    // Add any extensions to it after the fact.
+    Json::Value dev_exts = layer_root_node["device_extensions"];
+    if (!dev_exts.isNull() && dev_exts.isArray()) {
+        for (Json::ValueIterator dev_ext_it = dev_exts.begin(); dev_ext_it != dev_exts.end(); ++dev_ext_it) {
+            Json::Value dev_ext = (*dev_ext_it);
+            Json::Value dev_ext_name = dev_ext["name"];
+            Json::Value dev_ext_version = dev_ext["spec_version"];
+            Json::Value dev_ext_entries = dev_ext["entrypoints"];
+            if (!dev_ext_name.isNull() && dev_ext_name.isString() && !dev_ext_version.isNull() && dev_ext_version.isString() &&
+                !dev_ext_entries.isNull() && dev_ext_entries.isArray()) {
+                ExtensionListing ext = {};
+                ext.name = dev_ext_name.asString();
+                ext.spec_version = atoi(dev_ext_version.asString().c_str());
+                for (Json::ValueIterator entry_it = dev_ext_entries.begin(); entry_it != dev_ext_entries.end(); ++entry_it) {
+                    Json::Value entry = (*entry_it);
+                    if (!entry.isNull() && entry.isString()) {
+                        ext.entrypoints.push_back(entry.asString());
                     }
-                    manifest_files.back()->_device_extensions.push_back(ext);
                 }
+                manifest_files.back()->_device_extensions.push_back(ext);
             }
         }
+    }
 
-        Json::Value inst_exts = layer_root_node["instance_extensions"];
-        if (!inst_exts.isNull() && inst_exts.isArray()) {
-            for (Json::ValueIterator inst_ext_it = inst_exts.begin(); inst_ext_it != inst_exts.end(); ++inst_ext_it) {
-                Json::Value inst_ext = (*inst_ext_it);
-                Json::Value inst_ext_name = inst_ext["name"];
-                Json::Value inst_ext_version = inst_ext["spec_version"];
-                if (!inst_ext_name.isNull() && inst_ext_name.isString() && !inst_ext_version.isNull() &&
-                    inst_ext_version.isString()) {
-                    ExtensionListing ext = {};
-                    ext.name = inst_ext_name.asString();
-                    ext.spec_version = atoi(inst_ext_version.asString().c_str());
-                    manifest_files.back()->_instance_extensions.push_back(ext);
-                }
+    Json::Value inst_exts = layer_root_node["instance_extensions"];
+    if (!inst_exts.isNull() && inst_exts.isArray()) {
+        for (Json::ValueIterator inst_ext_it = inst_exts.begin(); inst_ext_it != inst_exts.end(); ++inst_ext_it) {
+            Json::Value inst_ext = (*inst_ext_it);
+            Json::Value inst_ext_name = inst_ext["name"];
+            Json::Value inst_ext_version = inst_ext["spec_version"];
+            if (!inst_ext_name.isNull() && inst_ext_name.isString() && !inst_ext_version.isNull() &&
+                inst_ext_version.isString()) {
+                ExtensionListing ext = {};
+                ext.name = inst_ext_name.asString();
+                ext.spec_version = atoi(inst_ext_version.asString().c_str());
+                manifest_files.back()->_instance_extensions.push_back(ext);
             }
         }
+    }
 
-        Json::Value funcs_renamed = layer_root_node["functions"];
-        if (!funcs_renamed.isNull() && funcs_renamed.size() > 0) {
-            for (Json::ValueIterator func_it = funcs_renamed.begin(); func_it != funcs_renamed.end(); ++func_it) {
-                if (!(*func_it).isString()) {
-                    std::string warning_message = "ApiLayerManifestFile::CreateIfValid ";
-                    warning_message += filename;
-                    warning_message += " \"functions\" section contains non-string values.";
-                    LoaderLogger::LogWarningMessage("", warning_message);
-                    continue;
-                }
-                std::string original_name = func_it.key().asString();
-                std::string new_name = (*func_it).asString();
-                manifest_files.back()->_functions_renamed.insert(std::make_pair(original_name, new_name));
+    Json::Value funcs_renamed = layer_root_node["functions"];
+    if (!funcs_renamed.isNull() && funcs_renamed.size() > 0) {
+        for (Json::ValueIterator func_it = funcs_renamed.begin(); func_it != funcs_renamed.end(); ++func_it) {
+            if (!(*func_it).isString()) {
+                std::string warning_message = "ApiLayerManifestFile::CreateIfValid ";
+                warning_message += filename;
+                warning_message += " \"functions\" section contains non-string values.";
+                LoaderLogger::LogWarningMessage("", warning_message);
+                continue;
             }
+            std::string original_name = func_it.key().asString();
+            std::string new_name = (*func_it).asString();
+            manifest_files.back()->_functions_renamed.insert(std::make_pair(original_name, new_name));
         }
+    }
     } catch (...) {
         LoaderLogger::LogErrorMessage("", "ApiLayerManifestFile::CreateIfValid - unknown error occurred");
         throw;
@@ -982,20 +982,20 @@ void ApiLayerManifestFile::CreateIfValid(ManifestFileType type, std::string file
 
 XrApiLayerProperties ApiLayerManifestFile::GetApiLayerProperties() {
     try {
-        XrApiLayerProperties props = {};
-        props.type = XR_TYPE_API_LAYER_PROPERTIES;
-        props.next = nullptr;
-        props.implementationVersion = _implementation_version;
-        props.specVersion = XR_MAKE_VERSION(_api_version.major, _api_version.minor, _api_version.patch);
-        strncpy(props.layerName, _layer_name.c_str(), XR_MAX_API_LAYER_NAME_SIZE - 1);
-        if (_layer_name.size() >= XR_MAX_API_LAYER_NAME_SIZE - 1) {
-            props.layerName[XR_MAX_API_LAYER_NAME_SIZE - 1] = '\0';
-        }
-        strncpy(props.description, _description.c_str(), XR_MAX_API_LAYER_DESCRIPTION_SIZE - 1);
-        if (_description.size() >= XR_MAX_API_LAYER_DESCRIPTION_SIZE - 1) {
-            props.description[XR_MAX_API_LAYER_DESCRIPTION_SIZE - 1] = '\0';
-        }
-        return props;
+    XrApiLayerProperties props = {};
+    props.type = XR_TYPE_API_LAYER_PROPERTIES;
+    props.next = nullptr;
+    props.implementationVersion = _implementation_version;
+    props.specVersion = XR_MAKE_VERSION(_api_version.major, _api_version.minor, _api_version.patch);
+    strncpy(props.layerName, _layer_name.c_str(), XR_MAX_API_LAYER_NAME_SIZE - 1);
+    if (_layer_name.size() >= XR_MAX_API_LAYER_NAME_SIZE - 1) {
+        props.layerName[XR_MAX_API_LAYER_NAME_SIZE - 1] = '\0';
+    }
+    strncpy(props.description, _description.c_str(), XR_MAX_API_LAYER_DESCRIPTION_SIZE - 1);
+    if (_description.size() >= XR_MAX_API_LAYER_DESCRIPTION_SIZE - 1) {
+        props.description[XR_MAX_API_LAYER_DESCRIPTION_SIZE - 1] = '\0';
+    }
+    return props;
     } catch (...) {
         LoaderLogger::LogErrorMessage("", "ApiLayerManifestFile::GetApiLayerProperties - unknown error occurred");
         throw;
@@ -1006,56 +1006,56 @@ XrApiLayerProperties ApiLayerManifestFile::GetApiLayerProperties() {
 XrResult ApiLayerManifestFile::FindManifestFiles(ManifestFileType type,
                                                  std::vector<std::unique_ptr<ApiLayerManifestFile>> &manifest_files) {
     try {
-        std::string relative_path;
-        std::string override_env_var;
-        std::string registry_location = "";
+    std::string relative_path;
+    std::string override_env_var;
+    std::string registry_location = "";
 
-        // Add the appropriate top-level folders for the relative path.  These should be
-        // the string "openxr/" followed by the API major version as a string.
-        relative_path = OPENXR_RELATIVE_PATH;
-        relative_path += std::to_string(XR_VERSION_MAJOR(XR_CURRENT_API_VERSION));
+    // Add the appropriate top-level folders for the relative path.  These should be
+    // the string "openxr/" followed by the API major version as a string.
+    relative_path = OPENXR_RELATIVE_PATH;
+    relative_path += std::to_string(XR_VERSION_MAJOR(XR_CURRENT_API_VERSION));
 
-        switch (type) {
-            case MANIFEST_TYPE_IMPLICIT_API_LAYER:
-                relative_path += OPENXR_IMPLICIT_API_LAYER_RELATIVE_PATH;
-                override_env_var = "";
+    switch (type) {
+        case MANIFEST_TYPE_IMPLICIT_API_LAYER:
+            relative_path += OPENXR_IMPLICIT_API_LAYER_RELATIVE_PATH;
+            override_env_var = "";
 #ifdef XR_OS_WINDOWS
-                registry_location = OPENXR_IMPLICIT_API_LAYER_REGISTRY_LOCATION;
+            registry_location = OPENXR_IMPLICIT_API_LAYER_REGISTRY_LOCATION;
 #endif
-                break;
-            case MANIFEST_TYPE_EXPLICIT_API_LAYER:
-                relative_path += OPENXR_EXPLICIT_API_LAYER_RELATIVE_PATH;
-                override_env_var = OPENXR_API_LAYER_PATH_ENV_VAR;
+            break;
+        case MANIFEST_TYPE_EXPLICIT_API_LAYER:
+            relative_path += OPENXR_EXPLICIT_API_LAYER_RELATIVE_PATH;
+            override_env_var = OPENXR_API_LAYER_PATH_ENV_VAR;
 #ifdef XR_OS_WINDOWS
-                registry_location = OPENXR_EXPLICIT_API_LAYER_REGISTRY_LOCATION;
+            registry_location = OPENXR_EXPLICIT_API_LAYER_REGISTRY_LOCATION;
 #endif
-                break;
-            default:
-                LoaderLogger::LogErrorMessage("", "ApiLayerManifestFile::FindManifestFiles - unknown manifest file requested");
-                throw std::runtime_error("invalid manifest type");
-        }
+            break;
+        default:
+            LoaderLogger::LogErrorMessage("", "ApiLayerManifestFile::FindManifestFiles - unknown manifest file requested");
+            throw std::runtime_error("invalid manifest type");
+    }
 
-        bool override_active = false;
-        std::vector<std::string> filenames;
-        ReadDataFilesInSearchPaths(type, override_env_var, relative_path, override_active, filenames);
+    bool override_active = false;
+    std::vector<std::string> filenames;
+    ReadDataFilesInSearchPaths(type, override_env_var, relative_path, override_active, filenames);
 
 #ifdef XR_OS_WINDOWS
-        // Read the registry if the override wasn't active.
-        if (!override_active) {
-            ReadLayerDataFilesInRegistry(type, registry_location, filenames);
-        }
+    // Read the registry if the override wasn't active.
+    if (!override_active) {
+        ReadLayerDataFilesInRegistry(type, registry_location, filenames);
+    }
 #endif
 
-        switch (type) {
-            case MANIFEST_TYPE_IMPLICIT_API_LAYER:
-            case MANIFEST_TYPE_EXPLICIT_API_LAYER:
-                for (std::string &cur_file : filenames) {
-                    ApiLayerManifestFile::CreateIfValid(type, cur_file, manifest_files);
-                }
-                break;
-            default:
-                break;
-        }
+    switch (type) {
+        case MANIFEST_TYPE_IMPLICIT_API_LAYER:
+        case MANIFEST_TYPE_EXPLICIT_API_LAYER:
+            for (std::string &cur_file : filenames) {
+                ApiLayerManifestFile::CreateIfValid(type, cur_file, manifest_files);
+            }
+            break;
+        default:
+            break;
+    }
 
     } catch (std::bad_alloc &) {
         LoaderLogger::LogErrorMessage("", "ApiLayerManifestFile::FindManifestFiles - memory allocation failed");

--- a/src/loader/manifest_file.cpp
+++ b/src/loader/manifest_file.cpp
@@ -60,15 +60,10 @@ static inline bool StringEndsWith(std::string const &value, std::string const &e
 
 // If the file found is a manifest file name, add it to the out_files manifest list.
 static void AddIfJson(ManifestFileType type, const std::string &full_file, std::vector<std::string> &manifest_files) {
-    try {
     if (0 == full_file.size() || !StringEndsWith(full_file, ".json")) {
         return;
     }
     manifest_files.push_back(full_file);
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("", "AddIfJson - unknown error occurred");
-        throw;
-    }
 }
 
 // Check the current path for any manifest files.  If the provided search_path is a directory, look for
@@ -76,7 +71,6 @@ static void AddIfJson(ManifestFileType type, const std::string &full_file, std::
 // be a single filename.
 static void CheckAllFilesInThePath(ManifestFileType type, const std::string &search_path, bool is_directory_list,
                                    std::vector<std::string> &manifest_files) {
-    try {
     if (FileSysUtilsPathExists(search_path)) {
         std::string absolute_path;
         if (!is_directory_list) {
@@ -99,10 +93,6 @@ static void CheckAllFilesInThePath(ManifestFileType type, const std::string &sea
             }
         }
     }
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("", "CheckAllFilesInThePath - unknown error occurred");
-        throw;
-    }
 }
 
 // Add all manifest files in the provided paths to the manifest_files list.  If search_path
@@ -114,7 +104,6 @@ static void AddFilesInPath(ManifestFileType type, const std::string &search_path
     std::size_t found = search_path.find_first_of(PATH_SEPARATOR);
     std::string cur_search;
 
-    try {
     // Handle any path listings in the string (separated by the appropriate path separator)
     while (found != std::string::npos) {
         // substr takes a start index and length.
@@ -136,10 +125,6 @@ static void AddFilesInPath(ManifestFileType type, const std::string &search_path
         cur_search = search_path.substr(last_found);
         CheckAllFilesInThePath(type, cur_search, is_directory_list, manifest_files);
     }
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("", "AddFilesInPath - unknown error occurred");
-        throw;
-    }
 }
 
 // Copy all paths listed in the cur_path string into output_path and append the appropriate relative_path onto the end of each.
@@ -149,7 +134,6 @@ static void CopyIncludedPaths(bool is_directory_list, const std::string &cur_pat
         std::size_t last_found = 0;
         std::size_t found = cur_path.find_first_of(PATH_SEPARATOR);
 
-        try {
         // Handle any path listings in the string (separated by the appropriate path separator)
         while (found != std::string::npos) {
             std::size_t length = found - last_found;
@@ -174,10 +158,6 @@ static void CopyIncludedPaths(bool is_directory_list, const std::string &cur_pat
             output_path += relative_path;
             output_path += PATH_SEPARATOR;
         }
-        } catch (...) {
-            LoaderLogger::LogErrorMessage("", "CopyIncludedPaths - unknown error occurred");
-            throw;
-        }
     }
 }
 
@@ -190,7 +170,6 @@ static void ReadDataFilesInSearchPaths(ManifestFileType type, const std::string 
     std::string override_path = "";
     std::string search_path = "";
 
-    try {
     if (override_env_var.size() != 0) {
 #ifndef XR_OS_WINDOWS
         if (geteuid() != getuid() || getegid() != getgid()) {
@@ -277,10 +256,6 @@ static void ReadDataFilesInSearchPaths(ManifestFileType type, const std::string 
 
     // Now, parse the paths and add any manifest files found in them.
     AddFilesInPath(type, search_path, is_directory_list, manifest_files);
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("", "ReadDataFilesInSearchPaths - unknown error occurred");
-        throw;
-    }
 }
 
 #ifdef XR_OS_LINUX
@@ -363,7 +338,6 @@ static bool FindXDGConfigFile(const std::string &relative_path, std::string &out
 static void ReadRuntimeDataFilesInRegistry(ManifestFileType type, const std::string &runtime_registry_location,
                                            const std::string &default_runtime_value_name,
                                            std::vector<std::string> &manifest_files) {
-    try {
     HKEY hkey;
     DWORD access_flags;
     wchar_t value_w[1024];
@@ -394,17 +368,12 @@ static void ReadRuntimeDataFilesInRegistry(ManifestFileType type, const std::str
     } else {
         AddFilesInPath(type, wide_to_utf8(value_w), false, manifest_files);
     }
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("", "ReadLayerDataFilesInRegistry - unknown error occurred");
-        throw;
-    }
 }
 
 // Look for layer data files in the provided paths, but first check the environment override to determine
 // if we should use that instead.
 static void ReadLayerDataFilesInRegistry(ManifestFileType type, const std::string &registry_location,
                                          std::vector<std::string> &manifest_files) {
-    try {
     HKEY hive[2] = {HKEY_LOCAL_MACHINE, HKEY_CURRENT_USER};
     bool found[2] = {false, false};
     HKEY hkey;
@@ -444,10 +413,6 @@ static void ReadLayerDataFilesInRegistry(ManifestFileType type, const std::strin
             name_size = 1023;
         }
     }
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("", "ReadLayerDataFilesInRegistry - unknown error occurred");
-        throw;
-    }
 }
 
 #endif  // XR_OS_WINDOWS
@@ -458,7 +423,6 @@ ManifestFile::ManifestFile(ManifestFileType type, const std::string &filename, c
 ManifestFile::~ManifestFile() {}
 
 bool ManifestFile::IsValidJson(Json::Value &root_node, JsonVersion &version) {
-    try {
     if (root_node["file_format_version"].isNull() || !root_node["file_format_version"].isString()) {
         LoaderLogger::LogErrorMessage("", "ManifestFile::IsValidJson - JSON file missing \"file_format_version\"");
         return false;
@@ -479,10 +443,6 @@ bool ManifestFile::IsValidJson(Json::Value &root_node, JsonVersion &version) {
         LoaderLogger::LogErrorMessage("", error_message);
         return false;
     }
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("", "ManifestFile::IsValidJson - unknown error occurred");
-        throw;
-    }
 
     return true;
 }
@@ -490,7 +450,6 @@ bool ManifestFile::IsValidJson(Json::Value &root_node, JsonVersion &version) {
 // Return any instance extensions found in the manifest files in the proper form for
 // OpenXR (XrExtensionProperties).
 void ManifestFile::GetInstanceExtensionProperties(std::vector<XrExtensionProperties> &props) {
-    try {
     size_t ext_count = _instance_extensions.size();
     size_t props_count = props.size();
     bool found = false;
@@ -514,16 +473,11 @@ void ManifestFile::GetInstanceExtensionProperties(std::vector<XrExtensionPropert
             props.push_back(prop);
         }
     }
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("", "ManifestFile::GetInstanceExtensionProperties - unknown error occurred");
-        throw;
-    }
 }
 
 // Return any device extensions found in the manifest files in the proper form for
 // OpenXR (XrExtensionProperties).
 void ManifestFile::GetDeviceExtensionProperties(std::vector<XrExtensionProperties> &props) {
-    try {
     size_t ext_count = _device_extensions.size();
     size_t props_count = props.size();
     bool found = false;
@@ -547,23 +501,14 @@ void ManifestFile::GetDeviceExtensionProperties(std::vector<XrExtensionPropertie
             props.push_back(prop);
         }
     }
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("", "ManifestFile::GetDeviceExtensionProperties - unknown error occurred");
-        throw;
-    }
 }
 
 const std::string &ManifestFile::GetFunctionName(const std::string &func_name) {
-    try {
     if (_functions_renamed.size() > 0) {
         auto found = _functions_renamed.find(func_name);
         if (found != _functions_renamed.end()) {
             return found->second;
         }
-    }
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("", "ManifestFile::GetFunctionName - unknown error occurred");
-        throw;
     }
     return func_name;
 }
@@ -574,7 +519,6 @@ RuntimeManifestFile::RuntimeManifestFile(const std::string &filename, const std:
 RuntimeManifestFile::~RuntimeManifestFile() {}
 
 void RuntimeManifestFile::CreateIfValid(std::string filename, std::vector<std::unique_ptr<RuntimeManifestFile>> &manifest_files) {
-    try {
     std::ifstream json_stream = std::ifstream(filename, std::ifstream::in);
     if (!json_stream.is_open()) {
         std::string error_message = "RuntimeManifestFile::createIfValid failed to open ";
@@ -705,20 +649,15 @@ void RuntimeManifestFile::CreateIfValid(std::string filename, std::vector<std::u
             manifest_files.back()->_functions_renamed.insert(std::make_pair(original_name, new_name));
         }
     }
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("", "RuntimeManifestFile::CreateIfValid - unknown error occurred");
-        throw;
-    }
 }
 
 // Find all manifest files in the appropriate search paths/registries for the given type.
 XrResult RuntimeManifestFile::FindManifestFiles(ManifestFileType type,
                                                 std::vector<std::unique_ptr<RuntimeManifestFile>> &manifest_files) {
     XrResult result = XR_SUCCESS;
-    try {
     if (MANIFEST_TYPE_RUNTIME != type) {
         LoaderLogger::LogErrorMessage("", "RuntimeManifestFile::FindManifestFiles - unknown manifest file requested");
-        throw std::runtime_error("invalid manifest type");
+        return XR_ERROR_FILE_ACCESS_ERROR;
     }
     std::string filename;
     char *override_path = PlatformUtilsGetSecureEnv(OPENXR_RUNTIME_JSON_ENV_VAR);
@@ -766,13 +705,6 @@ XrResult RuntimeManifestFile::FindManifestFiles(ManifestFileType type,
         LoaderLogger::LogInfoMessage("", info_message);
     }
     RuntimeManifestFile::CreateIfValid(filename, manifest_files);
-    } catch (std::bad_alloc &) {
-        LoaderLogger::LogErrorMessage("", "RuntimeManifestFile::FindManifestFiles - failed to allocate memory");
-        return XR_ERROR_OUT_OF_MEMORY;
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("", "RuntimeManifestFile::FindManifestFiles - unknown error occurred");
-        return XR_ERROR_FILE_ACCESS_ERROR;
-    }
     return result;
 }
 
@@ -789,7 +721,6 @@ ApiLayerManifestFile::~ApiLayerManifestFile() {}
 
 void ApiLayerManifestFile::CreateIfValid(ManifestFileType type, std::string filename,
                                          std::vector<std::unique_ptr<ApiLayerManifestFile>> &manifest_files) {
-    try {
     std::ifstream json_stream = std::ifstream(filename, std::ifstream::in);
     Json::Reader reader;
     Json::Value root_node = Json::nullValue;
@@ -974,14 +905,9 @@ void ApiLayerManifestFile::CreateIfValid(ManifestFileType type, std::string file
             manifest_files.back()->_functions_renamed.insert(std::make_pair(original_name, new_name));
         }
     }
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("", "ApiLayerManifestFile::CreateIfValid - unknown error occurred");
-        throw;
-    }
 }
 
 XrApiLayerProperties ApiLayerManifestFile::GetApiLayerProperties() {
-    try {
     XrApiLayerProperties props = {};
     props.type = XR_TYPE_API_LAYER_PROPERTIES;
     props.next = nullptr;
@@ -996,16 +922,11 @@ XrApiLayerProperties ApiLayerManifestFile::GetApiLayerProperties() {
         props.description[XR_MAX_API_LAYER_DESCRIPTION_SIZE - 1] = '\0';
     }
     return props;
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("", "ApiLayerManifestFile::GetApiLayerProperties - unknown error occurred");
-        throw;
-    }
 }
 
 // Find all layer manifest files in the appropriate search paths/registries for the given type.
 XrResult ApiLayerManifestFile::FindManifestFiles(ManifestFileType type,
                                                  std::vector<std::unique_ptr<ApiLayerManifestFile>> &manifest_files) {
-    try {
     std::string relative_path;
     std::string override_env_var;
     std::string registry_location = "";
@@ -1032,7 +953,7 @@ XrResult ApiLayerManifestFile::FindManifestFiles(ManifestFileType type,
             break;
         default:
             LoaderLogger::LogErrorMessage("", "ApiLayerManifestFile::FindManifestFiles - unknown manifest file requested");
-            throw std::runtime_error("invalid manifest type");
+            return XR_ERROR_FILE_ACCESS_ERROR;
     }
 
     bool override_active = false;
@@ -1057,12 +978,5 @@ XrResult ApiLayerManifestFile::FindManifestFiles(ManifestFileType type,
             break;
     }
 
-    } catch (std::bad_alloc &) {
-        LoaderLogger::LogErrorMessage("", "ApiLayerManifestFile::FindManifestFiles - memory allocation failed");
-        return XR_ERROR_OUT_OF_MEMORY;
-    } catch (...) {
-        LoaderLogger::LogErrorMessage("", "ApiLayerManifestFile::FindManifestFiles - unknown error occurred");
-        return XR_ERROR_FILE_ACCESS_ERROR;
-    }
     return XR_SUCCESS;
 }

--- a/src/loader/runtime_interface.cpp
+++ b/src/loader/runtime_interface.cpp
@@ -34,131 +34,131 @@ XrResult RuntimeInterface::LoadRuntime(const std::string& openxr_command) {
     XrResult last_error = XR_SUCCESS;
     bool any_loaded = false;
     try {
-        // If something's already loaded, we're done here.
-        if (_single_runtime_interface != nullptr) {
-            _single_runtime_count++;
-            return XR_SUCCESS;
-        }
+    // If something's already loaded, we're done here.
+    if (_single_runtime_interface != nullptr) {
+        _single_runtime_count++;
+        return XR_SUCCESS;
+    }
 
-        std::vector<std::unique_ptr<RuntimeManifestFile>> runtime_manifest_files = {};
+    std::vector<std::unique_ptr<RuntimeManifestFile>> runtime_manifest_files = {};
 
-        // Find the available runtimes which we may need to report information for.
-        last_error = RuntimeManifestFile::FindManifestFiles(MANIFEST_TYPE_RUNTIME, runtime_manifest_files);
-        if (XR_SUCCESS != last_error) {
-            LoaderLogger::LogErrorMessage(openxr_command, "RuntimeInterface::LoadRuntimes - unknown error");
-            last_error = XR_ERROR_FILE_ACCESS_ERROR;
-        } else {
-            for (std::unique_ptr<RuntimeManifestFile>& manifest_file : runtime_manifest_files) {
-                LoaderPlatformLibraryHandle runtime_library = LoaderPlatformLibraryOpen(manifest_file->LibraryPath());
-                if (nullptr == runtime_library) {
-                    if (!any_loaded) {
-                        last_error = XR_ERROR_INSTANCE_LOST;
-                    }
-                    std::string library_message = LoaderPlatformLibraryOpenError(manifest_file->LibraryPath());
-                    std::string warning_message = "RuntimeInterface::LoadRuntime skipping manifest file ";
-                    warning_message += manifest_file->Filename();
-                    warning_message += ", failed to load with message \"";
-                    warning_message += library_message;
-                    warning_message += "\"";
-                    LoaderLogger::LogErrorMessage(openxr_command, warning_message);
-                    continue;
+    // Find the available runtimes which we may need to report information for.
+    last_error = RuntimeManifestFile::FindManifestFiles(MANIFEST_TYPE_RUNTIME, runtime_manifest_files);
+    if (XR_SUCCESS != last_error) {
+        LoaderLogger::LogErrorMessage(openxr_command, "RuntimeInterface::LoadRuntimes - unknown error");
+        last_error = XR_ERROR_FILE_ACCESS_ERROR;
+    } else {
+        for (std::unique_ptr<RuntimeManifestFile>& manifest_file : runtime_manifest_files) {
+            LoaderPlatformLibraryHandle runtime_library = LoaderPlatformLibraryOpen(manifest_file->LibraryPath());
+            if (nullptr == runtime_library) {
+                if (!any_loaded) {
+                    last_error = XR_ERROR_INSTANCE_LOST;
                 }
-
-                // Get and settle on an runtime interface version (using any provided name if required).
-                std::string function_name = manifest_file->GetFunctionName("xrNegotiateLoaderRuntimeInterface");
-                PFN_xrNegotiateLoaderRuntimeInterface negotiate = reinterpret_cast<PFN_xrNegotiateLoaderRuntimeInterface>(
-                    LoaderPlatformLibraryGetProcAddr(runtime_library, function_name));
-
-                // Loader info for negotiation
-                XrNegotiateLoaderInfo loader_info = {};
-                loader_info.structType = XR_LOADER_INTERFACE_STRUCT_LOADER_INFO;
-                loader_info.structVersion = XR_LOADER_INFO_STRUCT_VERSION;
-                loader_info.structSize = sizeof(XrNegotiateLoaderInfo);
-                loader_info.minInterfaceVersion = 1;
-                loader_info.maxInterfaceVersion = XR_CURRENT_LOADER_RUNTIME_VERSION;
-                loader_info.minXrVersion = XR_MAKE_VERSION(0, 1, 0);
-                loader_info.maxXrVersion = XR_MAKE_VERSION(1, 0, 0);
-
-                // Set up the runtime return structure
-                XrNegotiateRuntimeRequest runtime_info = {};
-                runtime_info.structType = XR_LOADER_INTERFACE_STRUCT_RUNTIME_REQUEST;
-                runtime_info.structVersion = XR_RUNTIME_INFO_STRUCT_VERSION;
-                runtime_info.structSize = sizeof(XrNegotiateRuntimeRequest);
-
-                XrResult res = negotiate(&loader_info, &runtime_info);
-                // If we supposedly succeeded, but got a nullptr for GetInstanceProcAddr
-                // then something still went wrong, so return with an error.
-                if (XR_SUCCESS == res) {
-                    uint32_t runtime_major = XR_VERSION_MAJOR(runtime_info.runtimeXrVersion);
-                    uint32_t runtime_minor = XR_VERSION_MINOR(runtime_info.runtimeXrVersion);
-                    uint32_t loader_major = XR_VERSION_MAJOR(XR_CURRENT_API_VERSION);
-                    if (nullptr == runtime_info.getInstanceProcAddr) {
-                        std::string error_message = "RuntimeInterface::LoadRuntime skipping manifest file ";
-                        error_message += manifest_file->Filename();
-                        error_message += ", negotiation succeeded but returned NULL getInstanceProcAddr";
-                        LoaderLogger::LogErrorMessage(openxr_command, error_message);
-                        res = XR_ERROR_FILE_CONTENTS_INVALID;
-                    } else if (0 >= runtime_info.runtimeInterfaceVersion ||
-                               XR_CURRENT_LOADER_RUNTIME_VERSION < runtime_info.runtimeInterfaceVersion) {
-                        std::string error_message = "RuntimeInterface::LoadRuntime skipping manifest file ";
-                        error_message += manifest_file->Filename();
-                        error_message += ", negotiation succeeded but returned invalid interface version";
-                        LoaderLogger::LogErrorMessage(openxr_command, error_message);
-                        res = XR_ERROR_FILE_CONTENTS_INVALID;
-                    } else if (runtime_major != loader_major || (runtime_major == 0 && runtime_minor == 0)) {
-                        std::string error_message = "RuntimeInterface::LoadRuntime skipping manifest file ";
-                        error_message += manifest_file->Filename();
-                        error_message += ", OpenXR version returned not compatible with this loader";
-                        LoaderLogger::LogErrorMessage(openxr_command, error_message);
-                        res = XR_ERROR_FILE_CONTENTS_INVALID;
-                    }
-                }
-                if (XR_SUCCESS != res) {
-                    if (!any_loaded) {
-                        last_error = res;
-                    }
-                    std::string warning_message = "RuntimeInterface::LoadRuntime skipping manifest file ";
-                    warning_message += manifest_file->Filename();
-                    warning_message += ", negotiation failed with error ";
-                    warning_message += std::to_string(res);
-                    LoaderLogger::LogErrorMessage(openxr_command, warning_message);
-                    LoaderPlatformLibraryClose(runtime_library);
-                    continue;
-                }
-
-                std::string info_message = "RuntimeInterface::LoadRuntime succeeded loading runtime defined in manifest file ";
-                info_message += manifest_file->Filename();
-                info_message += " using interface version ";
-                info_message += std::to_string(runtime_info.runtimeInterfaceVersion);
-                info_message += " and OpenXR API version ";
-                info_message += std::to_string(XR_VERSION_MAJOR(runtime_info.runtimeXrVersion));
-                info_message += ".";
-                info_message += std::to_string(XR_VERSION_MINOR(runtime_info.runtimeXrVersion));
-                LoaderLogger::LogInfoMessage(openxr_command, info_message);
-
-                // Use this runtime
-                _single_runtime_interface.reset(new RuntimeInterface(runtime_library, runtime_info.getInstanceProcAddr));
-                _single_runtime_count++;
-
-                // Grab the list of extensions this runtime supports for easy filtering after the
-                // xrCreateInstance call
-                std::vector<std::string> supported_extensions;
-                std::vector<XrExtensionProperties> extension_properties;
-                _single_runtime_interface->GetInstanceExtensionProperties(extension_properties);
-                for (XrExtensionProperties ext_prop : extension_properties) {
-                    supported_extensions.push_back(ext_prop.extensionName);
-                }
-                _single_runtime_interface->SetSupportedExtensions(supported_extensions);
-
-                // If we load one, clear all errors.
-                any_loaded = true;
-                last_error = XR_SUCCESS;
-                break;
+                std::string library_message = LoaderPlatformLibraryOpenError(manifest_file->LibraryPath());
+                std::string warning_message = "RuntimeInterface::LoadRuntime skipping manifest file ";
+                warning_message += manifest_file->Filename();
+                warning_message += ", failed to load with message \"";
+                warning_message += library_message;
+                warning_message += "\"";
+                LoaderLogger::LogErrorMessage(openxr_command, warning_message);
+                continue;
             }
-        }
 
-        // Always clear the manifest file list.  Either we use them or we don't.
-        runtime_manifest_files.clear();
+            // Get and settle on an runtime interface version (using any provided name if required).
+            std::string function_name = manifest_file->GetFunctionName("xrNegotiateLoaderRuntimeInterface");
+            PFN_xrNegotiateLoaderRuntimeInterface negotiate = reinterpret_cast<PFN_xrNegotiateLoaderRuntimeInterface>(
+                LoaderPlatformLibraryGetProcAddr(runtime_library, function_name));
+
+            // Loader info for negotiation
+            XrNegotiateLoaderInfo loader_info = {};
+            loader_info.structType = XR_LOADER_INTERFACE_STRUCT_LOADER_INFO;
+            loader_info.structVersion = XR_LOADER_INFO_STRUCT_VERSION;
+            loader_info.structSize = sizeof(XrNegotiateLoaderInfo);
+            loader_info.minInterfaceVersion = 1;
+            loader_info.maxInterfaceVersion = XR_CURRENT_LOADER_RUNTIME_VERSION;
+            loader_info.minXrVersion = XR_MAKE_VERSION(0, 1, 0);
+            loader_info.maxXrVersion = XR_MAKE_VERSION(1, 0, 0);
+
+            // Set up the runtime return structure
+            XrNegotiateRuntimeRequest runtime_info = {};
+            runtime_info.structType = XR_LOADER_INTERFACE_STRUCT_RUNTIME_REQUEST;
+            runtime_info.structVersion = XR_RUNTIME_INFO_STRUCT_VERSION;
+            runtime_info.structSize = sizeof(XrNegotiateRuntimeRequest);
+
+            XrResult res = negotiate(&loader_info, &runtime_info);
+            // If we supposedly succeeded, but got a nullptr for GetInstanceProcAddr
+            // then something still went wrong, so return with an error.
+            if (XR_SUCCESS == res) {
+                uint32_t runtime_major = XR_VERSION_MAJOR(runtime_info.runtimeXrVersion);
+                uint32_t runtime_minor = XR_VERSION_MINOR(runtime_info.runtimeXrVersion);
+                uint32_t loader_major = XR_VERSION_MAJOR(XR_CURRENT_API_VERSION);
+                if (nullptr == runtime_info.getInstanceProcAddr) {
+                    std::string error_message = "RuntimeInterface::LoadRuntime skipping manifest file ";
+                    error_message += manifest_file->Filename();
+                    error_message += ", negotiation succeeded but returned NULL getInstanceProcAddr";
+                    LoaderLogger::LogErrorMessage(openxr_command, error_message);
+                    res = XR_ERROR_FILE_CONTENTS_INVALID;
+                } else if (0 >= runtime_info.runtimeInterfaceVersion ||
+                           XR_CURRENT_LOADER_RUNTIME_VERSION < runtime_info.runtimeInterfaceVersion) {
+                    std::string error_message = "RuntimeInterface::LoadRuntime skipping manifest file ";
+                    error_message += manifest_file->Filename();
+                    error_message += ", negotiation succeeded but returned invalid interface version";
+                    LoaderLogger::LogErrorMessage(openxr_command, error_message);
+                    res = XR_ERROR_FILE_CONTENTS_INVALID;
+                } else if (runtime_major != loader_major || (runtime_major == 0 && runtime_minor == 0)) {
+                    std::string error_message = "RuntimeInterface::LoadRuntime skipping manifest file ";
+                    error_message += manifest_file->Filename();
+                    error_message += ", OpenXR version returned not compatible with this loader";
+                    LoaderLogger::LogErrorMessage(openxr_command, error_message);
+                    res = XR_ERROR_FILE_CONTENTS_INVALID;
+                }
+            }
+            if (XR_SUCCESS != res) {
+                if (!any_loaded) {
+                    last_error = res;
+                }
+                std::string warning_message = "RuntimeInterface::LoadRuntime skipping manifest file ";
+                warning_message += manifest_file->Filename();
+                warning_message += ", negotiation failed with error ";
+                warning_message += std::to_string(res);
+                LoaderLogger::LogErrorMessage(openxr_command, warning_message);
+                LoaderPlatformLibraryClose(runtime_library);
+                continue;
+            }
+
+            std::string info_message = "RuntimeInterface::LoadRuntime succeeded loading runtime defined in manifest file ";
+            info_message += manifest_file->Filename();
+            info_message += " using interface version ";
+            info_message += std::to_string(runtime_info.runtimeInterfaceVersion);
+            info_message += " and OpenXR API version ";
+            info_message += std::to_string(XR_VERSION_MAJOR(runtime_info.runtimeXrVersion));
+            info_message += ".";
+            info_message += std::to_string(XR_VERSION_MINOR(runtime_info.runtimeXrVersion));
+            LoaderLogger::LogInfoMessage(openxr_command, info_message);
+
+            // Use this runtime
+            _single_runtime_interface.reset(new RuntimeInterface(runtime_library, runtime_info.getInstanceProcAddr));
+            _single_runtime_count++;
+
+            // Grab the list of extensions this runtime supports for easy filtering after the
+            // xrCreateInstance call
+            std::vector<std::string> supported_extensions;
+            std::vector<XrExtensionProperties> extension_properties;
+            _single_runtime_interface->GetInstanceExtensionProperties(extension_properties);
+            for (XrExtensionProperties ext_prop : extension_properties) {
+                supported_extensions.push_back(ext_prop.extensionName);
+            }
+            _single_runtime_interface->SetSupportedExtensions(supported_extensions);
+
+            // If we load one, clear all errors.
+            any_loaded = true;
+            last_error = XR_SUCCESS;
+            break;
+        }
+    }
+
+    // Always clear the manifest file list.  Either we use them or we don't.
+    runtime_manifest_files.clear();
     } catch (std::bad_alloc&) {
         LoaderLogger::LogErrorMessage(openxr_command, "RuntimeInterface::LoadRuntimes - failed to allocate memory");
         last_error = XR_ERROR_OUT_OF_MEMORY;
@@ -202,15 +202,15 @@ const XrGeneratedDispatchTable* RuntimeInterface::GetDispatchTable(XrInstance in
 
 const XrGeneratedDispatchTable* RuntimeInterface::GetDebugUtilsMessengerDispatchTable(XrDebugUtilsMessengerEXT messenger) {
     try {
-        XrInstance runtime_instance = XR_NULL_HANDLE;
-        {
-            std::lock_guard<std::mutex> mlock(_single_runtime_interface->_messenger_to_instance_mutex);
-            auto it = _single_runtime_interface->_messenger_to_instance_map.find(messenger);
-            if (it != _single_runtime_interface->_messenger_to_instance_map.end()) {
-                runtime_instance = it->second;
-            }
+    XrInstance runtime_instance = XR_NULL_HANDLE;
+    {
+        std::lock_guard<std::mutex> mlock(_single_runtime_interface->_messenger_to_instance_mutex);
+        auto it = _single_runtime_interface->_messenger_to_instance_map.find(messenger);
+        if (it != _single_runtime_interface->_messenger_to_instance_map.end()) {
+            runtime_instance = it->second;
         }
-        return GetDispatchTable(runtime_instance);
+    }
+    return GetDispatchTable(runtime_instance);
     } catch (...) {
         return nullptr;
     }
@@ -231,41 +231,41 @@ RuntimeInterface::~RuntimeInterface() {
 
 void RuntimeInterface::GetInstanceExtensionProperties(std::vector<XrExtensionProperties>& extension_properties) {
     try {
-        std::vector<XrExtensionProperties> runtime_extension_properties;
-        PFN_xrEnumerateInstanceExtensionProperties rt_xrEnumerateInstanceExtensionProperties;
-        _get_instant_proc_addr(XR_NULL_HANDLE, "xrEnumerateInstanceExtensionProperties",
-                               reinterpret_cast<PFN_xrVoidFunction*>(&rt_xrEnumerateInstanceExtensionProperties));
-        uint32_t count = 0;
-        uint32_t count_output = 0;
-        // Get the count from the runtime
-        rt_xrEnumerateInstanceExtensionProperties(nullptr, count, &count_output, nullptr);
-        if (count_output > 0) {
-            runtime_extension_properties.resize(count_output);
-            count = count_output;
-            for (XrExtensionProperties& ext_prop : runtime_extension_properties) {
-                ext_prop.type = XR_TYPE_EXTENSION_PROPERTIES;
-                ext_prop.next = nullptr;
-            }
-            rt_xrEnumerateInstanceExtensionProperties(nullptr, count, &count_output, runtime_extension_properties.data());
+    std::vector<XrExtensionProperties> runtime_extension_properties;
+    PFN_xrEnumerateInstanceExtensionProperties rt_xrEnumerateInstanceExtensionProperties;
+    _get_instant_proc_addr(XR_NULL_HANDLE, "xrEnumerateInstanceExtensionProperties",
+                           reinterpret_cast<PFN_xrVoidFunction*>(&rt_xrEnumerateInstanceExtensionProperties));
+    uint32_t count = 0;
+    uint32_t count_output = 0;
+    // Get the count from the runtime
+    rt_xrEnumerateInstanceExtensionProperties(nullptr, count, &count_output, nullptr);
+    if (count_output > 0) {
+        runtime_extension_properties.resize(count_output);
+        count = count_output;
+        for (XrExtensionProperties& ext_prop : runtime_extension_properties) {
+            ext_prop.type = XR_TYPE_EXTENSION_PROPERTIES;
+            ext_prop.next = nullptr;
         }
-        size_t ext_count = runtime_extension_properties.size();
-        size_t props_count = extension_properties.size();
-        for (size_t ext = 0; ext < ext_count; ++ext) {
-            bool found = false;
-            for (size_t prop = 0; prop < props_count; ++prop) {
-                // If we find it, then make sure the spec version matches that of the runtime instead of the
-                // layer.
-                if (!strcmp(extension_properties[prop].extensionName, runtime_extension_properties[ext].extensionName)) {
-                    // Make sure the spec version used is the runtime's
-                    extension_properties[prop].specVersion = runtime_extension_properties[ext].specVersion;
-                    found = true;
-                    break;
-                }
-            }
-            if (!found) {
-                extension_properties.push_back(runtime_extension_properties[ext]);
+        rt_xrEnumerateInstanceExtensionProperties(nullptr, count, &count_output, runtime_extension_properties.data());
+    }
+    size_t ext_count = runtime_extension_properties.size();
+    size_t props_count = extension_properties.size();
+    for (size_t ext = 0; ext < ext_count; ++ext) {
+        bool found = false;
+        for (size_t prop = 0; prop < props_count; ++prop) {
+            // If we find it, then make sure the spec version matches that of the runtime instead of the
+            // layer.
+            if (!strcmp(extension_properties[prop].extensionName, runtime_extension_properties[ext].extensionName)) {
+                // Make sure the spec version used is the runtime's
+                extension_properties[prop].specVersion = runtime_extension_properties[ext].specVersion;
+                found = true;
+                break;
             }
         }
+        if (!found) {
+            extension_properties.push_back(runtime_extension_properties[ext]);
+        }
+    }
 
     } catch (...) {
         LoaderLogger::LogErrorMessage("xrEnumerateInstanceExtensionProperties",
@@ -278,16 +278,16 @@ XrResult RuntimeInterface::CreateInstance(const XrInstanceCreateInfo* info, XrIn
     XrResult res = XR_SUCCESS;
     bool create_succeeded = false;
     try {
-        PFN_xrCreateInstance rt_xrCreateInstance;
-        _get_instant_proc_addr(XR_NULL_HANDLE, "xrCreateInstance", reinterpret_cast<PFN_xrVoidFunction*>(&rt_xrCreateInstance));
-        res = rt_xrCreateInstance(info, instance);
-        if (XR_SUCCESS == res) {
-            create_succeeded = true;
-            std::unique_ptr<XrGeneratedDispatchTable> dispatch_table(new XrGeneratedDispatchTable());
-            GeneratedXrPopulateDispatchTable(dispatch_table.get(), *instance, _get_instant_proc_addr);
-            std::lock_guard<std::mutex> mlock(_dispatch_table_mutex);
-            _dispatch_table_map[*instance] = std::move(dispatch_table);
-        }
+    PFN_xrCreateInstance rt_xrCreateInstance;
+    _get_instant_proc_addr(XR_NULL_HANDLE, "xrCreateInstance", reinterpret_cast<PFN_xrVoidFunction*>(&rt_xrCreateInstance));
+    res = rt_xrCreateInstance(info, instance);
+    if (XR_SUCCESS == res) {
+        create_succeeded = true;
+        std::unique_ptr<XrGeneratedDispatchTable> dispatch_table(new XrGeneratedDispatchTable());
+        GeneratedXrPopulateDispatchTable(dispatch_table.get(), *instance, _get_instant_proc_addr);
+        std::lock_guard<std::mutex> mlock(_dispatch_table_mutex);
+        _dispatch_table_map[*instance] = std::move(dispatch_table);
+    }
     } catch (std::bad_alloc&) {
         LoaderLogger::LogErrorMessage("xrCreateInstance", "RuntimeInterface::CreateInstance - failed to allocate memory");
         res = XR_ERROR_OUT_OF_MEMORY;
@@ -309,20 +309,20 @@ XrResult RuntimeInterface::CreateInstance(const XrInstanceCreateInfo* info, XrIn
 
 XrResult RuntimeInterface::DestroyInstance(XrInstance instance) {
     try {
-        if (XR_NULL_HANDLE != instance) {
-            // Destroy the dispatch table for this instance first
-            {
-                std::lock_guard<std::mutex> mlock(_dispatch_table_mutex);
-                auto map_iter = _dispatch_table_map.find(instance);
-                if (map_iter != _dispatch_table_map.end()) {
-                    _dispatch_table_map.erase(map_iter);
-                }
+    if (XR_NULL_HANDLE != instance) {
+        // Destroy the dispatch table for this instance first
+        {
+            std::lock_guard<std::mutex> mlock(_dispatch_table_mutex);
+            auto map_iter = _dispatch_table_map.find(instance);
+            if (map_iter != _dispatch_table_map.end()) {
+                _dispatch_table_map.erase(map_iter);
             }
-            // Now delete the instance
-            PFN_xrDestroyInstance rt_xrDestroyInstance;
-            _get_instant_proc_addr(instance, "xrDestroyInstance", reinterpret_cast<PFN_xrVoidFunction*>(&rt_xrDestroyInstance));
-            rt_xrDestroyInstance(instance);
         }
+        // Now delete the instance
+        PFN_xrDestroyInstance rt_xrDestroyInstance;
+        _get_instant_proc_addr(instance, "xrDestroyInstance", reinterpret_cast<PFN_xrVoidFunction*>(&rt_xrDestroyInstance));
+        rt_xrDestroyInstance(instance);
+    }
     } catch (...) {
         LoaderLogger::LogErrorMessage("xrDestroyInstance", "RuntimeInterface::DestroyInstance - unknown error");
         // Can't return anything but success
@@ -332,9 +332,9 @@ XrResult RuntimeInterface::DestroyInstance(XrInstance instance) {
 
 bool RuntimeInterface::TrackDebugMessenger(XrInstance instance, XrDebugUtilsMessengerEXT messenger) {
     try {
-        std::lock_guard<std::mutex> mlock(_messenger_to_instance_mutex);
-        _messenger_to_instance_map[messenger] = instance;
-        return true;
+    std::lock_guard<std::mutex> mlock(_messenger_to_instance_mutex);
+    _messenger_to_instance_map[messenger] = instance;
+    return true;
     } catch (...) {
         return false;
     }
@@ -354,12 +354,12 @@ void RuntimeInterface::SetSupportedExtensions(std::vector<std::string>& supporte
 bool RuntimeInterface::SupportsExtension(const std::string& extension_name) {
     bool found_prop = false;
     try {
-        for (std::string supported_extension : _supported_extensions) {
-            if (supported_extension == extension_name) {
-                found_prop = true;
-                break;
-            }
+    for (std::string supported_extension : _supported_extensions) {
+        if (supported_extension == extension_name) {
+            found_prop = true;
+            break;
         }
+    }
     } catch (...) {
     }
     return found_prop;

--- a/src/scripts/loader_source_generator.py
+++ b/src/scripts/loader_source_generator.py
@@ -470,64 +470,64 @@ class LoaderSourceOutputGenerator(AutomaticSourceOutputGenerator):
                             if pointer_count == 1 and param.pointer_count_var is not None:
                                 if not param.is_optional:
                                     # Check we have at least 1 in the array.
-                                    tramp_variable_defines += '        if (0 == %s) {\n' % param.pointer_count_var
-                                    tramp_variable_defines += '            LoaderLogger::LogValidationErrorMessage("VUID-%s-%s-parameter", "%s",\n' % (
+                                    tramp_variable_defines += '    if (0 == %s) {\n' % param.pointer_count_var
+                                    tramp_variable_defines += '        LoaderLogger::LogValidationErrorMessage("VUID-%s-%s-parameter", "%s",\n' % (
                                         cur_cmd.name, param.pointer_count_var, cur_cmd.name)
-                                    tramp_variable_defines += '                                                    "%s is 0, but %s is not optional", {XrLoaderLogObjectInfo{%s, %s} });\n' % (
+                                    tramp_variable_defines += '                                                "%s is 0, but %s is not optional", {XrLoaderLogObjectInfo{%s, %s} });\n' % (
                                         param.pointer_count_var, param.name, first_handle_name,
                                         self.genXrObjectType(param.type))
-                                    tramp_variable_defines += '        }\n'
-                            tramp_variable_defines += '        LoaderInstance *loader_instance = g_%s_map.Get(%s);\n' % (
+                                    tramp_variable_defines += '    }\n'
+                            tramp_variable_defines += '    LoaderInstance *loader_instance = g_%s_map.Get(%s);\n' % (
                                 base_handle_name, first_handle_name)
                             if cur_cmd.is_destroy_disconnect:
-                                tramp_variable_defines += '        // Destroy the mapping entry for this item if it was valid.\n'
-                                tramp_variable_defines += '        if (nullptr != loader_instance) {\n'
-                                tramp_variable_defines += '                g_%s_map.Erase(%s);\n' % (
+                                tramp_variable_defines += '    // Destroy the mapping entry for this item if it was valid.\n'
+                                tramp_variable_defines += '    if (nullptr != loader_instance) {\n'
+                                tramp_variable_defines += '            g_%s_map.Erase(%s);\n' % (
                                     base_handle_name, first_handle_name)
-                                tramp_variable_defines += '        }\n'
+                                tramp_variable_defines += '    }\n'
                             # These should be mutually exclusive - verify it.
                             assert((not cur_cmd.is_destroy_disconnect)
                                    or (pointer_count == 0))
 
                             if pointer_count == 1:
                                 # NOTE - @ 10-June-2019 this stanza is never exercised in loader code-gen. Consider whether necessary. DJH
-                                tramp_variable_defines += '        for (uint32_t i = 1; i < %s; ++i) {\n' % param.pointer_count_var
-                                tramp_variable_defines += '            LoaderInstance *elt_loader_instance = g_%s_map.Get(%s[i]);\n' % (
+                                tramp_variable_defines += '    for (uint32_t i = 1; i < %s; ++i) {\n' % param.pointer_count_var
+                                tramp_variable_defines += '        LoaderInstance *elt_loader_instance = g_%s_map.Get(%s[i]);\n' % (
                                     base_handle_name, param.name)
-                                tramp_variable_defines += '            if (elt_loader_instance == nullptr || elt_loader_instance != loader_instance) {\n'
-                                tramp_variable_defines += '                auto elt_name = "%s[" + std::to_string(i) + "]";\n' % param.name
+                                tramp_variable_defines += '        if (elt_loader_instance == nullptr || elt_loader_instance != loader_instance) {\n'
+                                tramp_variable_defines += '            auto elt_name = "%s[" + std::to_string(i) + "]";\n' % param.name
                                 loader_objects = '{XrLoaderLogObjectInfo{%s[i], %s} }' % (first_handle_name,
                                                                                           self.genXrObjectType(param.type))
-                                tramp_variable_defines += '                if (elt_loader_instance == nullptr) {\n'
-                                tramp_variable_defines += '                    LoaderLogger::LogValidationErrorMessage("VUID-%s-%s-parameter", "%s",\n' % (
+                                tramp_variable_defines += '            if (elt_loader_instance == nullptr) {\n'
+                                tramp_variable_defines += '                LoaderLogger::LogValidationErrorMessage("VUID-%s-%s-parameter", "%s",\n' % (
                                     cur_cmd.name, param.name, cur_cmd.name)
-                                tramp_variable_defines += '                                                    elt_name + " is not a valid %s", %s);\n' % (
+                                tramp_variable_defines += '                                                elt_name + " is not a valid %s", %s);\n' % (
                                     param.name, param.type, loader_objects)
-                                tramp_variable_defines += '                } else {\n'
-                                tramp_variable_defines += '                    LoaderLogger::LogValidationErrorMessage("VUID-%s-%s-parameter", "%s",\n' % (
+                                tramp_variable_defines += '            } else {\n'
+                                tramp_variable_defines += '                LoaderLogger::LogValidationErrorMessage("VUID-%s-%s-parameter", "%s",\n' % (
                                     cur_cmd.name, param.name, cur_cmd.name)
-                                tramp_variable_defines += '                                                            "%s[" + std::to_string(i) + "] belongs to a different instance than %s[0]", %s);\n' % (
+                                tramp_variable_defines += '                                                        "%s[" + std::to_string(i) + "] belongs to a different instance than %s[0]", %s);\n' % (
                                     param.name, param.name, loader_objects)
-                                tramp_variable_defines += '                }\n'
-                                if has_return:
-                                    tramp_variable_defines += '                return XR_ERROR_HANDLE_INVALID;\n'
                                 tramp_variable_defines += '            }\n'
+                                if has_return:
+                                    tramp_variable_defines += '            return XR_ERROR_HANDLE_INVALID;\n'
                                 tramp_variable_defines += '        }\n'
+                                tramp_variable_defines += '    }\n'
                             loader_objects = '{XrLoaderLogObjectInfo{%s, %s} }' % (first_handle_name,
                                                                                    self.genXrObjectType(param.type))
-                            tramp_variable_defines += '        if (nullptr == loader_instance) {\n'
-                            tramp_variable_defines += '            LoaderLogger::LogValidationErrorMessage("VUID-%s-%s-parameter", "%s",\n' % (
+                            tramp_variable_defines += '    if (nullptr == loader_instance) {\n'
+                            tramp_variable_defines += '        LoaderLogger::LogValidationErrorMessage("VUID-%s-%s-parameter", "%s",\n' % (
                                 cur_cmd.name, param.name, cur_cmd.name)
-                            tramp_variable_defines += '                                                    "%s is not a valid %s", %s);\n' % (
+                            tramp_variable_defines += '                                                "%s is not a valid %s", %s);\n' % (
                                 first_handle_name, param.type, loader_objects)
                             if has_return:
-                                tramp_variable_defines += '            return XR_ERROR_HANDLE_INVALID;\n'
-                            tramp_variable_defines += '        }\n'
+                                tramp_variable_defines += '        return XR_ERROR_HANDLE_INVALID;\n'
+                            tramp_variable_defines += '    }\n'
                         else:
                             tramp_variable_defines += self.printCodeGenErrorMessage(
                                 'Command %s does not have an OpenXR Object handle as the first parameter.' % cur_cmd.name)
 
-                        tramp_variable_defines += '        const std::unique_ptr<XrGeneratedDispatchTable>& dispatch_table = loader_instance->DispatchTable();\n'
+                        tramp_variable_defines += '    const std::unique_ptr<XrGeneratedDispatchTable>& dispatch_table = loader_instance->DispatchTable();\n'
 
                     tramp_param_replace.append(
                         self.MemberOrParam(type=param.type,
@@ -584,25 +584,25 @@ class LoaderSourceOutputGenerator(AutomaticSourceOutputGenerator):
 
                 # If this is not core, but an extension, check to make sure the extension is enabled.
                 if x == 1:
-                    generated_funcs += '        if (!loader_instance->ExtensionIsEnabled("%s")) {\n' % (
+                    generated_funcs += '    if (!loader_instance->ExtensionIsEnabled("%s")) {\n' % (
                         cur_cmd.ext_name)
-                    generated_funcs += '            LoaderLogger::LogValidationErrorMessage("VUID-%s-extension-notenabled",\n' % cur_cmd.name
-                    generated_funcs += '                                                    "%s",\n' % cur_cmd.name
-                    generated_funcs += '                                                    "The %s extension has not been enabled prior to calling %s");\n' % (
+                    generated_funcs += '        LoaderLogger::LogValidationErrorMessage("VUID-%s-extension-notenabled",\n' % cur_cmd.name
+                    generated_funcs += '                                                "%s",\n' % cur_cmd.name
+                    generated_funcs += '                                                "The %s extension has not been enabled prior to calling %s");\n' % (
                         cur_cmd.ext_name, cur_cmd.name)
                     if has_return:
-                        generated_funcs += '            return XR_ERROR_FUNCTION_UNSUPPORTED;\n'
+                        generated_funcs += '        return XR_ERROR_FUNCTION_UNSUPPORTED;\n'
                     else:
-                        generated_funcs += '            return;\n'
-                    generated_funcs += '        }\n\n'
+                        generated_funcs += '        return;\n'
+                    generated_funcs += '    }\n\n'
 
                 if has_return:
                     if just_return_call:
-                        generated_funcs += '        return '
+                        generated_funcs += '    return '
                     else:
-                        generated_funcs += '        result = '
+                        generated_funcs += '    result = '
                 else:
-                    generated_funcs += '        '
+                    generated_funcs += '    '
 
                 generated_funcs += 'dispatch_table->'
                 generated_funcs += base_name
@@ -618,7 +618,7 @@ class LoaderSourceOutputGenerator(AutomaticSourceOutputGenerator):
                 generated_funcs += func_follow_up
 
                 if has_return and not just_return_call:
-                    generated_funcs += '        return result;\n'
+                    generated_funcs += '    return result;\n'
                 if cur_cmd.is_create_connect:
                     generated_funcs += '    } catch (std::bad_alloc &) {\n'
                     generated_funcs += '        LoaderLogger::LogErrorMessage("%s", "%s trampoline failed allocating memory");\n' % (
@@ -657,26 +657,25 @@ class LoaderSourceOutputGenerator(AutomaticSourceOutputGenerator):
                     loader_override_func = False
                     if base_name == 'StructureTypeToString':
                         generated_funcs += self.outputStructTypeToString(
-                            cur_cmd, 2)
+                            cur_cmd, 1)
                         loader_override_func = True
                         just_return_call = False
                     elif base_name == 'ResultToString':
                         generated_funcs += self.outputResultToString(
-                            cur_cmd, 2)
+                            cur_cmd, 1)
                         loader_override_func = True
                         just_return_call = False
 
                     if cur_cmd.ext_name in EXTENSIONS_LOADER_IMPLEMENTS or loader_override_func:
-                        generated_funcs += '        if (nullptr != dispatch_table->%s) {\n' % base_name
-                        generated_funcs += '    '
+                        generated_funcs += '    if (nullptr != dispatch_table->%s) {\n' % base_name
 
                     if has_return:
                         if just_return_call:
-                            generated_funcs += '        return '
+                            generated_funcs += '    return '
                         else:
-                            generated_funcs += '        result = '
+                            generated_funcs += '    result = '
                     else:
-                        generated_funcs += '        '
+                        generated_funcs += '    '
 
                     generated_funcs += 'dispatch_table->'
                     generated_funcs += base_name
@@ -690,10 +689,10 @@ class LoaderSourceOutputGenerator(AutomaticSourceOutputGenerator):
                     generated_funcs += ');\n'
 
                     if cur_cmd.ext_name in EXTENSIONS_LOADER_IMPLEMENTS or loader_override_func:
-                        generated_funcs += '        }\n'
+                        generated_funcs += '    }\n'
 
                     if has_return and not just_return_call:
-                        generated_funcs += '        return result;\n'
+                        generated_funcs += '    return result;\n'
                     generated_funcs += '    } catch (...) {\n'
                     generated_funcs += '        LoaderLogger::LogErrorMessage("%s", "%s terminator encountered an unknown error");\n' % (
                         cur_cmd.name, cur_cmd.name)

--- a/src/scripts/loader_source_generator.py
+++ b/src/scripts/loader_source_generator.py
@@ -579,7 +579,6 @@ class LoaderSourceOutputGenerator(AutomaticSourceOutputGenerator):
                     generated_funcs += '#if %s\n' % cur_cmd.protect_string
 
                 generated_funcs += cur_cmd.cdecl.replace(";", " {\n")
-                generated_funcs += '    try {\n'
                 generated_funcs += tramp_variable_defines
 
                 # If this is not core, but an extension, check to make sure the extension is enabled.
@@ -619,30 +618,7 @@ class LoaderSourceOutputGenerator(AutomaticSourceOutputGenerator):
 
                 if has_return and not just_return_call:
                     generated_funcs += '    return result;\n'
-                if cur_cmd.is_create_connect:
-                    generated_funcs += '    } catch (std::bad_alloc &) {\n'
-                    generated_funcs += '        LoaderLogger::LogErrorMessage("%s", "%s trampoline failed allocating memory");\n' % (
-                        cur_cmd.name, cur_cmd.name)
-                    generated_funcs += '        return XR_ERROR_OUT_OF_MEMORY;\n'
-                    generated_funcs += '    } catch (...) {\n'
-                    generated_funcs += '        LoaderLogger::LogErrorMessage("%s", "%s trampoline encountered an unknown error");\n' % (
-                        cur_cmd.name, cur_cmd.name)
-                    generated_funcs += '        return XR_ERROR_INITIALIZATION_FAILED;\n'
-                elif cur_cmd.params[0].type == 'XrInstance':
-                    generated_funcs += '    } catch (...) {\n'
-                    generated_funcs += '        LoaderLogger::LogErrorMessage("%s", "%s trampoline encountered an unknown error.  Likely XrInstance "\n' % (
-                        cur_cmd.name, cur_cmd.name)
-                    generated_funcs += '            + HandleToHexString(%s) + " is invalid");\n' % cur_cmd.params[0].name
-                    if has_return:
-                        generated_funcs += '        return XR_ERROR_HANDLE_INVALID;\n'
-                elif has_return:
-                    generated_funcs += '    } catch (...) {\n'
-                    generated_funcs += '        LoaderLogger::LogErrorMessage("%s", "%s trampoline encountered an unknown error");\n' % (
-                        cur_cmd.name, cur_cmd.name)
-                    generated_funcs += '        // NOTE: Most calls only allow XR_SUCCESS as a return code\n'
-                    generated_funcs += '        return XR_SUCCESS;\n'
 
-                generated_funcs += '    }\n'
                 generated_funcs += '}\n\n'
 
                 # If this is a function that needs a terminator, provide the call to it, not the runtime.
@@ -652,7 +628,6 @@ class LoaderSourceOutputGenerator(AutomaticSourceOutputGenerator):
                     term_decl = cur_cmd.cdecl.replace(";", " {\n")
                     term_decl = term_decl.replace(" xr", " LoaderGenTermXr")
                     generated_funcs += term_decl
-                    generated_funcs += '    try {\n'
 
                     loader_override_func = False
                     if base_name == 'StructureTypeToString':
@@ -693,13 +668,6 @@ class LoaderSourceOutputGenerator(AutomaticSourceOutputGenerator):
 
                     if has_return and not just_return_call:
                         generated_funcs += '    return result;\n'
-                    generated_funcs += '    } catch (...) {\n'
-                    generated_funcs += '        LoaderLogger::LogErrorMessage("%s", "%s terminator encountered an unknown error");\n' % (
-                        cur_cmd.name, cur_cmd.name)
-                    if has_return:
-                        generated_funcs += '        // NOTE: Most calls only allow XR_SUCCESS as a return code\n'
-                        generated_funcs += '        return XR_SUCCESS;\n'
-                    generated_funcs += '    }\n'
                     generated_funcs += '}\n'
                 if cur_cmd.protect_value:
                     generated_funcs += '#endif // %s\n' % cur_cmd.protect_string


### PR DESCRIPTION
Try to make Loader exception free by doing the following:
1. For Exceptions are thrown and caught directly by the function that throws. These instances are changed to early return with a corresponding XrResult and logging, if any.
2. For Throws that are the result of a catch(..) with some “unknown error” or “bad alloc” logging. Remove these instances
3. Remove all catches directly.
4. Change JSON_USE_EXCEPTION to be defined as 0 so jsoncpp will not throw exception.