### PR TITLE
Default catch

### DIFF
--- a/specification/loader/source.adoc
+++ b/specification/loader/source.adoc
@@ -67,17 +67,6 @@ generate the header yourself (preferred), or supply equivalent definitions:
 * Define `HAVE_SECURE_GETENV` on systems where `secure_getenv` is available.
 * Define `HAVE_{dunder}SECURE_GETENV` on systems where
   `{dunder}secure_getenv` is available.
-* Define `XRLOADER_ENABLE_EXCEPTION_HANDLING` to enable `try`/`catch` in the
-  loader to handle any library-thrown exceptions.
-  This is *required* to avoid exceptions escaping the C ABI presented by the
-  loader.
-  The only two reasons you may wish to _not_ define this are:
-** Due to a project policy, you're using a custom standard-library build
-   that has exception throwing disabled.
-   (The loader itself does not throw any exceptions but it uses standard
-   library functionality that may throw.)
-** You're developing or debugging the loader and want exceptions to go
-   uncaught to trigger a debugger.
 
 ====
 

--- a/specification/loader/source.adoc
+++ b/specification/loader/source.adoc
@@ -155,9 +155,26 @@ std::experimental::filesystem::path search_path;
 
 .Exceptions
 
-The OpenXR loader relies on throwing and catching pass:[C++] exceptions.  Adding code
-should take this into account and properly wrap executing code with a "try"/"catch"
-block.
+The OpenXR loader itself does not internally throw pass:[C++] exceptions,
+for compatibility with environments where exceptions are forbidden.
+However, since it exposes a C ABI, and the standard library facilities used
+may throw exceptions, functions exposed to the ABI (those with names matching OpenXR functions)
+must: have `XRLOADER_ABI_TRY` before the opening `{` of the function body
+and `XRLOADER_ABI_CATCH_FALLBACK` after the closing `}` of the function body.
+(This is done automatically for those functions whose trampoline is entirely generated.)
+In normal cases, these two macros are defined by `exception_handling.hpp` to expand to `try`
+and a full `catch` clause, respectively. This prevents any exceptions from escaping,
+in what's known as a "function-try-block".
+
+In very limited cases, you may choose to disable exception handling through the provided CMake option
+or by defining `XRLOADER_DISABLE_EXCEPTION_HANDLING`.
+The only two reasons you may define this are:
+
+* Due to a platform or project policy, you're using a custom standard-library build
+  that has exception throwing disabled.
+
+* You're developing or debugging the loader and want exceptions to go
+  uncaught to trigger a debugger.
 
 
 .Experimental Filesystem Usage

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -91,9 +91,9 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     add_definitions(-DXR_USE_GRAPHICS_API_D3D12)
 endif()
 
-if(BUILD_LOADER_WITH_EXCEPTION_HANDLING)
+if(NOT BUILD_LOADER_WITH_EXCEPTION_HANDLING)
     # This variable is configured into common_config.h
-    set(XRLOADER_ENABLE_EXCEPTION_HANDLING TRUE)
+    set(XRLOADER_DISABLE_EXCEPTION_HANDLING TRUE)
 endif()
 # Check for the existence of the secure_getenv or __secure_getenv commands
 include(CheckFunctionExists)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -91,10 +91,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     add_definitions(-DXR_USE_GRAPHICS_API_D3D12)
 endif()
 
-if(NOT BUILD_LOADER_WITH_EXCEPTION_HANDLING)
-    # This variable is configured into common_config.h
-    set(XRLOADER_DISABLE_EXCEPTION_HANDLING TRUE)
-endif()
 # Check for the existence of the secure_getenv or __secure_getenv commands
 include(CheckFunctionExists)
 

--- a/src/common/platform_utils.hpp
+++ b/src/common/platform_utils.hpp
@@ -32,9 +32,7 @@
 // that it found present and build-time configuration.
 // If you don't have this file, on non-Windows you'll need to define
 // one of HAVE_SECURE_GETENV or HAVE___SECURE_GETENV depending on which
-// of secure_getenv or __secure_getenv are present, as well as defining
-// XRLOADER_ENABLE_EXCEPTION_HANDLING if your standard library can throw exceptions
-// (which most can)
+// of secure_getenv or __secure_getenv are present
 #ifdef OPENXR_HAVE_COMMON_CONFIG
 #include "common_config.h"
 #endif  // OPENXR_HAVE_COMMON_CONFIG

--- a/src/common_config.h.in
+++ b/src/common_config.h.in
@@ -24,9 +24,8 @@
 // If you can't provide the .h version of this file (because you're not using the
 // provided CMake build system and not providing it yourself), you need to do the following:
 //
-// - Define XRLOADER_ENABLE_EXCEPTION_HANDLING if your
-//   standard library can throw exceptions
-//   (most can - it's non-standard for them to not do so.)
+// - Define XRLOADER_DISABLE_EXCEPTION_HANDLING if the loader should **not** catch exceptions:
+//   This should almost never be done.
 // - On non-Windows, for security purposes, define one of
 //   `HAVE_SECURE_GETENV` or `HAVE___SECURE_GETENV` depending on which
 //   of secure_getenv or __secure_getenv are present, respectively
@@ -38,6 +37,6 @@
 // If defined, __secure_getenv is available
 #cmakedefine HAVE___SECURE_GETENV
 
-// If defined, the OpenXR loader will catch any standard-library exceptions.
-// Must be defined unless you're using a non-standard standard library build with exceptions disabled.
-#cmakedefine XRLOADER_ENABLE_EXCEPTION_HANDLING
+// If defined, the OpenXR loader will **not** catch any standard-library exceptions.
+// Must not be defined unless you're using a non-standard standard library build with exceptions disabled.
+#cmakedefine XRLOADER_DISABLE_EXCEPTION_HANDLING

--- a/src/common_config.h.in
+++ b/src/common_config.h.in
@@ -24,8 +24,6 @@
 // If you can't provide the .h version of this file (because you're not using the
 // provided CMake build system and not providing it yourself), you need to do the following:
 //
-// - Define XRLOADER_DISABLE_EXCEPTION_HANDLING if the loader should **not** catch exceptions:
-//   This should almost never be done.
 // - On non-Windows, for security purposes, define one of
 //   `HAVE_SECURE_GETENV` or `HAVE___SECURE_GETENV` depending on which
 //   of secure_getenv or __secure_getenv are present, respectively
@@ -36,7 +34,3 @@
 
 // If defined, __secure_getenv is available
 #cmakedefine HAVE___SECURE_GETENV
-
-// If defined, the OpenXR loader will **not** catch any standard-library exceptions.
-// Must not be defined unless you're using a non-standard standard library build with exceptions disabled.
-#cmakedefine XRLOADER_DISABLE_EXCEPTION_HANDLING

--- a/src/loader/CMakeLists.txt
+++ b/src/loader/CMakeLists.txt
@@ -100,6 +100,11 @@ if(VulkanHeaders_FOUND)
         PRIVATE ${Vulkan_INCLUDE_DIRS}
     )
 endif()
+if(NOT BUILD_LOADER_WITH_EXCEPTION_HANDLING)
+    target_compile_definitions(${LOADER_NAME}
+        PRIVATE XRLOADER_DISABLE_EXCEPTION_HANDLING
+    )
+endif()
 
 target_compile_definitions(${LOADER_NAME}
     PRIVATE API_NAME="OpenXR"

--- a/src/loader/exception_handling.hpp
+++ b/src/loader/exception_handling.hpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Author: Ryan Pavlik <ryan.pavlik@collabora.com
+// Author: Ryan Pavlik <ryan.pavlik@collabora.com>
 //
 // Provides protection for C ABI functions if standard library functions may throw.
 
@@ -22,7 +22,14 @@
 #include "common_config.h"
 #endif  // OPENXR_HAVE_COMMON_CONFIG
 
-#ifdef XRLOADER_ENABLE_EXCEPTION_HANDLING
+#ifdef XRLOADER_DISABLE_EXCEPTION_HANDLING
+
+#define XRLOADER_ABI_TRY
+#define XRLOADER_ABI_CATCH_BAD_ALLOC_OOM
+#define XRLOADER_ABI_CATCH_FALLBACK
+
+#else
+
 #include <stdexcept>
 #define XRLOADER_ABI_TRY try
 #define XRLOADER_ABI_CATCH_BAD_ALLOC_OOM                               \
@@ -40,15 +47,4 @@
         return XR_ERROR_RUNTIME_FAILURE;                                                \
     }
 
-#else
-
-// Make it hard to accidentally build this wrong.
-#ifndef XRLOADER_SILENCE_EXCEPTION_HANDLING_WARNING
-#warning \
-    "Warning: Exception handling disabled in OpenXR loader - exceptions may escape C ABI if standard library can throw exceptions!"
-#endif
-
-#define XRLOADER_ABI_TRY
-#define XRLOADER_ABI_CATCH_BAD_ALLOC_OOM
-#define XRLOADER_ABI_CATCH_FALLBACK
 #endif

--- a/src/loader/manifest_file.cpp
+++ b/src/loader/manifest_file.cpp
@@ -62,12 +62,12 @@
 #define OPENXR_RUNTIME_JSON_ENV_VAR "XR_RUNTIME_JSON"
 #define OPENXR_API_LAYER_PATH_ENV_VAR "XR_API_LAYER_PATH"
 
-#ifndef XRLOADER_ENABLE_EXCEPTION_HANDLING
+#ifdef XRLOADER_DISABLE_EXCEPTION_HANDLING
 #if JSON_USE_EXCEPTIONS
 #error \
     "Loader is configured to not catch exceptions, but jsoncpp was built with exception-throwing enabled, which could violate the C ABI. One of those two things needs to change."
 #endif  // JSON_USE_EXCEPTIONS
-#endif  // !XRLOADER_ENABLE_EXCEPTION_HANDLING
+#endif  // !XRLOADER_DISABLE_EXCEPTION_HANDLING
 
 // Utility functions for finding files in the appropriate paths
 


### PR DESCRIPTION
Fixes #94  - makes it so that building with no compiler defines works and catches exceptions.

Also updates the docs accordingly