### PR TITLE
Fix a loader bug which prevented Layers from not implementing all XR functions

### DIFF
--- a/src/scripts/api_dump_generator.py
+++ b/src/scripts/api_dump_generator.py
@@ -1189,6 +1189,9 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
         generated_commands += '        contents.emplace_back("const char*", "name", name);\n'
         generated_commands += '        contents.emplace_back("PFN_xrVoidFunction*", "function", PointerToHexString(reinterpret_cast<const void*>(function)));\n'
         generated_commands += '        ApiDumpLayerRecordContent(contents);\n'
+        
+        generated_commands += '        // Set the function pointer to NULL so that the fall-through below actually works:\n'
+        generated_commands += '        *function = nullptr;\n\n'
 
         count = 0
         for x in range(0, 2):

--- a/src/scripts/loader_source_generator.py
+++ b/src/scripts/loader_source_generator.py
@@ -859,6 +859,8 @@ class LoaderSourceOutputGenerator(AutomaticSourceOutputGenerator):
                     if count == 0:
                         export_funcs += '\n    // A few instance commands need to go through a loader terminator.\n'
                         export_funcs += '    // Otherwise, go directly to the runtime version of the command if it exists.\n'
+                        export_funcs += '    // But first set the function pointer to NULL so that the fall-through below actually works.\n'
+                        export_funcs += '    *function = nullptr;\n\n'
                         export_funcs += '    if (0 == strcmp(name, "%s")) {\n' % (
                             cur_cmd.name)
                     else:


### PR DESCRIPTION
Both the loader and the api dump layer have GetInstanceProcAddr functions
which try to match the function names with the functions they know. If it
wasn't found, the next layer will get called. However, the detection of
this situation is whether or not the function pointer is NULL, which breaks
if the input value of that pointer hasn't been NULL to begin with.

This fix adds a line to init the function pointer to NULL to fix the code.

Without this fix layers only work if they implement all OpenXR functions.