### PR TITLE
Some fixes to Validation Layer (as found applying to the UE4 OpenXR plugin)

### DIFF
--- a/src/api_layers/core_validation.cpp
+++ b/src/api_layers/core_validation.cpp
@@ -46,6 +46,8 @@
 #define LAYER_EXPORT __attribute__((visibility("default")))
 #elif defined(__SUNPRO_C) && (__SUNPRO_C >= 0x590)
 #define LAYER_EXPORT __attribute__((visibility("default")))
+#elif defined(_MSC_VER)
+#define LAYER_EXPORT __declspec(dllexport)
 #else
 #define LAYER_EXPORT
 #endif

--- a/src/api_layers/core_validation.cpp
+++ b/src/api_layers/core_validation.cpp
@@ -593,9 +593,19 @@ XrResult CoreValidationXrCreateSession(XrInstance instance, const XrSessionCreat
         while (nullptr != cur_ptr) {
             switch (cur_ptr->type) {
                 default:
-                    continue;
+                    break;
+                case XR_TYPE_GRAPHICS_BINDING_VULKAN_KHR:
+                    num_graphics_bindings_found++;
+                    break;
 #ifdef XR_USE_PLATFORM_WIN32
                 case XR_TYPE_GRAPHICS_BINDING_OPENGL_WIN32_KHR:
+                case XR_TYPE_GRAPHICS_BINDING_D3D11_KHR:
+                case XR_TYPE_GRAPHICS_BINDING_D3D12_KHR:
+                    num_graphics_bindings_found++;
+                    break;
+#endif
+#if defined(XR_USE_PLATFORM_ANDROID)
+                case XR_TYPE_GRAPHICS_BINDING_OPENGL_ES_ANDROID_KHR:
                     num_graphics_bindings_found++;
                     break;
 #endif


### PR DESCRIPTION
Added a definition of LAYER_EXPORT for when building with Visual Studio so functions export correctly.
Fixed potential infinite loop in CoreValidationXrCreateSession if first binding is not a graphics binding
Added graphics binding types for Android, Win32, also Vulkan.