### PR TITLE
Export only core symbols

### DIFF
--- a/include/openxr/openxr_platform_defines.h
+++ b/include/openxr/openxr_platform_defines.h
@@ -36,11 +36,7 @@ extern "C" {
  * Function pointer type: typedef void (XRAPI_PTR *PFN_xrFunction)(void);
  */
 #if defined(_WIN32)
-#ifdef XRAPI_DLL_EXPORT
-#define XRAPI_ATTR __declspec(dllexport)
-#else
 #define XRAPI_ATTR
-#endif
 // On Windows, functions use the stdcall convention
 #define XRAPI_CALL __stdcall
 #define XRAPI_PTR XRAPI_CALL

--- a/src/loader/CMakeLists.txt
+++ b/src/loader/CMakeLists.txt
@@ -37,6 +37,11 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     set(LOADER_NAME ${LOADER_NAME}-${MAJOR}_${MINOR})
 endif()
 
+if(NOT MSVC)
+    set(CMAKE_C_VISIBILITY_PRESET hidden)
+    set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+endif()
+
 # List of all files externally generated outside of the loader that the loader
 # needs to build with.
 SET(LOADER_EXTERNAL_GEN_FILES
@@ -168,6 +173,7 @@ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
     target_compile_options(openxr_loader
         PRIVATE -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers -Wpointer-arith
         PRIVATE -fno-strict-aliasing -fno-builtin-memcmp "$<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>"
+        -ffunction-sections -fdata-sections
     )
     # For GCC version 7.1 or greater, we need to disable the implicit fallthrough warning since
     # there's no consistent way to satisfy all compilers until they all accept the C++17 standard

--- a/src/loader/loader_platform.hpp
+++ b/src/loader/loader_platform.hpp
@@ -31,6 +31,8 @@
 #define LOADER_EXPORT __attribute__((visibility("default")))
 #elif defined(__SUNPRO_C) && (__SUNPRO_C >= 0x590)
 #define LOADER_EXPORT __attribute__((visibility("default")))
+#elif defined(_WIN32) && defined(XRAPI_DLL_EXPORT)
+#define LOADER_EXPORT __declspec(dllexport)
 #else
 #define LOADER_EXPORT
 #endif

--- a/src/scripts/loader_source_generator.py
+++ b/src/scripts/loader_source_generator.py
@@ -126,6 +126,7 @@ class LoaderSourceOutputGenerator(AutomaticSourceOutputGenerator):
             preamble += '#include "openxr/openxr_platform.h"\n\n'
             preamble += '#include "loader_interfaces.h"\n\n'
             preamble += '#include "loader_instance.hpp"\n\n'
+            preamble += '#include "loader_platform.hpp"\n\n'
 
         elif self.genOpts.filename == 'xr_generated_loader.cpp':
             preamble += '#include "xr_generated_loader.hpp"\n\n'
@@ -213,6 +214,11 @@ class LoaderSourceOutputGenerator(AutomaticSourceOutputGenerator):
 
                     # Use the Cdecl directly from the XML
                     func_proto = cur_cmd.cdecl
+
+                    # Export only core functions
+                    if self.isCoreExtensionName(cur_cmd.ext_name):
+                        func_proto = func_proto.replace(
+                            "XRAPI_ATTR", "LOADER_EXPORT XRAPI_ATTR")
 
                     # Output the standard API form of the command
                     manual_funcs += func_proto
@@ -493,8 +499,14 @@ class LoaderSourceOutputGenerator(AutomaticSourceOutputGenerator):
 
                 if cur_cmd.protect_value:
                     generated_funcs += '#if %s\n' % cur_cmd.protect_string
+                decl = cur_cmd.cdecl.replace(";", " XRLOADER_ABI_TRY {\n")
 
-                generated_funcs += cur_cmd.cdecl.replace(";", " XRLOADER_ABI_TRY {\n")
+                # Export only core functions
+                if self.isCoreExtensionName(cur_cmd.ext_name):
+                    decl = decl.replace(
+                        "XRAPI_ATTR", "LOADER_EXPORT XRAPI_ATTR")
+
+                generated_funcs += decl
                 generated_funcs += tramp_variable_defines
 
                 # If this is not core, but an extension, check to make sure the extension is enabled.

--- a/src/tests/hello_xr/graphicsplugin_d3d11.cpp
+++ b/src/tests/hello_xr/graphicsplugin_d3d11.cpp
@@ -127,9 +127,13 @@ struct D3D11GraphicsPlugin : public IGraphicsPlugin {
     std::vector<std::string> GetInstanceExtensions() const override { return {XR_KHR_D3D11_ENABLE_EXTENSION_NAME}; }
 
     void InitializeDevice(XrInstance instance, XrSystemId systemId) override {
+        PFN_xrGetD3D11GraphicsRequirementsKHR pfnGetD3D11GraphicsRequirementsKHR = nullptr;
+        CHECK_XRCMD(xrGetInstanceProcAddr(instance, "xrGetD3D11GraphicsRequirementsKHR",
+                                          reinterpret_cast<PFN_xrVoidFunction*>(&pfnGetD3D11GraphicsRequirementsKHR)));
+
         // Create the D3D11 device for the adapter associated with the system.
         XrGraphicsRequirementsD3D11KHR graphicsRequirements{XR_TYPE_GRAPHICS_REQUIREMENTS_D3D11_KHR};
-        CHECK_XRCMD(xrGetD3D11GraphicsRequirementsKHR(instance, systemId, &graphicsRequirements));
+        CHECK_XRCMD(pfnGetD3D11GraphicsRequirementsKHR(instance, systemId, &graphicsRequirements));
         const ComPtr<IDXGIAdapter1> adapter = GetAdapter(graphicsRequirements.adapterLuid);
 
         // Create a list of feature levels which are both supported by the OpenXR runtime and this application.

--- a/src/tests/hello_xr/graphicsplugin_opengl.cpp
+++ b/src/tests/hello_xr/graphicsplugin_opengl.cpp
@@ -78,8 +78,13 @@ struct OpenGLGraphicsPlugin : public IGraphicsPlugin {
     }
 
     void InitializeDevice(XrInstance instance, XrSystemId systemId) override {
+        // Extension function must be loaded by name
+        PFN_xrGetOpenGLGraphicsRequirementsKHR pfnGetOpenGLGraphicsRequirementsKHR = nullptr;
+        CHECK_XRCMD(xrGetInstanceProcAddr(instance, "xrGetOpenGLGraphicsRequirementsKHR",
+                                          reinterpret_cast<PFN_xrVoidFunction*>(&pfnGetOpenGLGraphicsRequirementsKHR)));
+
         XrGraphicsRequirementsOpenGLKHR graphicsRequirements{XR_TYPE_GRAPHICS_REQUIREMENTS_OPENGL_KHR};
-        CHECK_XRCMD(xrGetOpenGLGraphicsRequirementsKHR(instance, systemId, &graphicsRequirements));
+        CHECK_XRCMD(pfnGetOpenGLGraphicsRequirementsKHR(instance, systemId, &graphicsRequirements));
 
         // Initialize the gl extensions. Note we have to open a window.
         ksDriverInstance driverInstance{};


### PR DESCRIPTION
This adjusts the loader, on all platforms, to only export core functions, which is what I think we say in the docs we do. (aside from static linking, possibly only on windows, not sure)

This did require some changes to hello_xr, but I think only in accordance with the spec.

Not sure if we wanted to mark some of the graphics binding functions as exported too.

The other thing I did was "fix" the XRAPI_ATTR on Windows: it had gotten a declspec(dllexport) at some point, which I didn't find anywhere in Vulkan and I think was a mis-use of that attribute. We already had LOADER_EXPORT, it was just being inconsistently used and configured.

Have only tried this on Linux.

Fixes #45
