### PR TITLE
Include a debug OutputDebugString logger for Win32

### DIFF
--- a/src/loader/loader_logger.cpp
+++ b/src/loader/loader_logger.cpp
@@ -115,6 +115,11 @@ LoaderLogger::LoaderLogger() {
     // Add an error logger by default so that we at least get errors out to std::cerr.
     AddLogRecorder(MakeStdErrLoaderLogRecorder(nullptr));
 
+#if _WIN32
+    // Add an debugger logger by default so that we at least get errors out to the debugger.
+    AddLogRecorder(MakeDebuggerLoaderLogRecorder(nullptr));
+#endif
+
     // If the environment variable to enable loader debugging is set, then enable the
     // appropriate logging out to std::cout.
     std::string debug_string = PlatformUtilsGetEnv("XR_LOADER_DEBUG");

--- a/src/loader/loader_logger.hpp
+++ b/src/loader/loader_logger.hpp
@@ -63,6 +63,7 @@ enum XrLoaderLogType {
     XR_LOADER_LOG_STDERR,
     XR_LOADER_LOG_STDOUT,
     XR_LOADER_LOG_DEBUG_UTILS,
+    XR_LOADER_LOG_DEBUGGER,
 };
 
 class LoaderLogRecorder {

--- a/src/loader/loader_logger_recorders.hpp
+++ b/src/loader/loader_logger_recorders.hpp
@@ -35,6 +35,11 @@ std::unique_ptr<LoaderLogRecorder> MakeStdOutLoaderLogRecorder(void* user_data, 
 std::unique_ptr<LoaderLogRecorder> MakeDebugUtilsLoaderLogRecorder(const XrDebugUtilsMessengerCreateInfoEXT* create_info,
                                                                    XrDebugUtilsMessengerEXT debug_messenger);
 
+#if _WIN32
+//! Win32 debugger output
+std::unique_ptr<LoaderLogRecorder> MakeDebuggerLoaderLogRecorder(void* user_data);
+#endif
+
 // TODO: Add other Derived classes:
 //  - FileLoaderLogRecorder     - During/after xrCreateInstance
 //  - PipeLoaderLogRecorder?    - During/after xrCreateInstance


### PR DESCRIPTION
The loader automatically enables a stderr logger, but this isn't visible in non-Console win32 apps (WinMain). This adds a default debugger output for _WIN32 (OutputDebugString) which should be more useful.