### PR TITLE
Remove debug ext only when added by loader

### DIFF
--- a/src/loader/api_layer_interface.cpp
+++ b/src/loader/api_layer_interface.cpp
@@ -390,7 +390,7 @@ ApiLayerInterface::~ApiLayerInterface() {
     LoaderPlatformLibraryClose(_layer_library);
 }
 
-bool ApiLayerInterface::SupportsExtension(const std::string& extension_name) {
+bool ApiLayerInterface::SupportsExtension(const std::string& extension_name) const {
     bool found_prop = false;
     for (const std::string& supported_extension : _supported_extensions) {
         if (supported_extension == extension_name) {

--- a/src/loader/api_layer_interface.hpp
+++ b/src/loader/api_layer_interface.hpp
@@ -54,7 +54,7 @@ class ApiLayerInterface {
 
     // Generated methods
     void GenUpdateInstanceDispatchTable(XrInstance instance, std::unique_ptr<XrGeneratedDispatchTable>& table);
-    bool SupportsExtension(const std::string& extension_name);
+    bool SupportsExtension(const std::string& extension_name) const;
 
    private:
     std::string _layer_name;

--- a/src/loader/loader_instance.cpp
+++ b/src/loader/loader_instance.cpp
@@ -69,18 +69,14 @@ class InstanceCreateInfoManager {
     // Remove extensions named in the parameter and return a pointer to the current state.
     const XrInstanceCreateInfo* FilterOutExtensions(const std::vector<const char*>& extensions_to_skip) {
         if (enabled_extensions_cstr.empty()) {
-            return &modified_create_info;
+            return Get();
         }
         if (extensions_to_skip.empty()) {
-            return &modified_create_info;
+            return Get();
         }
-        auto b = enabled_extensions_cstr.begin();
-        auto e = enabled_extensions_cstr.end();
-        auto shouldSkipExtension = [&](const char* extensionInQuestion) {
-            auto it = std::find_if(b, e, [&](const char* extension) { return strcmp(extensionInQuestion, extension) == 0; });
-            return it != extensions_to_skip.end();
-        };
-        vector_remove_if_and_erase(enabled_extensions_cstr, shouldSkipExtension);
+        for (auto& ext : extensions_to_skip) {
+            FilterOutExtension(ext);
+        }
         return Update();
     }
     // Remove the extension named in the parameter and return a pointer to the current state.

--- a/src/loader/loader_instance.cpp
+++ b/src/loader/loader_instance.cpp
@@ -48,6 +48,72 @@ const std::array<XrExtensionProperties, 1>& LoaderInstance::LoaderSpecificExtens
     return extensions;
 }
 
+namespace {
+class InstanceCreateInfoManager {
+   public:
+    explicit InstanceCreateInfoManager(const XrInstanceCreateInfo* info) : original_create_info(info), modified_create_info(*info) {
+        Reset();
+    }
+
+    // Reset the "modified" state to match the original state.
+    void Reset() {
+        enabled_extensions_cstr.clear();
+        enabled_extensions_cstr.reserve(original_create_info->enabledExtensionCount);
+
+        for (uint32_t i = 0; i < original_create_info->enabledExtensionCount; ++i) {
+            enabled_extensions_cstr.push_back(original_create_info->enabledExtensionNames[i]);
+        }
+        Update();
+    }
+
+    // Remove extensions named in the parameter and return a pointer to the current state.
+    const XrInstanceCreateInfo* FilterOutExtensions(const std::vector<const char*>& extensions_to_skip) {
+        if (enabled_extensions_cstr.empty()) {
+            return &modified_create_info;
+        }
+        if (extensions_to_skip.empty()) {
+            return &modified_create_info;
+        }
+        auto b = enabled_extensions_cstr.begin();
+        auto e = enabled_extensions_cstr.end();
+        auto shouldSkipExtension = [&](const char* extensionInQuestion) {
+            auto it = std::find_if(b, e, [&](const char* extension) { return strcmp(extensionInQuestion, extension) == 0; });
+            return it != extensions_to_skip.end();
+        };
+        vector_remove_if_and_erase(enabled_extensions_cstr, shouldSkipExtension);
+        return Update();
+    }
+    // Remove the extension named in the parameter and return a pointer to the current state.
+    const XrInstanceCreateInfo* FilterOutExtension(const char* extension_to_skip) {
+        if (enabled_extensions_cstr.empty()) {
+            return &modified_create_info;
+        }
+        auto b = enabled_extensions_cstr.begin();
+        auto e = enabled_extensions_cstr.end();
+        auto it = std::find_if(b, e, [&](const char* extension) { return strcmp(extension_to_skip, extension) == 0; });
+        if (it != e) {
+            // Just that one element goes away
+            enabled_extensions_cstr.erase(it);
+        }
+        return Update();
+    }
+
+    // Get the current modified XrInstanceCreateInfo
+    const XrInstanceCreateInfo* Get() const { return &modified_create_info; }
+
+   private:
+    const XrInstanceCreateInfo* Update() {
+        modified_create_info.enabledExtensionCount = static_cast<uint32_t>(enabled_extensions_cstr.size());
+        modified_create_info.enabledExtensionNames = enabled_extensions_cstr.empty() ? nullptr : enabled_extensions_cstr.data();
+        return &modified_create_info;
+    }
+    const XrInstanceCreateInfo* original_create_info;
+
+    XrInstanceCreateInfo modified_create_info;
+    std::vector<const char*> enabled_extensions_cstr;
+};
+}  // namespace
+
 // Factory method
 XrResult LoaderInstance::CreateInstance(std::vector<std::unique_ptr<ApiLayerInterface>>&& api_layer_interfaces,
                                         const XrInstanceCreateInfo* info, XrInstance* instance) {
@@ -61,6 +127,20 @@ XrResult LoaderInstance::CreateInstance(std::vector<std::unique_ptr<ApiLayerInte
     // Create the loader instance
     std::unique_ptr<LoaderInstance> loader_instance(new LoaderInstance(std::move(api_layer_interfaces)));
     *instance = reinterpret_cast<XrInstance>(loader_instance.get());
+
+    // Remove the loader-supported-extensions (debug utils), if it's in the list of enabled extensions but not supported by
+    // the runtime.
+    InstanceCreateInfoManager create_info_manager{info};
+    const XrInstanceCreateInfo* modified_create_info = info;
+    if (info->enabledExtensionCount > 0) {
+        std::vector<const char*> extensions_to_skip;
+        for (const auto& ext : LoaderInstance::LoaderSpecificExtensions()) {
+            if (!RuntimeInterface::GetRuntime().SupportsExtension(ext.extensionName)) {
+                extensions_to_skip.emplace_back(ext.extensionName);
+            }
+        }
+        modified_create_info = create_info_manager.FilterOutExtensions(extensions_to_skip);
+    }
 
     // Only start the xrCreateApiLayerInstance stack if we have layers.
     std::vector<std::unique_ptr<ApiLayerInterface>>& layer_interfaces = loader_instance->LayerInterfaces();
@@ -110,10 +190,12 @@ XrResult LoaderInstance::CreateInstance(std::vector<std::unique_ptr<ApiLayerInte
         api_layer_ci.loaderInstance = reinterpret_cast<void*>(loader_instance.get());
         api_layer_ci.settings_file_location[0] = '\0';
         api_layer_ci.nextInfo = next_info_list.get();
-        last_error = topmost_cali_fp(info, &api_layer_ci, instance);
+        //! @todo do we filter our create info extension list here?
+        //! Think that actually each layer might need to filter...
+        last_error = topmost_cali_fp(modified_create_info, &api_layer_ci, instance);
 
     } else {
-        last_error = topmost_ci_fp(info, instance);
+        last_error = topmost_ci_fp(modified_create_info, instance);
     }
 
     if (XR_SUCCEEDED(last_error)) {

--- a/src/tests/hello_xr/main.cpp
+++ b/src/tests/hello_xr/main.cpp
@@ -11,7 +11,7 @@ void ShowHelp() {
     // TODO: Improve/update when things are more settled.
     Log::Write(Log::Level::Info,
                "HelloXr --graphics|-g <Graphics API> [--formfactor|-ff <Form factor>] [--viewconfig|-vc <View config>] "
-               "[--blendmode|-bm <Blend mode>] [--space|-s <Space>]");
+               "[--blendmode|-bm <Blend mode>] [--space|-s <Space>] [--verbose|-v]");
     Log::Write(Log::Level::Info, "Graphics APIs:            D3D11, D3D12, OpenGLES, OpenGL, Vulkan");
     Log::Write(Log::Level::Info, "Form factors:             Hmd, Handheld");
     Log::Write(Log::Level::Info, "View configurations:      Mono, Stereo");


### PR DESCRIPTION
Fixes #124 without the side-effects of the other approach (that is, this is an alternate to #123)

cc @yl-msft 

This can be tested with Monado - the master branch reports the support for the extension (though it's not fully implemented), while https://gitlab.freedesktop.org/monado/monado/commits/no-debug-messenger has it disabled for testing purposes.

To test, you can modify hello_xr to require the debug extension as follows:

Find this code in `openxr_program.cpp`:

```c++

        // Create union of extensions required by platform and graphics plugins.
        std::vector<const char*> extensions;
```

and change it to this:

```c++
        // Create union of extensions required by platform and graphics plugins.
        std::vector<const char*> extensions = {XR_EXT_DEBUG_UTILS_EXTENSION_NAME};
```

Note that the `InstanceCreateInfoManager` is intended to be re-usable in other layers, etc that may have a need for pruning the extension list. Also, the current state in this branch is that the extension is removed from the create info even if there are layers that report support for it (none of the built-in ones do so despite actually working with it?) - this might need some fine-tuning. However, it will avoid spurious failures.