### PR TITLE
loader: Remove a constant static std::vector, use a std::array instead.

### DIFF
--- a/src/loader/loader_core.cpp
+++ b/src/loader/loader_core.cpp
@@ -127,8 +127,7 @@ xrEnumerateInstanceExtensionProperties(const char *layerName, uint32_t propertyC
     // If this is not in reference to a specific layer, then add the loader-specific extension properties as well.
     // These are extensions that the loader directly supports.
     if (!just_layer_properties) {
-        auto loader_extension_props = LoaderInstance::LoaderSpecificExtensions();
-        for (XrExtensionProperties &loader_prop : loader_extension_props) {
+        for (const XrExtensionProperties &loader_prop : LoaderInstance::LoaderSpecificExtensions()) {
             bool found_prop = false;
             for (XrExtensionProperties &existing_prop : extension_properties) {
                 if (0 == strcmp(existing_prop.extensionName, loader_prop.extensionName)) {

--- a/src/loader/loader_instance.cpp
+++ b/src/loader/loader_instance.cpp
@@ -42,9 +42,11 @@
 
 // Extensions that are supported by the loader, but may not be supported
 // the the runtime.
-static const XrExtensionProperties g_debug_utils_props = {XR_TYPE_EXTENSION_PROPERTIES, nullptr, XR_EXT_DEBUG_UTILS_EXTENSION_NAME,
-                                                          XR_EXT_debug_utils_SPEC_VERSION};
-const std::vector<XrExtensionProperties> LoaderInstance::_loader_supported_extensions = {g_debug_utils_props};
+const std::array<XrExtensionProperties, 1>& LoaderInstance::LoaderSpecificExtensions() {
+    static const std::array<XrExtensionProperties, 1> extensions = {XrExtensionProperties{
+        XR_TYPE_EXTENSION_PROPERTIES, nullptr, XR_EXT_DEBUG_UTILS_EXTENSION_NAME, XR_EXT_debug_utils_SPEC_VERSION}};
+    return extensions;
+}
 
 // Factory method
 XrResult LoaderInstance::CreateInstance(std::vector<std::unique_ptr<ApiLayerInterface>>&& api_layer_interfaces,
@@ -126,7 +128,7 @@ XrResult LoaderInstance::CreateInstance(std::vector<std::unique_ptr<ApiLayerInte
             }
             // Next check the loader
             if (!found) {
-                for (auto loader_extension : LoaderInstance::_loader_supported_extensions) {
+                for (auto& loader_extension : LoaderInstance::LoaderSpecificExtensions()) {
                     if (strcmp(loader_extension.extensionName, info->enabledExtensionNames[ext]) == 0) {
                         found = true;
                         break;

--- a/src/loader/loader_instance.hpp
+++ b/src/loader/loader_instance.hpp
@@ -23,6 +23,7 @@
 
 #include <openxr/openxr.h>
 
+#include <array>
 #include <cmath>
 #include <memory>
 #include <mutex>
@@ -80,7 +81,7 @@ class LoaderInstance {
     std::vector<std::unique_ptr<ApiLayerInterface>>& LayerInterfaces() { return _api_layer_interfaces; }
     void AddEnabledExtension(const std::string& extension) { return _enabled_extensions.push_back(extension); }
     bool ExtensionIsEnabled(const std::string& extension);
-    static const std::vector<XrExtensionProperties>& LoaderSpecificExtensions() { return _loader_supported_extensions; }
+    static const std::array<XrExtensionProperties, 1>& LoaderSpecificExtensions();
     XrDebugUtilsMessengerEXT DefaultDebugUtilsMessenger() { return _messenger; }
     void SetDefaultDebugUtilsMessenger(XrDebugUtilsMessengerEXT messenger) { _messenger = messenger; }
 
@@ -91,7 +92,6 @@ class LoaderInstance {
     XrInstance _runtime_instance;
     bool _dispatch_valid;
     std::unique_ptr<XrGeneratedDispatchTable> _dispatch_table;
-    static const std::vector<XrExtensionProperties> _loader_supported_extensions;
     std::vector<std::string> _enabled_extensions;
     // Internal debug messenger created during xrCreateInstance
     XrDebugUtilsMessengerEXT _messenger;


### PR DESCRIPTION
Consumer code also modified slightly to both a: work and b: avoid vector copies.

Previously, was getting warnings at build time that the std::vector constructor could throw exceptions it was impossible to catch (because of static lifetime)

cc @zheqiMicrosoft 