### PR TITLE
Remove unneeded generation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -165,8 +165,6 @@ endmacro()
 set(GENERATED_OUTPUT)
 run_xr_xml_generate(utility_source_generator.py xr_generated_dispatch_table.h)
 run_xr_xml_generate(utility_source_generator.py xr_generated_dispatch_table.c)
-run_xr_xml_generate(utility_source_generator.py xr_generated_utilities.h)
-run_xr_xml_generate(utility_source_generator.py xr_generated_utilities.c)
 add_custom_target(xr_global_generated_files DEPENDS
     ${GENERATED_DEPENDS}
 )

--- a/src/scripts/loader_source_generator.py
+++ b/src/scripts/loader_source_generator.py
@@ -75,27 +75,6 @@ EXTENSIONS_LOADER_IMPLEMENTS = [
     'XR_EXT_debug_utils'
 ]
 
-def generateErrorMessage(indent_level, vuid, cur_cmd, message, object_info):
-    lines = []
-    lines.append('LoaderLogger::LogValidationErrorMessage(')
-    lines.append('    "VUID-{}",'.format('-'.join(vuid)))
-    lines.append('    "{}",'.format(cur_cmd.name))
-    lines.append('    {},'.format(message))
-
-    object_info_constructors = ['XrLoaderLogObjectInfo{%s, %s}' % p for p in object_info]
-    if len(object_info_constructors) <= 1:
-        lines.append('    {%s});' % (', '.join(object_info_constructors)))
-    else:
-        lines.append('    {')
-        lines.append(',\n'.join('    %s' % x for x in object_info_constructors))
-        lines.append('    });')
-    if isinstance(indent_level, str):
-        base_indent = indent_level
-    else:
-        base_indent = (4 * indent_level) * ' '
-    indented_lines_with_lf = (''.join((base_indent, line, '\n')) for line in lines)
-    return ''.join(indented_lines_with_lf)
-
 
 def generateErrorMessage(indent_level, vuid, cur_cmd, message, object_info):
     lines = []

--- a/src/scripts/src_genxr.py
+++ b/src/scripts/src_genxr.py
@@ -207,38 +207,6 @@ def makeGenOpts(args):
             emitExtensions    = emitExtensionsPat)
         ]
 
-    genOpts['xr_generated_utilities.h'] = [
-          UtilitySourceOutputGenerator,
-          AutomaticSourceGeneratorOptions(
-            conventions       = conventions,
-            filename          = 'xr_generated_utilities.h',
-            directory         = directory,
-            apiname           = 'openxr',
-            profile           = None,
-            versions          = featuresPat,
-            emitversions      = featuresPat,
-            defaultExtensions = 'openxr',
-            addExtensions     = None,
-            removeExtensions  = None,
-            emitExtensions    = emitExtensionsPat)
-        ]
-
-    genOpts['xr_generated_utilities.c'] = [
-          UtilitySourceOutputGenerator,
-          AutomaticSourceGeneratorOptions(
-            conventions       = conventions,
-            filename          = 'xr_generated_utilities.c',
-            directory         = directory,
-            apiname           = 'openxr',
-            profile           = None,
-            versions          = featuresPat,
-            emitversions      = featuresPat,
-            defaultExtensions = 'openxr',
-            addExtensions     = None,
-            removeExtensions  = None,
-            emitExtensions    = emitExtensionsPat)
-        ]
-
     genOpts['xr_generated_loader.hpp'] = [
           LoaderSourceOutputGenerator,
           AutomaticSourceGeneratorOptions(


### PR DESCRIPTION
The loader shouldn't be implementing the xr*ToString functions anymore, but it was. After that was removed, I could remove the xr_generated_utilities files.

Fixes #74 

Related to internal PR 1491 and internal issue 1139.