### PR TITLE
Cleanup session labels

### DIFF
--- a/src/api_layers/core_validation.cpp
+++ b/src/api_layers/core_validation.cpp
@@ -652,6 +652,15 @@ XrResult CoreValidationXrCreateSession(XrInstance instance, const XrSessionCreat
     }
 }
 
+// Called during xrDestroySession.  We need to delete all session related labels.
+void CoreValidationDeleteSessionLabels(XrSession session) {
+    auto info_with_lock = g_session_info.getWithLock(session);
+    GenValidUsageXrInstanceInfo *gen_instance_info = info_with_lock.second->instance_info;
+    if (nullptr != gen_instance_info) {
+        gen_instance_info->debug_data.DeleteSessionLabels(session);
+    }
+}
+
 // ---- XR_EXT_debug_utils extension commands
 XrResult CoreValidationXrSetDebugUtilsObjectNameEXT(XrInstance instance, const XrDebugUtilsObjectNameInfoEXT *nameInfo) {
     try {

--- a/src/scripts/validation_layer_generator.py
+++ b/src/scripts/validation_layer_generator.py
@@ -2456,7 +2456,7 @@ class ValidationSourceOutputGenerator(AutomaticSourceOutputGenerator):
             elif is_destroy:
                 if last_param.type == 'XrSession':
                     next_validate_func += '\n        // Clean up any labels associated with this session\n'
-                    # next_validate_func += '        CoreValidationDeleteSessionLabels(session);\n\n'
+                    next_validate_func += '        CoreValidationDeleteSessionLabels(session);\n\n'
                 # Only remove the handle from our map if the runtime returned success
                 next_validate_func += '        if (XR_SUCCEEDED(result)) {\n'
 


### PR DESCRIPTION
This should fix a bug in #105 and its predecessor #104 - I accidentally removed, rather than re-implement, CoreValidationDeleteSessionLabels