### PR TITLE
Fix Build Breaks

### DIFF
--- a/src/common/loader_interfaces.h
+++ b/src/common/loader_interfaces.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <openxr/openxr.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/common/xr_dependencies.h
+++ b/src/common/xr_dependencies.h
@@ -30,8 +30,12 @@
 #define WINAPI_PARTITION_DESKTOP 1
 #endif
 
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif  // NOMINMAX
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif  // WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
 #endif  // XR_USE_PLATFORM_WIN32

--- a/src/loader/exception_handling.hpp
+++ b/src/loader/exception_handling.hpp
@@ -18,7 +18,9 @@
 
 #pragma once
 
+#if !defined(OPENXR_NON_CMAKE_BUILD)
 #include "common_cmake_config.h"
+#endif  // !defined(OPENXR_NON_CMAKE_BUILD)
 
 #ifdef XRLOADER_ENABLE_EXCEPTION_HANDLING
 #include <stdexcept>

--- a/src/loader/manifest_file.cpp
+++ b/src/loader/manifest_file.cpp
@@ -23,7 +23,9 @@
 
 #include "manifest_file.hpp"
 
+#if !defined(OPENXR_NON_CMAKE_BUILD)
 #include "common_cmake_config.h"
+#endif  // !defined(OPENXR_NON_CMAKE_BUILD)
 #include "filesystem_utils.hpp"
 #include "loader_platform.hpp"
 #include "platform_utils.hpp"


### PR DESCRIPTION
Build warning occurs when NOMINMAX or WIN32_LEAN_AND_MEAN is already defined
If the loader files are generated without cmake, common_cmake_config.h doesn't exist so its inclusion should be wrapped around a macro. google wants headers included alphabetically and loader_interfaces.h depends on openxr.h