### PR TITLE
Export All API symbols

### DIFF
--- a/include/openxr/openxr_platform_defines.h
+++ b/include/openxr/openxr_platform_defines.h
@@ -36,11 +36,7 @@ extern "C" {
  * Function pointer type: typedef void (XRAPI_PTR *PFN_xrFunction)(void);
  */
 #if defined(_WIN32)
-#ifdef XRAPI_DLL_EXPORT
-#define XRAPI_ATTR __declspec(dllexport)
-#else
 #define XRAPI_ATTR
-#endif
 // On Windows, functions use the stdcall convention
 #define XRAPI_CALL __stdcall
 #define XRAPI_PTR XRAPI_CALL

--- a/specification/loader/application.adoc
+++ b/specification/loader/application.adoc
@@ -1,8 +1,8 @@
 [[application-interaction]]
 == Application Interaction ==
 
-An application requests a specific version of the OpenXR API when creating an 
-instance by writing to the "apiVersion" member of the `XrApplicationInfo` 
+An application requests a specific version of the OpenXR API when creating an
+instance by writing to the "apiVersion" member of the `XrApplicationInfo`
 structure which, in turn, is passed into the `XrInstanceCreateInfo` structure.
 If either the loader or the active runtime do not support the requested version,
 they may return an error and fail instance creation.  Refer to the
@@ -14,80 +14,19 @@ for more information about this.
 There are two ways an application can choose interface with OpenXR functions
 through the loader:
 
-1. Directly linking to the core OpenXR commands exposed and exported by the loader.
+1. Directly linking to the OpenXR commands exposed and exported by the loader.
 2. Creating an application-managed dispatch table of OpenXR commands by querying
-the loader for function pointers via `xrGetInstanceProcAddr`. This method 
-supports core OpenXR commands, commands of (enabled) OpenXR extensions supported by the runtime, 
-and any commands exposed by enabled API layers.
+the loader for function pointers via `xrGetInstanceProcAddr`.
 
 [[openxr-direct-exports]]
 ==== OpenXR Direct Exports ====
 
-The loader library on Windows and Linux will directly export all core OpenXR
-commands for the OpenXR version it supports. When an application links directly
+The loader library on Windows and Linux directly exports all OpenXR
+commands for the OpenXR version and platform it supports.
+When an application links directly
 to the loader library in this way, the OpenXR calls are simple _trampoline_
 functions that jump to the appropriate dispatch table entry for the object
 provided.
-
-The specific list, in alphabetical order, of OpenXR commands directly exported by the loader for API
-version 1.0 are:
-
-
-- `xrAcquireSwapchainImage`
-- `xrApplyHapticFeedback`
-- `xrAttachSessionActionSets`
-- `xrBeginFrame`
-- `xrBeginSession`
-- `xrCreateAction`
-- `xrCreateActionSet`
-- `xrCreateActionSpace`
-- `xrCreateInstance`
-- `xrCreateReferenceSpace`
-- `xrCreateSession`
-- `xrCreateSwapchain`
-- `xrDestroyAction`
-- `xrDestroyActionSet`
-- `xrDestroyInstance`
-- `xrDestroySession`
-- `xrDestroySpace`
-- `xrDestroySwapchain`
-- `xrEndFrame`
-- `xrEndSession`
-- `xrEnumerateApiLayerProperties`
-- `xrEnumerateBoundSourcesForAction`
-- `xrEnumerateEnvironmentBlendModes`
-- `xrEnumerateInstanceExtensionProperties`
-- `xrEnumerateReferenceSpaces`
-- `xrEnumerateSwapchainFormats`
-- `xrEnumerateSwapchainImages`
-- `xrEnumerateViewConfigurations`
-- `xrEnumerateViewConfigurationViews`
-- `xrGetActionStateBoolean`
-- `xrGetActionStateFloat`
-- `xrGetActionStatePose`
-- `xrGetActionStateVector2f`
-- `xrGetCurrentInteractionProfile`
-- `xrGetInputSourceLocalizedName`
-- `xrGetInstanceProcAddr`
-- `xrGetInstanceProperties`
-- `xrGetReferenceSpaceBoundsRect`
-- `xrGetSystem`
-- `xrGetSystemProperties`
-- `xrGetViewConfigurationProperties`
-- `xrLocateSpace`
-- `xrLocateViews`
-- `xrPathToString`
-- `xrPollEvent`
-- `xrReleaseSwapchainImage`
-- `xrRequestExitSession`
-- `xrResultToString`
-- `xrStopHapticFeedback`
-- `xrStringToPath`
-- `xrStructureTypeToString`
-- `xrSuggestInteractionProfileBindings`
-- `xrSyncActions`
-- `xrWaitFrame`
-- `xrWaitSwapchainImage`
 
 When an OpenXR application chooses to use one of the exports directly exposed
 from the OpenXR loader, the call chain will look like one of the following (if
@@ -110,7 +49,7 @@ With loader indirect linking an application dynamically generates its own
 dispatch table of OpenXR commands.  This method allows an application to
 fail gracefully if the loader cannot be found, or supports an older version
 of the API than the application. To do this, the application uses the
-appropriate platform specific dynamic symbol lookup (such as dlsym()) on the
+appropriate platform specific dynamic symbol lookup (such as `dlsym()`) on the
 loader library to discover the address of the `xrGetInstanceProcAddr` command.
 Once discovered, this command can be used to query the addresses of all other
 OpenXR commands (such as `xrCreateInstance`,

--- a/src/loader/CMakeLists.txt
+++ b/src/loader/CMakeLists.txt
@@ -37,6 +37,11 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     set(LOADER_NAME ${LOADER_NAME}-${MAJOR}_${MINOR})
 endif()
 
+if(NOT MSVC)
+    set(CMAKE_C_VISIBILITY_PRESET hidden)
+    set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+endif()
+
 # List of all files externally generated outside of the loader that the loader
 # needs to build with.
 SET(LOADER_EXTERNAL_GEN_FILES

--- a/src/loader/loader_platform.hpp
+++ b/src/loader/loader_platform.hpp
@@ -31,6 +31,8 @@
 #define LOADER_EXPORT __attribute__((visibility("default")))
 #elif defined(__SUNPRO_C) && (__SUNPRO_C >= 0x590)
 #define LOADER_EXPORT __attribute__((visibility("default")))
+#elif defined(_WIN32) && defined(XRAPI_DLL_EXPORT)
+#define LOADER_EXPORT __declspec(dllexport)
 #else
 #define LOADER_EXPORT
 #endif


### PR DESCRIPTION
Alternate to #98 suggested by @brycehutchings - this just treats "only export core" as a documentation bug. Keeps essentially the same behavior as right now, just fixes some bugs related to exporting. (and cuts the exports of internal symbols)

Fixes #45 