### PR TITLE
Migrate validation debug utils

### DIFF
--- a/src/api_layers/CMakeLists.txt
+++ b/src/api_layers/CMakeLists.txt
@@ -89,6 +89,8 @@ add_library(XrApiLayer_core_validation SHARED
     core_validation.cpp
     ${CMAKE_SOURCE_DIR}/src/common/hex_and_handles.cpp
     ${CMAKE_SOURCE_DIR}/src/common/hex_and_handles.h
+    ${CMAKE_SOURCE_DIR}/src/common/object_info.cpp
+    ${CMAKE_SOURCE_DIR}/src/common/object_info.h
     ${CMAKE_BINARY_DIR}/src/xr_generated_dispatch_table.c 
     ${CMAKE_CURRENT_BINARY_DIR}/xr_generated_core_validation.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/xr_generated_core_validation.hpp

--- a/src/api_layers/core_validation.cpp
+++ b/src/api_layers/core_validation.cpp
@@ -260,7 +260,7 @@ void CoreValidLogMessage(GenValidUsageXrInstanceInfo *instance_info, const std::
                 names_and_labels.PopulateCallbackData(callback_data);
 
                 // Loop through all active messengers and give each a chance to output information
-                for (auto &debug_messenger : instance_info->debug_messengers) {
+                for (const auto &debug_messenger : instance_info->debug_messengers) {
                     CoreValidationMessengerInfo *validation_messenger_info = debug_messenger.get();
                     XrDebugUtilsMessengerCreateInfoEXT *messenger_create_info = validation_messenger_info->create_info;
                     // If a callback exists, and the message is of a type this callback cares about, call it.
@@ -282,7 +282,7 @@ void CoreValidLogMessage(GenValidUsageXrInstanceInfo *instance_info, const std::
                 if (!objects_info.empty()) {
                     std::cout << "  Objects:" << std::endl;
                     uint32_t count = 0;
-                    for (auto object_info : objects_info) {
+                    for (const auto &object_info : objects_info) {
                         std::string object_type = GenValidUsageXrObjectTypeToString(object_info.type);
                         std::ostringstream oss_object_handle;
                         std::cout << "   [" << std::to_string(count++) << "] - " << object_type << " ("
@@ -308,7 +308,7 @@ void CoreValidLogMessage(GenValidUsageXrInstanceInfo *instance_info, const std::
                 if (!objects_info.empty()) {
                     text_file << "  Objects:" << std::endl;
                     uint32_t count = 0;
-                    for (auto object_info : objects_info) {
+                    for (const auto &object_info : objects_info) {
                         std::string object_type = GenValidUsageXrObjectTypeToString(object_info.type);
                         text_file << "   [" << std::to_string(count++) << "] - " << object_type << " ("
                                   << Uint64ToHexString(object_info.handle) << ")";
@@ -364,7 +364,7 @@ void CoreValidLogMessage(GenValidUsageXrInstanceInfo *instance_info, const std::
                     text_file << "            <div class='type'>Relevant OpenXR Objects</div>\n";
                     text_file << "         </summary>\n";
                     uint32_t count = 0;
-                    for (auto object_info : objects_info) {
+                    for (const auto &object_info : objects_info) {
                         std::string object_type = GenValidUsageXrObjectTypeToString(object_info.type);
                         text_file << "         <div class='data'>\n";
                         text_file << "             <div class='var'>[" << count++ << "]</div>\n";

--- a/src/api_layers/core_validation.cpp
+++ b/src/api_layers/core_validation.cpp
@@ -474,8 +474,8 @@ XrResult CoreValidationXrCreateApiLayerInstance(const XrInstanceCreateInfo *info
             std::transform(string_export_type.begin(), string_export_type.end(), string_export_type.begin(),
                            [](unsigned char c) { return std::tolower(c); });
 
-            std::cerr << "Core Validation output type: " << string_export_type << ", first time = " << std::to_string(first_time)
-                      << std::endl;
+            std::cerr << "Core Validation output type: " << string_export_type
+                      << ", first time = " << (first_time ? "true" : "false") << std::endl;
             if (string_export_type == "text") {
                 if (!g_record_info.file_name.empty()) {
                     g_record_info.type = RECORD_TEXT_FILE;

--- a/src/api_layers/core_validation.cpp
+++ b/src/api_layers/core_validation.cpp
@@ -715,11 +715,13 @@ XrResult CoreValidationXrDestroyDebugUtilsMessengerEXT(XrDebugUtilsMessengerEXT 
             return XR_ERROR_HANDLE_INVALID;
         }
         auto info_with_lock = g_debugutilsmessengerext_info.getWithLock(messenger);
-        GenValidUsageXrHandleInfo *gen_handle_info = info_with_lock.second;
-        if (nullptr != gen_handle_info) {
-            auto &debug_messengers = gen_handle_info->instance_info->debug_messengers;
-            vector_remove_if_and_erase(debug_messengers,
-                                       [=](UniqueCoreValidationMessengerInfo const &msg) { return msg->messenger == messenger; });
+        if (info_with_lock.second != nullptr) {
+            GenValidUsageXrHandleInfo *gen_handle_info = info_with_lock.second;
+            if (nullptr != gen_handle_info) {
+                auto &debug_messengers = gen_handle_info->instance_info->debug_messengers;
+                vector_remove_if_and_erase(
+                    debug_messengers, [=](UniqueCoreValidationMessengerInfo const &msg) { return msg->messenger == messenger; });
+            }
         }
         return result;
     } catch (...) {
@@ -733,9 +735,11 @@ XrResult CoreValidationXrSessionBeginDebugUtilsLabelRegionEXT(XrSession session,
         return test_result;
     }
     auto info_with_lock = g_session_info.getWithLock(session);
-    GenValidUsageXrInstanceInfo *gen_instance_info = info_with_lock.second->instance_info;
-    if (nullptr != gen_instance_info) {
-        gen_instance_info->debug_data.BeginLabelRegion(session, *labelInfo);
+    if (info_with_lock.second != nullptr) {
+        GenValidUsageXrInstanceInfo *gen_instance_info = info_with_lock.second->instance_info;
+        if (nullptr != gen_instance_info) {
+            gen_instance_info->debug_data.BeginLabelRegion(session, *labelInfo);
+        }
     }
     return GenValidUsageNextXrSessionBeginDebugUtilsLabelRegionEXT(session, labelInfo);
 }
@@ -746,9 +750,11 @@ XrResult CoreValidationXrSessionEndDebugUtilsLabelRegionEXT(XrSession session) {
         return test_result;
     }
     auto info_with_lock = g_session_info.getWithLock(session);
-    GenValidUsageXrInstanceInfo *gen_instance_info = info_with_lock.second->instance_info;
-    if (nullptr != gen_instance_info) {
-        gen_instance_info->debug_data.EndLabelRegion(session);
+    if (info_with_lock.second != nullptr) {
+        GenValidUsageXrInstanceInfo *gen_instance_info = info_with_lock.second->instance_info;
+        if (nullptr != gen_instance_info) {
+            gen_instance_info->debug_data.EndLabelRegion(session);
+        }
     }
     return GenValidUsageNextXrSessionEndDebugUtilsLabelRegionEXT(session);
 }
@@ -759,9 +765,11 @@ XrResult CoreValidationXrSessionInsertDebugUtilsLabelEXT(XrSession session, cons
         return test_result;
     }
     auto info_with_lock = g_session_info.getWithLock(session);
-    GenValidUsageXrInstanceInfo *gen_instance_info = info_with_lock.second->instance_info;
-    if (nullptr != gen_instance_info) {
-        gen_instance_info->debug_data.InsertLabel(session, *labelInfo);
+    if (info_with_lock.second != nullptr) {
+        GenValidUsageXrInstanceInfo *gen_instance_info = info_with_lock.second->instance_info;
+        if (nullptr != gen_instance_info) {
+            gen_instance_info->debug_data.InsertLabel(session, *labelInfo);
+        }
     }
     return GenValidUsageNextXrSessionInsertDebugUtilsLabelEXT(session, labelInfo);
 }

--- a/src/api_layers/validation_utils.h
+++ b/src/api_layers/validation_utils.h
@@ -25,6 +25,7 @@
 #include "api_layer_platform_defines.h"
 #include "hex_and_handles.h"
 #include "extra_algorithms.h"
+#include "object_info.h"
 
 #include <openxr/openxr.h>
 #include <openxr/openxr_platform.h>
@@ -79,7 +80,7 @@ struct GenValidUsageXrInstanceInfo {
     XrGeneratedDispatchTable *dispatch_table;
     std::vector<std::string> enabled_extensions;
     std::vector<UniqueCoreValidationMessengerInfo> debug_messengers;
-    std::vector<UniqueXrDebugUtilsObjectNameInfoEXT> object_names;
+    DebugUtilsData debug_data;
 };
 
 // Structure used for storing information for other handles

--- a/src/common/object_info.cpp
+++ b/src/common/object_info.cpp
@@ -1,0 +1,281 @@
+// Copyright (c) 2017-2019 The Khronos Group Inc.
+// Copyright (c) 2017-2019 Valve Corporation
+// Copyright (c) 2017-2019 LunarG, Inc.
+// Copyright (c) 2019 Collabora, Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: Mark Young <marky@lunarg.com>, Ryan Pavlik <ryan.pavlik@collabora.com>
+//
+
+#include "object_info.h"
+
+#include "extra_algorithms.h"
+#include "hex_and_handles.h"
+
+#include <openxr/openxr.h>
+
+#include <algorithm>
+#include <iterator>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+std::string XrSdkLogObjectInfo::ToString() const {
+    std::ostringstream oss;
+    oss << Uint64ToHexString(handle);
+    if (!name.empty()) {
+        oss << " (" << name << ")";
+    }
+    return oss.str();
+}
+
+void ObjectInfoCollection::AddObjectName(uint64_t object_handle, XrObjectType object_type, const std::string& object_name) {
+    // If name is empty, we should erase it
+    if (object_name.empty()) {
+        RemoveObject(object_handle, object_type);
+        return;
+    }
+
+    // Otherwise, add it or update the name
+    XrSdkLogObjectInfo new_obj = {object_handle, object_type};
+
+    // If it already exists, update the name
+    auto lookup_info = LookUpStoredObjectInfo(new_obj);
+    if (lookup_info != nullptr) {
+        lookup_info->name = object_name;
+        return;
+    }
+
+    // It doesn't exist, so add a new info block
+    new_obj.name = object_name;
+    object_info_.push_back(new_obj);
+}
+
+void ObjectInfoCollection::RemoveObject(uint64_t object_handle, XrObjectType object_type) {
+    vector_remove_if_and_erase(
+        object_info_, [=](XrSdkLogObjectInfo const& info) { return info.handle == object_handle && info.type == object_type; });
+}
+
+XrSdkLogObjectInfo const* ObjectInfoCollection::LookUpStoredObjectInfo(XrSdkLogObjectInfo const& info) const {
+    auto e = object_info_.end();
+    auto it = std::find_if(object_info_.begin(), e, [&](XrSdkLogObjectInfo const& stored) { return Equivalent(stored, info); });
+    if (it != e) {
+        return &(*it);
+    }
+    return nullptr;
+}
+
+XrSdkLogObjectInfo* ObjectInfoCollection::LookUpStoredObjectInfo(XrSdkLogObjectInfo const& info) {
+    auto e = object_info_.end();
+    auto it = std::find_if(object_info_.begin(), e, [&](XrSdkLogObjectInfo const& stored) { return Equivalent(stored, info); });
+    if (it != e) {
+        return &(*it);
+    }
+    return nullptr;
+}
+
+bool ObjectInfoCollection::LookUpObjectName(XrDebugUtilsObjectNameInfoEXT& info) const {
+    auto info_lookup = LookUpStoredObjectInfo(info.objectHandle, info.objectType);
+    if (info_lookup != nullptr) {
+        info.objectName = info_lookup->name.c_str();
+        return true;
+    }
+    return false;
+}
+
+bool ObjectInfoCollection::LookUpObjectName(XrSdkLogObjectInfo& info) const {
+    auto info_lookup = LookUpStoredObjectInfo(info);
+    if (info_lookup != nullptr) {
+        info.name = info_lookup->name;
+        return true;
+    }
+    return false;
+}
+
+static std::vector<XrDebugUtilsObjectNameInfoEXT> PopulateObjectNameInfo(std::vector<XrSdkLogObjectInfo> const& obj) {
+    std::vector<XrDebugUtilsObjectNameInfoEXT> ret;
+    ret.reserve(obj.size());
+    std::transform(obj.begin(), obj.end(), std::back_inserter(ret), [](XrSdkLogObjectInfo const& info) {
+        return XrDebugUtilsObjectNameInfoEXT{XR_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT, nullptr, info.type, info.handle,
+                                             info.name.c_str()};
+    });
+    return ret;
+}
+
+NamesAndLabels::NamesAndLabels(std::vector<XrSdkLogObjectInfo> obj, std::vector<XrDebugUtilsLabelEXT> lab)
+    : sdk_objects(std::move(obj)), objects(PopulateObjectNameInfo(sdk_objects)), labels(std::move(lab)) {}
+
+void NamesAndLabels::PopulateCallbackData(XrDebugUtilsMessengerCallbackDataEXT& callback_data) const {
+    callback_data.objects = objects.empty() ? nullptr : const_cast<XrDebugUtilsObjectNameInfoEXT*>(objects.data());
+    callback_data.objectCount = static_cast<uint32_t>(objects.size());
+    callback_data.sessionLabels = labels.empty() ? nullptr : const_cast<XrDebugUtilsLabelEXT*>(labels.data());
+    callback_data.sessionLabelCount = static_cast<uint32_t>(labels.size());
+}
+
+void DebugUtilsData::LookUpSessionLabels(XrSession session, std::vector<XrDebugUtilsLabelEXT>& labels) const {
+    auto session_label_iterator = session_labels_.find(session);
+    if (session_label_iterator != session_labels_.end()) {
+        auto& XrSdkSessionLabels = *session_label_iterator->second;
+        // Copy the debug utils labels in reverse order in the the labels vector.
+        std::transform(XrSdkSessionLabels.rbegin(), XrSdkSessionLabels.rend(), std::back_inserter(labels),
+                       [](XrSdkSessionLabelPtr const& label) { return label->debug_utils_label; });
+    }
+}
+
+XrSdkSessionLabel::XrSdkSessionLabel(const XrDebugUtilsLabelEXT& label_info, bool individual)
+    : label_name(label_info.labelName), debug_utils_label(label_info), is_individual_label(individual) {
+    // Update the c string pointer to the one we hold.
+    debug_utils_label.labelName = label_name.c_str();
+}
+
+XrSdkSessionLabelPtr XrSdkSessionLabel::make(const XrDebugUtilsLabelEXT& label_info, bool individual) {
+    XrSdkSessionLabelPtr ret(new XrSdkSessionLabel(label_info, individual));
+    return ret;
+}
+void DebugUtilsData::AddObjectName(uint64_t object_handle, XrObjectType object_type, const std::string& object_name) {
+    object_info_.AddObjectName(object_handle, object_type, object_name);
+}
+
+// We always want to remove the old individual label before we do anything else.
+// So, do that in it's own method
+void DebugUtilsData::RemoveIndividualLabel(XrSdkSessionLabelList& label_vec) {
+    if (!label_vec.empty() && label_vec.back()->is_individual_label) {
+        label_vec.pop_back();
+    }
+}
+
+XrSdkSessionLabelList* DebugUtilsData::GetSessionLabelList(XrSession session) {
+    auto session_label_iterator = session_labels_.find(session);
+    if (session_label_iterator == session_labels_.end()) {
+        return nullptr;
+    }
+    return session_label_iterator->second.get();
+}
+
+XrSdkSessionLabelList& DebugUtilsData::GetOrCreateSessionLabelList(XrSession session) {
+    XrSdkSessionLabelList* vec_ptr = GetSessionLabelList(session);
+    if (vec_ptr == nullptr) {
+        std::unique_ptr<XrSdkSessionLabelList> vec(new XrSdkSessionLabelList);
+        vec_ptr = vec.get();
+        session_labels_[session] = std::move(vec);
+    }
+    return *vec_ptr;
+}
+
+void DebugUtilsData::BeginLabelRegion(XrSession session, const XrDebugUtilsLabelEXT& label_info) {
+    auto& vec = GetOrCreateSessionLabelList(session);
+
+    // Individual labels do not stay around in the transition into a new label region
+    RemoveIndividualLabel(vec);
+
+    // Start the new label region
+    vec.emplace_back(XrSdkSessionLabel::make(label_info, false));
+}
+
+void DebugUtilsData::EndLabelRegion(XrSession session) {
+    XrSdkSessionLabelList* vec_ptr = GetSessionLabelList(session);
+    if (vec_ptr == nullptr) {
+        return;
+    }
+
+    // Individual labels do not stay around in the transition out of label region
+    RemoveIndividualLabel(*vec_ptr);
+
+    // Remove the last label region
+    if (!vec_ptr->empty()) {
+        vec_ptr->pop_back();
+    }
+}
+
+void DebugUtilsData::InsertLabel(XrSession session, const XrDebugUtilsLabelEXT& label_info) {
+    auto& vec = GetOrCreateSessionLabelList(session);
+
+    // Remove any individual layer that might already be there
+    RemoveIndividualLabel(vec);
+
+    // Insert a new individual label
+    vec.emplace_back(XrSdkSessionLabel::make(label_info, true));
+}
+
+void DebugUtilsData::DeleteObject(uint64_t object_handle, XrObjectType object_type) {
+    object_info_.RemoveObject(object_handle, object_type);
+
+    if (object_type == XR_OBJECT_TYPE_SESSION) {
+        auto session = TreatIntegerAsHandle<XrSession>(object_handle);
+        XrSdkSessionLabelList* vec_ptr = GetSessionLabelList(session);
+        if (vec_ptr != nullptr) {
+            session_labels_.erase(session);
+        }
+    }
+}
+
+void DebugUtilsData::DeleteSessionLabels(XrSession session) { session_labels_.erase(session); }
+
+NamesAndLabels DebugUtilsData::PopulateNamesAndLabels(std::vector<XrSdkLogObjectInfo> objects) const {
+    std::vector<XrDebugUtilsLabelEXT> labels;
+    for (auto& obj : objects) {
+        // Check for any names that have been associated with the objects and set them up here
+        object_info_.LookUpObjectName(obj);
+        // If this is a session, see if there are any labels associated with it for us to add
+        // to the callback content.
+        if (XR_OBJECT_TYPE_SESSION == obj.type) {
+            LookUpSessionLabels(obj.GetTypedHandle<XrSession>(), labels);
+        }
+    }
+
+    return {objects, labels};
+}
+
+AugmentedCallbackData DebugUtilsData::AugmentCallbackData(
+    const XrDebugUtilsMessengerCallbackDataEXT& provided_callback_data) const {
+    AugmentedCallbackData ret{provided_callback_data};
+    if (object_info_.Empty() || provided_callback_data.objectCount == 0) {
+        return ret;
+    }
+    bool obj_name_found = false;
+    for (uint32_t obj = 0; obj < provided_callback_data.objectCount; ++obj) {
+        auto& current_obj = provided_callback_data.objects[obj];
+        if (!obj_name_found) {
+            auto lookup = object_info_.LookUpStoredObjectInfo(current_obj.objectHandle, current_obj.objectType);
+            if (lookup != nullptr) {
+                obj_name_found = true;
+            }
+        }
+
+        // If this is a session, see if there are any labels associated with it for us to add
+        // to the callback content.
+        if (XR_OBJECT_TYPE_SESSION == current_obj.objectType) {
+            XrSession session = TreatIntegerAsHandle<XrSession>(current_obj.objectHandle);
+            LookUpSessionLabels(session, ret.labels);
+        }
+    }
+
+    if (!obj_name_found && ret.labels.empty()) {
+        // nothing to add to the data
+        return ret;
+    }
+
+    // If a name or a label has been found, we should update it in a new version of the callback data
+    ret.new_objects.assign(provided_callback_data.objects, provided_callback_data.objects + provided_callback_data.objectCount);
+
+    for (auto& obj : ret.new_objects) {
+        object_info_.LookUpObjectName(obj);
+    }
+    ret.temporary_callback_data.objects = ret.new_objects.data();
+    ret.temporary_callback_data.sessionLabelCount = static_cast<uint32_t>(ret.labels.size());
+    ret.temporary_callback_data.sessionLabels = ret.labels.empty() ? nullptr : ret.labels.data();
+    ret.callback_data_to_use = &ret.temporary_callback_data;
+    return ret;
+}

--- a/src/common/object_info.h
+++ b/src/common/object_info.h
@@ -1,0 +1,211 @@
+// Copyright (c) 2017-2019 The Khronos Group Inc.
+// Copyright (c) 2017-2019 Valve Corporation
+// Copyright (c) 2017-2019 LunarG, Inc.
+// Copyright (c) 2019 Collabora, Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: Mark Young <marky@lunarg.com>, Ryan Pavlik <ryan.pavlik@collabora.com
+//
+/*!
+ * @file
+ *
+ * The core of an XR_EXT_debug_utils implementation, used/shared by the loader and several SDK layers.
+ */
+
+#pragma once
+
+#include "hex_and_handles.h"
+
+#include <openxr/openxr.h>
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+struct XrSdkLogObjectInfo {
+    //! Type-erased handle value
+    uint64_t handle;
+
+    //! Kind of object this handle refers to
+    XrObjectType type;
+
+    //! To be assigned by the application - not part of this object's identity
+    std::string name;
+
+    /// Un-erase the type of the handle and get it properly typed again.
+    ///
+    /// Note: Does not check the type before doing it!
+    template <typename HandleType>
+    HandleType& GetTypedHandle() {
+        return TreatIntegerAsHandle<HandleType&>(handle);
+    }
+
+    //! @overload
+    template <typename HandleType>
+    HandleType const& GetTypedHandle() const {
+        return TreatIntegerAsHandle<HandleType&>(handle);
+    }
+
+    XrSdkLogObjectInfo() = default;
+
+    //! Create from a typed handle and object type
+    template <typename T>
+    XrSdkLogObjectInfo(T h, XrObjectType t) : handle(MakeHandleGeneric(h)), type(t) {}
+
+    //! Create from an untyped handle value (integer) and object type
+    XrSdkLogObjectInfo(uint64_t h, XrObjectType t) : handle(h), type(t) {}
+    //! Create from an untyped handle value (integer), object type, and name
+    XrSdkLogObjectInfo(uint64_t h, XrObjectType t, const char* n) : handle(h), type(t), name(n == nullptr ? "" : n) {}
+
+    std::string ToString() const;
+};
+
+//! True if the two object infos have the same handle value and handle type
+static inline bool Equivalent(XrSdkLogObjectInfo const& a, XrSdkLogObjectInfo const& b) {
+    return a.handle == b.handle && a.type == b.type;
+}
+
+//! @overload
+static inline bool Equivalent(XrDebugUtilsObjectNameInfoEXT const& a, XrSdkLogObjectInfo const& b) {
+    return a.objectHandle == b.handle && a.objectType == b.type;
+}
+
+//! @overload
+static inline bool Equivalent(XrSdkLogObjectInfo const& a, XrDebugUtilsObjectNameInfoEXT const& b) { return Equivalent(b, a); }
+
+/// Object info registered with calls to xrSetDebugUtilsObjectNameEXT
+class ObjectInfoCollection {
+   public:
+    void AddObjectName(uint64_t object_handle, XrObjectType object_type, const std::string& object_name);
+
+    void RemoveObject(uint64_t object_handle, XrObjectType object_type);
+
+    //! Find the stored object info, if any, matching handle and type.
+    //! Return nullptr if not found.
+    XrSdkLogObjectInfo const* LookUpStoredObjectInfo(XrSdkLogObjectInfo const& info) const;
+
+    //! Find the stored object info, if any, matching handle and type.
+    //! Return nullptr if not found.
+    XrSdkLogObjectInfo* LookUpStoredObjectInfo(XrSdkLogObjectInfo const& info);
+
+    //! Find the stored object info, if any.
+    //! Return nullptr if not found.
+    XrSdkLogObjectInfo const* LookUpStoredObjectInfo(uint64_t handle, XrObjectType type) const {
+        return LookUpStoredObjectInfo({handle, type});
+    }
+
+    //! Find the object name, if any, and update debug utils info accordingly.
+    //! Return true if found and updated.
+    bool LookUpObjectName(XrDebugUtilsObjectNameInfoEXT& info) const;
+
+    //! Find the object name, if any, and update logging info accordingly.
+    //! Return true if found and updated.
+    bool LookUpObjectName(XrSdkLogObjectInfo& info) const;
+
+    //! Is the collection empty?
+    bool Empty() const { return object_info_.empty(); }
+
+   private:
+    // Object names that have been set for given objects
+    std::vector<XrSdkLogObjectInfo> object_info_;
+};
+
+struct XrSdkSessionLabel;
+using XrSdkSessionLabelPtr = std::unique_ptr<XrSdkSessionLabel>;
+using XrSdkSessionLabelList = std::vector<XrSdkSessionLabelPtr>;
+
+struct XrSdkSessionLabel {
+    static XrSdkSessionLabelPtr make(const XrDebugUtilsLabelEXT& label_info, bool individual);
+
+    std::string label_name;
+    XrDebugUtilsLabelEXT debug_utils_label;
+    bool is_individual_label;
+
+   private:
+    XrSdkSessionLabel(const XrDebugUtilsLabelEXT& label_info, bool individual);
+};
+
+/// The metadata for a collection of objects. Must persist unmodified during the entire debug messenger call!
+struct NamesAndLabels {
+    NamesAndLabels(std::vector<XrSdkLogObjectInfo> obj, std::vector<XrDebugUtilsLabelEXT> lab);
+    /// C++ structure owning the data (strings) backing the objects vector.
+    std::vector<XrSdkLogObjectInfo> sdk_objects;
+
+    std::vector<XrDebugUtilsObjectNameInfoEXT> objects;
+    std::vector<XrDebugUtilsLabelEXT> labels;
+
+    /// Populate the debug utils callback data structure.
+    void PopulateCallbackData(XrDebugUtilsMessengerCallbackDataEXT& data) const;
+    // XrDebugUtilsMessengerCallbackDataEXT MakeCallbackData() const;
+};
+
+struct AugmentedCallbackData {
+    explicit AugmentedCallbackData(const XrDebugUtilsMessengerCallbackDataEXT& data_to_use)
+        : temporary_callback_data(data_to_use), callback_data_to_use(&data_to_use) {}
+    std::vector<XrDebugUtilsLabelEXT> labels;
+    XrDebugUtilsMessengerCallbackDataEXT temporary_callback_data;
+    std::vector<XrDebugUtilsObjectNameInfoEXT> new_objects;
+
+    const XrDebugUtilsMessengerCallbackDataEXT* callback_data_to_use;
+};
+/// Tracks all the data (handle names and session labels) required to fully augment XR_EXT_debug_utils-related calls.
+class DebugUtilsData {
+   public:
+    DebugUtilsData() = default;
+
+    DebugUtilsData(const DebugUtilsData&) = delete;
+    DebugUtilsData& operator=(const DebugUtilsData&) = delete;
+
+    bool Empty() const { return object_info_.Empty() && session_labels_.empty(); }
+
+    //! Core of implementation for xrSetDebugUtilsObjectNameEXT
+    void AddObjectName(uint64_t object_handle, XrObjectType object_type, const std::string& object_name);
+
+    /// Core of implementation for xrSessionBeginDebugUtilsLabelRegionEXT
+    void BeginLabelRegion(XrSession session, const XrDebugUtilsLabelEXT& label_info);
+
+    /// Core of implementation for xrSessionEndDebugUtilsLabelRegionEXT
+    void EndLabelRegion(XrSession session);
+
+    /// Core of implementation for xrSessionInsertDebugUtilsLabelEXT
+    void InsertLabel(XrSession session, const XrDebugUtilsLabelEXT& label_info);
+
+    /// Removes all labels associated with a session - call in xrDestroySession and xrDestroyInstance (for all child sessions)
+    void DeleteSessionLabels(XrSession session);
+
+    /// Retrieve labels for the given session, if any, and push them in reverse order on the vector.
+    void LookUpSessionLabels(XrSession session, std::vector<XrDebugUtilsLabelEXT>& labels) const;
+
+    /// Removes all data related to this object - including session labels if it's a session.
+    ///
+    /// Does not take care of handling child objects - you must do this yourself.
+    void DeleteObject(uint64_t object_handle, XrObjectType object_type);
+
+    /// Given the collection of objects, populate their names and list of labels
+    NamesAndLabels PopulateNamesAndLabels(std::vector<XrSdkLogObjectInfo> objects) const;
+
+    AugmentedCallbackData AugmentCallbackData(const XrDebugUtilsMessengerCallbackDataEXT& provided_callback_data) const;
+
+   private:
+    void RemoveIndividualLabel(XrSdkSessionLabelList& label_vec);
+    XrSdkSessionLabelList* GetSessionLabelList(XrSession session);
+    XrSdkSessionLabelList& GetOrCreateSessionLabelList(XrSession session);
+
+    // Session labels: one vector of them per session.
+    std::unordered_map<XrSession, std::unique_ptr<XrSdkSessionLabelList>> session_labels_;
+
+    // Names for objects.
+    ObjectInfoCollection object_info_;
+};

--- a/src/common/object_info.h
+++ b/src/common/object_info.h
@@ -34,6 +34,34 @@
 #include <unordered_map>
 #include <vector>
 
+struct XrSdkGenericObject {
+    //! Type-erased handle value
+    uint64_t handle;
+
+    //! Kind of object this handle refers to
+    XrObjectType type;
+    /// Un-erase the type of the handle and get it properly typed again.
+    ///
+    /// Note: Does not check the type before doing it!
+    template <typename HandleType>
+    HandleType& GetTypedHandle() {
+        return TreatIntegerAsHandle<HandleType&>(handle);
+    }
+
+    //! @overload
+    template <typename HandleType>
+    HandleType const& GetTypedHandle() const {
+        return TreatIntegerAsHandle<HandleType&>(handle);
+    }
+
+    //! Create from a typed handle and object type
+    template <typename T>
+    XrSdkGenericObject(T h, XrObjectType t) : handle(MakeHandleGeneric(h)), type(t) {}
+
+    //! Create from an untyped handle value (integer) and object type
+    XrSdkGenericObject(uint64_t h, XrObjectType t) : handle(h), type(t) {}
+};
+
 struct XrSdkLogObjectInfo {
     //! Type-erased handle value
     uint64_t handle;
@@ -139,6 +167,7 @@ struct XrSdkSessionLabel {
 
 /// The metadata for a collection of objects. Must persist unmodified during the entire debug messenger call!
 struct NamesAndLabels {
+    NamesAndLabels() = default;
     NamesAndLabels(std::vector<XrSdkLogObjectInfo> obj, std::vector<XrDebugUtilsLabelEXT> lab);
     /// C++ structure owning the data (strings) backing the objects vector.
     std::vector<XrSdkLogObjectInfo> sdk_objects;

--- a/src/loader/CMakeLists.txt
+++ b/src/loader/CMakeLists.txt
@@ -71,6 +71,8 @@ add_library(${LOADER_NAME} ${LIBRARY_TYPE}
     ${CMAKE_SOURCE_DIR}/src/common/filesystem_utils.hpp
     ${CMAKE_SOURCE_DIR}/src/common/hex_and_handles.cpp
     ${CMAKE_SOURCE_DIR}/src/common/hex_and_handles.h
+    ${CMAKE_SOURCE_DIR}/src/common/object_info.cpp
+    ${CMAKE_SOURCE_DIR}/src/common/object_info.h
     ${CMAKE_SOURCE_DIR}/src/external/jsoncpp/src/lib_json/json_reader.cpp
     ${CMAKE_SOURCE_DIR}/src/external/jsoncpp/src/lib_json/json_value.cpp
     ${CMAKE_SOURCE_DIR}/src/external/jsoncpp/src/lib_json/json_writer.cpp

--- a/src/loader/loader_core.cpp
+++ b/src/loader/loader_core.cpp
@@ -570,19 +570,19 @@ XRAPI_ATTR XrResult XRAPI_CALL xrSessionBeginDebugUtilsLabelRegionEXT(XrSession 
     if (nullptr == loader_instance) {
         LoaderLogger::LogValidationErrorMessage("VUID-xrSessionBeginDebugUtilsLabelRegionEXT-session-parameter",
                                                 "xrSessionBeginDebugUtilsLabelRegionEXT", "session is not a valid XrSession",
-                                                {XrLoaderLogObjectInfo{session, XR_OBJECT_TYPE_SESSION}});
+                                                    {XrSdkLogObjectInfo{session, XR_OBJECT_TYPE_SESSION}});
         return XR_ERROR_HANDLE_INVALID;
     }
     if (!loader_instance->ExtensionIsEnabled(XR_EXT_DEBUG_UTILS_EXTENSION_NAME)) {
         LoaderLogger::LogValidationErrorMessage("TBD", "xrSessionBeginDebugUtilsLabelRegionEXT",
                                                 "Extension entrypoint called without enabling appropriate extension",
-                                                {XrLoaderLogObjectInfo{session, XR_OBJECT_TYPE_SESSION}});
+                                                    {XrSdkLogObjectInfo{session, XR_OBJECT_TYPE_SESSION}});
         return XR_ERROR_FUNCTION_UNSUPPORTED;
     }
     if (nullptr == labelInfo) {
         LoaderLogger::LogValidationErrorMessage("VUID-xrSessionBeginDebugUtilsLabelRegionEXT-labelInfo-parameter",
                                                 "xrSessionBeginDebugUtilsLabelRegionEXT", "labelInfo must be non-NULL",
-                                                {XrLoaderLogObjectInfo{session, XR_OBJECT_TYPE_SESSION}});
+                                                    {XrSdkLogObjectInfo{session, XR_OBJECT_TYPE_SESSION}});
         return XR_ERROR_VALIDATION_FAILURE;
     }
 
@@ -600,7 +600,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrSessionEndDebugUtilsLabelRegionEXT(XrSession se
     if (nullptr == loader_instance) {
         LoaderLogger::LogValidationErrorMessage("VUID-xrSessionEndDebugUtilsLabelRegionEXT-session-parameter",
                                                 "xrSessionEndDebugUtilsLabelRegionEXT", "session is not a valid XrSession",
-                                                {XrLoaderLogObjectInfo{session, XR_OBJECT_TYPE_SESSION}});
+                                                    {XrSdkLogObjectInfo{session, XR_OBJECT_TYPE_SESSION}});
         return XR_ERROR_HANDLE_INVALID;
     }
     if (!loader_instance->ExtensionIsEnabled(XR_EXT_DEBUG_UTILS_EXTENSION_NAME)) {
@@ -621,19 +621,19 @@ XRAPI_ATTR XrResult XRAPI_CALL xrSessionInsertDebugUtilsLabelEXT(XrSession sessi
     if (nullptr == loader_instance) {
         LoaderLogger::LogValidationErrorMessage("VUID-xrSessionInsertDebugUtilsLabelEXT-session-parameter",
                                                 "xrSessionInsertDebugUtilsLabelEXT", "session is not a valid XrSession",
-                                                {XrLoaderLogObjectInfo{session, XR_OBJECT_TYPE_SESSION}});
+                                                    {XrSdkLogObjectInfo{session, XR_OBJECT_TYPE_SESSION}});
         return XR_ERROR_HANDLE_INVALID;
     }
     if (!loader_instance->ExtensionIsEnabled(XR_EXT_DEBUG_UTILS_EXTENSION_NAME)) {
         LoaderLogger::LogValidationErrorMessage("TBD", "xrSessionInsertDebugUtilsLabelEXT",
                                                 "Extension entrypoint called without enabling appropriate extension",
-                                                {XrLoaderLogObjectInfo{session, XR_OBJECT_TYPE_SESSION}});
+                                                    {XrSdkLogObjectInfo{session, XR_OBJECT_TYPE_SESSION}});
         return XR_ERROR_FUNCTION_UNSUPPORTED;
     }
     if (nullptr == labelInfo) {
         LoaderLogger::LogValidationErrorMessage("VUID-xrSessionInsertDebugUtilsLabelEXT-labelInfo-parameter",
                                                 "xrSessionInsertDebugUtilsLabelEXT", "labelInfo must be non-NULL",
-                                                {XrLoaderLogObjectInfo{session, XR_OBJECT_TYPE_SESSION}});
+                                                    {XrSdkLogObjectInfo{session, XR_OBJECT_TYPE_SESSION}});
         return XR_ERROR_VALIDATION_FAILURE;
     }
 

--- a/src/loader/loader_logger.cpp
+++ b/src/loader/loader_logger.cpp
@@ -39,76 +39,9 @@
 std::unique_ptr<LoaderLogger> LoaderLogger::_instance;
 std::once_flag LoaderLogger::_once_flag;
 
-std::string XrLoaderLogObjectInfo::ToString() const {
-    std::ostringstream oss;
-    oss << Uint64ToHexString(handle);
-    if (!name.empty()) {
-        oss << " (" << name << ")";
-    }
-    return oss.str();
-}
-
 bool LoaderLogRecorder::LogDebugUtilsMessage(XrDebugUtilsMessageSeverityFlagsEXT /*message_severity*/,
                                              XrDebugUtilsMessageTypeFlagsEXT /*message_type*/,
                                              const XrDebugUtilsMessengerCallbackDataEXT* /*callback_data*/) {
-    return false;
-}
-
-void ObjectInfoCollection::AddObjectName(uint64_t object_handle, XrObjectType object_type, const std::string& object_name) {
-    // If name is empty, we should erase it
-    if (object_name.empty()) {
-        vector_remove_if_and_erase(_object_info, [=](XrLoaderLogObjectInfo const& info) { return info.handle == object_handle; });
-        return;
-    }
-    // Otherwise, add it or update the name
-
-    XrLoaderLogObjectInfo new_obj = {object_handle, object_type};
-
-    // If it already exists, update the name
-    auto lookup_info = LookUpStoredObjectInfo(new_obj);
-    if (lookup_info != nullptr) {
-        lookup_info->name = object_name;
-        return;
-    }
-
-    // It doesn't exist, so add a new info block
-    new_obj.name = object_name;
-    _object_info.push_back(new_obj);
-}
-
-XrLoaderLogObjectInfo const* ObjectInfoCollection::LookUpStoredObjectInfo(XrLoaderLogObjectInfo const& info) const {
-    auto e = _object_info.end();
-    auto it = std::find_if(_object_info.begin(), e, [&](XrLoaderLogObjectInfo const& stored) { return Equivalent(stored, info); });
-    if (it != e) {
-        return &(*it);
-    }
-    return nullptr;
-}
-
-XrLoaderLogObjectInfo* ObjectInfoCollection::LookUpStoredObjectInfo(XrLoaderLogObjectInfo const& info) {
-    auto e = _object_info.end();
-    auto it = std::find_if(_object_info.begin(), e, [&](XrLoaderLogObjectInfo const& stored) { return Equivalent(stored, info); });
-    if (it != e) {
-        return &(*it);
-    }
-    return nullptr;
-}
-
-bool ObjectInfoCollection::LookUpObjectName(XrDebugUtilsObjectNameInfoEXT& info) const {
-    auto info_lookup = LookUpStoredObjectInfo(info.objectHandle, info.objectType);
-    if (info_lookup != nullptr) {
-        info.objectName = info_lookup->name.c_str();
-        return true;
-    }
-    return false;
-}
-
-bool ObjectInfoCollection::LookUpObjectName(XrLoaderLogObjectInfo& info) const {
-    auto info_lookup = LookUpStoredObjectInfo(info);
-    if (info_lookup != nullptr) {
-        info.name = info_lookup->name;
-        return true;
-    }
     return false;
 }
 
@@ -213,30 +146,18 @@ void LoaderLogger::RemoveLogRecorder(uint64_t unique_id) {
 
 bool LoaderLogger::LogMessage(XrLoaderLogMessageSeverityFlagBits message_severity, XrLoaderLogMessageTypeFlags message_type,
                               const std::string& message_id, const std::string& command_name, const std::string& message,
-                              const std::vector<XrLoaderLogObjectInfo>& objects) {
+                              const std::vector<XrSdkLogObjectInfo>& objects) {
     XrLoaderLogMessengerCallbackData callback_data = {};
     callback_data.message_id = message_id.c_str();
     callback_data.command_name = command_name.c_str();
     callback_data.message = message.c_str();
 
-    std::vector<XrDebugUtilsLabelEXT> labels;
+    auto names_and_labels = data_.PopulateNamesAndLabels(objects);
+    callback_data.objects = names_and_labels.sdk_objects.empty() ? nullptr : names_and_labels.sdk_objects.data();
+    callback_data.object_count = static_cast<uint8_t>(names_and_labels.objects.size());
 
-    // Copy objects into a vector we can modify and will keep around past the callback.
-    std::vector<XrLoaderLogObjectInfo> object_vector = objects;
-    for (auto& obj : object_vector) {
-        // Check for any names that have been associated with the objects and set them up here
-        _object_names.LookUpObjectName(obj);
-        // If this is a session, see if there are any labels associated with it for us to add
-        // to the callback content.
-        if (XR_OBJECT_TYPE_SESSION == obj.type) {
-            LookUpSessionLabels(obj.GetTypedHandle<XrSession>(), labels);
-        }
-    }
-    callback_data.objects = object_vector.empty() ? nullptr : object_vector.data();
-    callback_data.object_count = static_cast<uint8_t>(object_vector.size());
-
-    callback_data.session_labels = labels.empty() ? nullptr : labels.data();
-    callback_data.session_labels_count = static_cast<uint8_t>(labels.size());
+    callback_data.session_labels = names_and_labels.labels.empty() ? nullptr : names_and_labels.labels.data();
+    callback_data.session_labels_count = static_cast<uint8_t>(names_and_labels.labels.size());
 
     bool exit_app = false;
     for (std::unique_ptr<LoaderLogRecorder>& recorder : _recorders) {
@@ -248,16 +169,6 @@ bool LoaderLogger::LogMessage(XrLoaderLogMessageSeverityFlagBits message_severit
     return exit_app;
 }
 
-void LoaderLogger::LookUpSessionLabels(XrSession session, std::vector<XrDebugUtilsLabelEXT>& labels) const {
-    auto session_label_iterator = _session_labels.find(session);
-    if (session_label_iterator != _session_labels.end()) {
-        auto& internalSessionLabels = *session_label_iterator->second;
-        // Copy the debug utils labels in reverse order in the the labels vector.
-        std::transform(internalSessionLabels.rbegin(), internalSessionLabels.rend(), std::back_inserter(labels),
-                       [](InternalSessionLabelPtr const& label) { return label->debug_utils_label; });
-    }
-}
-
 // Extension-specific logging functions
 bool LoaderLogger::LogDebugUtilsMessage(XrDebugUtilsMessageSeverityFlagsEXT message_severity,
                                         XrDebugUtilsMessageTypeFlagsEXT message_type,
@@ -266,44 +177,7 @@ bool LoaderLogger::LogDebugUtilsMessage(XrDebugUtilsMessageSeverityFlagsEXT mess
     XrLoaderLogMessageSeverityFlags log_message_severity = DebugUtilsSeveritiesToLoaderLogMessageSeverities(message_severity);
     XrLoaderLogMessageTypeFlags log_message_type = DebugUtilsMessageTypesToLoaderLogMessageTypes(message_type);
 
-    bool obj_name_found = false;
-    std::vector<XrDebugUtilsLabelEXT> labels;
-    if (!_object_names.Empty() && callback_data->objectCount > 0) {
-        for (uint32_t obj = 0; obj < callback_data->objectCount; ++obj) {
-            auto& current_obj = callback_data->objects[obj];
-            auto stored_info = _object_names.LookUpStoredObjectInfo(current_obj.objectHandle, current_obj.objectType);
-            if (stored_info != nullptr) {
-                obj_name_found = true;
-            }
-
-            // If this is a session, see if there are any labels associated with it for us to add
-            // to the callback content.
-            if (XR_OBJECT_TYPE_SESSION == current_obj.objectType) {
-                XrSession session = TreatIntegerAsHandle<XrSession>(current_obj.objectHandle);
-                LookUpSessionLabels(session, labels);
-            }
-        }
-    }
-    // Use unmodified ones by default.
-    XrDebugUtilsMessengerCallbackDataEXT const* callback_data_to_use = callback_data;
-
-    XrDebugUtilsMessengerCallbackDataEXT new_callback_data = *callback_data;
-    std::vector<XrDebugUtilsObjectNameInfoEXT> new_objects;
-
-    // If a name or a label has been found, we should update it in a new version of the callback
-    if (obj_name_found || !labels.empty()) {
-        // Copy objects
-        new_objects =
-            std::vector<XrDebugUtilsObjectNameInfoEXT>(callback_data->objects, callback_data->objects + callback_data->objectCount);
-        for (auto& obj : new_objects) {
-            // Check for any names that have been associated with the objects and set them up here
-            _object_names.LookUpObjectName(obj);
-        }
-        new_callback_data.objects = new_objects.data();
-        new_callback_data.sessionLabelCount = static_cast<uint32_t>(labels.size());
-        new_callback_data.sessionLabels = labels.empty() ? nullptr : labels.data();
-        callback_data_to_use = &new_callback_data;
-    }
+    auto augmented = data_.AugmentCallbackData(*callback_data);
 
     // Loop through the recorders
     for (std::unique_ptr<LoaderLogRecorder>& recorder : _recorders) {
@@ -314,92 +188,23 @@ bool LoaderLogger::LogDebugUtilsMessage(XrDebugUtilsMessageSeverityFlagsEXT mess
             continue;
         }
 
-        exit_app |= recorder->LogDebugUtilsMessage(message_severity, message_type, callback_data_to_use);
+        exit_app |= recorder->LogDebugUtilsMessage(message_severity, message_type, augmented.callback_data_to_use);
     }
     return exit_app;
 }
 
 void LoaderLogger::AddObjectName(uint64_t object_handle, XrObjectType object_type, const std::string& object_name) {
-    _object_names.AddObjectName(object_handle, object_type, object_name);
-}
-
-// We always want to remove the old individual label before we do anything else.
-// So, do that in it's own method
-void LoaderLogger::RemoveIndividualLabel(InternalSessionLabelList& label_vec) {
-    if (!label_vec.empty() && label_vec.back()->is_individual_label) {
-        label_vec.pop_back();
-    }
-}
-
-InternalSessionLabelList* LoaderLogger::GetSessionLabelList(XrSession session) {
-    auto session_label_iterator = _session_labels.find(session);
-    if (session_label_iterator == _session_labels.end()) {
-        return nullptr;
-    }
-    return session_label_iterator->second.get();
-}
-
-InternalSessionLabelList& LoaderLogger::GetOrCreateSessionLabelList(XrSession session) {
-    InternalSessionLabelList* vec_ptr = GetSessionLabelList(session);
-    if (vec_ptr == nullptr) {
-        std::unique_ptr<InternalSessionLabelList> vec(new InternalSessionLabelList);
-        vec_ptr = vec.get();
-        _session_labels[session] = std::move(vec);
-    }
-    return *vec_ptr;
+    data_.AddObjectName(object_handle, object_type, object_name);
 }
 
 void LoaderLogger::BeginLabelRegion(XrSession session, const XrDebugUtilsLabelEXT* label_info) {
-    auto& vec = GetOrCreateSessionLabelList(session);
-
-    // Individual labels do not stay around in the transition into a new label region
-    RemoveIndividualLabel(vec);
-
-    // Start the new label region
-    InternalSessionLabelPtr new_session_label(new InternalSessionLabel);
-    new_session_label->label_name = label_info->labelName;
-    new_session_label->debug_utils_label = *label_info;
-    new_session_label->debug_utils_label.labelName = new_session_label->label_name.c_str();
-    new_session_label->is_individual_label = false;
-    vec.emplace_back(std::move(new_session_label));
+    data_.BeginLabelRegion(session, *label_info);
 }
 
-void LoaderLogger::EndLabelRegion(XrSession session) {
-    InternalSessionLabelList* vec_ptr = GetSessionLabelList(session);
-    if (vec_ptr == nullptr) {
-        return;
-    }
-
-    // Individual labels do not stay around in the transition out of label region
-    RemoveIndividualLabel(*vec_ptr);
-
-    // Remove the last label region
-    if (!vec_ptr->empty()) {
-        vec_ptr->pop_back();
-    }
-}
+void LoaderLogger::EndLabelRegion(XrSession session) { data_.EndLabelRegion(session); }
 
 void LoaderLogger::InsertLabel(XrSession session, const XrDebugUtilsLabelEXT* label_info) {
-    //! @todo only difference from BeginLabelRegion is value of is_individual_label
-    auto& vec = GetOrCreateSessionLabelList(session);
-
-    // Remove any individual layer that might already be there
-    RemoveIndividualLabel(vec);
-
-    // Insert a new individual label
-    InternalSessionLabelPtr new_session_label(new InternalSessionLabel);
-    new_session_label->label_name = label_info->labelName;
-    new_session_label->debug_utils_label = *label_info;
-    new_session_label->debug_utils_label.labelName = new_session_label->label_name.c_str();
-    new_session_label->is_individual_label = true;
-    vec.emplace_back(std::move(new_session_label));
+    data_.InsertLabel(session, *label_info);
 }
 
-// Called during xrDestroySession.  We need to delete all session related labels.
-void LoaderLogger::DeleteSessionLabels(XrSession session) {
-    InternalSessionLabelList* vec_ptr = GetSessionLabelList(session);
-    if (vec_ptr == nullptr) {
-        return;
-    }
-    _session_labels.erase(session);
-}
+void LoaderLogger::DeleteSessionLabels(XrSession session) { data_.DeleteSessionLabels(session); }

--- a/src/loader/loader_logger.hpp
+++ b/src/loader/loader_logger.hpp
@@ -28,6 +28,7 @@
 #include <openxr/openxr.h>
 
 #include "hex_and_handles.h"
+#include "object_info.h"
 
 // Use internal versions of flags similar to XR_EXT_debug_utils so that
 // we're not tightly coupled to that extension.  This way, if the extension
@@ -47,59 +48,12 @@ typedef XrFlags64 XrLoaderLogMessageSeverityFlags;
 typedef XrFlags64 XrLoaderLogMessageTypeFlagBits;
 typedef XrFlags64 XrLoaderLogMessageTypeFlags;
 
-struct XrLoaderLogObjectInfo {
-    //! Type-erased handle value
-    uint64_t handle;
-
-    //! Kind of object this handle refers to
-    XrObjectType type;
-
-    //! To be assigned by the application - not part of this object's identity
-    std::string name;
-
-    /// Un-erase the type of the handle and get it properly typed again.
-    ///
-    /// Note: Does not check the type before doing it!
-    template <typename HandleType>
-    HandleType& GetTypedHandle() {
-        return TreatIntegerAsHandle<HandleType&>(handle);
-    }
-
-    //! @overload
-    template <typename HandleType>
-    HandleType const& GetTypedHandle() const {
-        return TreatIntegerAsHandle<HandleType&>(handle);
-    }
-
-    XrLoaderLogObjectInfo() = default;
-
-    //! Create from a typed handle and object type
-    template <typename T>
-    XrLoaderLogObjectInfo(T h, XrObjectType t) : handle(MakeHandleGeneric(h)), type(t) {}
-
-    //! Create from an untyped handle value (integer) and object type
-    XrLoaderLogObjectInfo(uint64_t h, XrObjectType t) : handle(h), type(t) {}
-
-    std::string ToString() const;
-};
-
-//! True if the two object infos have the same handle value and handle type
-static inline bool Equivalent(XrLoaderLogObjectInfo const& a, XrLoaderLogObjectInfo const& b) {
-    return a.handle == b.handle && a.type == b.type;
-}
-//! @overload
-static inline bool Equivalent(XrDebugUtilsObjectNameInfoEXT const& a, XrLoaderLogObjectInfo const& b) {
-    return a.objectHandle == b.handle && a.objectType == b.type;
-}
-//! @overload
-static inline bool Equivalent(XrLoaderLogObjectInfo const& a, XrDebugUtilsObjectNameInfoEXT const& b) { return Equivalent(b, a); }
-
 struct XrLoaderLogMessengerCallbackData {
     const char* message_id;
     const char* command_name;
     const char* message;
     uint8_t object_count;
-    XrLoaderLogObjectInfo* objects;
+    XrSdkLogObjectInfo* objects;
     uint8_t session_labels_count;
     XrDebugUtilsLabelEXT* session_labels;
 };
@@ -159,49 +113,6 @@ class LoaderLogRecorder {
     XrLoaderLogMessageTypeFlags _message_types;
 };
 
-class ObjectInfoCollection {
-   public:
-    //! Called from LoaderXrTermSetDebugUtilsObjectNameEXT - an empty name means remove
-    void AddObjectName(uint64_t object_handle, XrObjectType object_type, const std::string& object_name);
-
-    //! Find the stored object info, if any, matching handle and type.
-    //! Return nullptr if not found.
-    XrLoaderLogObjectInfo const* LookUpStoredObjectInfo(XrLoaderLogObjectInfo const& info) const;
-    //! Find the stored object info, if any, matching handle and type.
-    //! Return nullptr if not found.
-    XrLoaderLogObjectInfo* LookUpStoredObjectInfo(XrLoaderLogObjectInfo const& info);
-
-    //! Find the stored object info, if any.
-    //! Return nullptr if not found.
-    XrLoaderLogObjectInfo const* LookUpStoredObjectInfo(uint64_t handle, XrObjectType type) const {
-        return LookUpStoredObjectInfo({handle, type});
-    }
-
-    //! Find the object name, if any, and update debug utils info accordingly.
-    //! Return true if found and updated.
-    bool LookUpObjectName(XrDebugUtilsObjectNameInfoEXT& info) const;
-
-    //! Find the object name, if any, and update logging info accordingly.
-    //! Return true if found and updated.
-    bool LookUpObjectName(XrLoaderLogObjectInfo& info) const;
-
-    //! Is the collection empty?
-    bool Empty() const { return _object_info.empty(); }
-
-   private:
-    // Object names that have been set for given objects
-    std::vector<XrLoaderLogObjectInfo> _object_info;
-};
-
-struct InternalSessionLabel {
-    XrDebugUtilsLabelEXT debug_utils_label;
-    std::string label_name;
-    bool is_individual_label;
-};
-
-using InternalSessionLabelPtr = std::unique_ptr<InternalSessionLabel>;
-using InternalSessionLabelList = std::vector<InternalSessionLabelPtr>;
-
 class LoaderLogger {
    public:
     static LoaderLogger& GetInstance() {
@@ -221,34 +132,34 @@ class LoaderLogger {
 
     bool LogMessage(XrLoaderLogMessageSeverityFlagBits message_severity, XrLoaderLogMessageTypeFlags message_type,
                     const std::string& message_id, const std::string& command_name, const std::string& message,
-                    const std::vector<XrLoaderLogObjectInfo>& objects = {});
+                    const std::vector<XrSdkLogObjectInfo>& objects = {});
     static bool LogErrorMessage(const std::string& command_name, const std::string& message,
-                                const std::vector<XrLoaderLogObjectInfo>& objects = {}) {
+                                const std::vector<XrSdkLogObjectInfo>& objects = {}) {
         return GetInstance().LogMessage(XR_LOADER_LOG_MESSAGE_SEVERITY_ERROR_BIT, XR_LOADER_LOG_MESSAGE_TYPE_GENERAL_BIT,
                                         "OpenXR-Loader", command_name, message, objects);
     }
     static bool LogWarningMessage(const std::string& command_name, const std::string& message,
-                                  const std::vector<XrLoaderLogObjectInfo>& objects = {}) {
+                                  const std::vector<XrSdkLogObjectInfo>& objects = {}) {
         return GetInstance().LogMessage(XR_LOADER_LOG_MESSAGE_SEVERITY_WARNING_BIT, XR_LOADER_LOG_MESSAGE_TYPE_GENERAL_BIT,
                                         "OpenXR-Loader", command_name, message, objects);
     }
     static bool LogInfoMessage(const std::string& command_name, const std::string& message,
-                               const std::vector<XrLoaderLogObjectInfo>& objects = {}) {
+                               const std::vector<XrSdkLogObjectInfo>& objects = {}) {
         return GetInstance().LogMessage(XR_LOADER_LOG_MESSAGE_SEVERITY_INFO_BIT, XR_LOADER_LOG_MESSAGE_TYPE_GENERAL_BIT,
                                         "OpenXR-Loader", command_name, message, objects);
     }
     static bool LogVerboseMessage(const std::string& command_name, const std::string& message,
-                                  const std::vector<XrLoaderLogObjectInfo>& objects = {}) {
+                                  const std::vector<XrSdkLogObjectInfo>& objects = {}) {
         return GetInstance().LogMessage(XR_LOADER_LOG_MESSAGE_SEVERITY_VERBOSE_BIT, XR_LOADER_LOG_MESSAGE_TYPE_GENERAL_BIT,
                                         "OpenXR-Loader", command_name, message, objects);
     }
     static bool LogValidationErrorMessage(const std::string& vuid, const std::string& command_name, const std::string& message,
-                                          const std::vector<XrLoaderLogObjectInfo>& objects = {}) {
+                                          const std::vector<XrSdkLogObjectInfo>& objects = {}) {
         return GetInstance().LogMessage(XR_LOADER_LOG_MESSAGE_SEVERITY_ERROR_BIT, XR_LOADER_LOG_MESSAGE_TYPE_SPECIFICATION_BIT,
                                         vuid, command_name, message, objects);
     }
     static bool LogValidationWarningMessage(const std::string& vuid, const std::string& command_name, const std::string& message,
-                                            const std::vector<XrLoaderLogObjectInfo>& objects = {}) {
+                                            const std::vector<XrSdkLogObjectInfo>& objects = {}) {
         return GetInstance().LogMessage(XR_LOADER_LOG_MESSAGE_SEVERITY_WARNING_BIT, XR_LOADER_LOG_MESSAGE_TYPE_SPECIFICATION_BIT,
                                         vuid, command_name, message, objects);
     }
@@ -262,22 +173,13 @@ class LoaderLogger {
     LoaderLogger(const LoaderLogger&) = delete;
     LoaderLogger& operator=(const LoaderLogger&) = delete;
 
-    /// Retrieve labels for the given session, if any, and push them in reverse order on the vector.
-    void LookUpSessionLabels(XrSession session, std::vector<XrDebugUtilsLabelEXT>& labels) const;
-
-    void RemoveIndividualLabel(InternalSessionLabelList& label_vec);
-    InternalSessionLabelList* GetSessionLabelList(XrSession session);
-    InternalSessionLabelList& GetOrCreateSessionLabelList(XrSession session);
-
     static std::unique_ptr<LoaderLogger> _instance;
     static std::once_flag _once_flag;
 
     // List of available recorder objects
     std::vector<std::unique_ptr<LoaderLogRecorder>> _recorders;
 
-    ObjectInfoCollection _object_names;
-    // Session labels
-    std::unordered_map<XrSession, std::unique_ptr<InternalSessionLabelList>> _session_labels;
+    DebugUtilsData data_;
 };
 
 // Utility functions for converting to/from XR_EXT_debug_utils values

--- a/src/scripts/loader_source_generator.py
+++ b/src/scripts/loader_source_generator.py
@@ -81,7 +81,7 @@ def generateErrorMessage(indent_level, vuid, cur_cmd, message, object_info):
     lines.append('    "{}",'.format(cur_cmd.name))
     lines.append('    {},'.format(message))
 
-    object_info_constructors = ['XrLoaderLogObjectInfo{%s, %s}' % p for p in object_info]
+    object_info_constructors = ['XrSdkLogObjectInfo{%s, %s}' % p for p in object_info]
     if len(object_info_constructors) <= 1:
         lines.append('    {%s});' % (', '.join(object_info_constructors)))
     else:

--- a/src/scripts/validation_layer_generator.py
+++ b/src/scripts/validation_layer_generator.py
@@ -2456,7 +2456,7 @@ class ValidationSourceOutputGenerator(AutomaticSourceOutputGenerator):
             elif is_destroy:
                 if last_param.type == 'XrSession':
                     next_validate_func += '\n        // Clean up any labels associated with this session\n'
-                    next_validate_func += '        CoreValidationDeleteSessionLabels(session);\n\n'
+                    # next_validate_func += '        CoreValidationDeleteSessionLabels(session);\n\n'
                 # Only remove the handle from our map if the runtime returned success
                 next_validate_func += '        if (XR_SUCCEEDED(result)) {\n'
 


### PR DESCRIPTION
Replaces #104, which replaced #85 and #86 (contains both of them).  

`Factors out some code about debug messenger data, cleaning it up in the process.
Then, re-uses it in the validation layer too.`

Added a commit to fix the linker error, and created as a new PR because I'm not able to push to @rpavlik 's fork.