### PR TITLE
Fix directory searching for layers

### DIFF
--- a/src/common/filesystem_utils.cpp
+++ b/src/common/filesystem_utils.cpp
@@ -223,12 +223,11 @@ bool FileSysUtilsParsePathList(std::string& path_list, std::vector<std::string>&
 }
 
 bool FileSysUtilsFindFilesInPath(const std::string& path, std::vector<std::string>& files) {
-    // Append "\\*" to file name to list folder contents. This appears to contradict the
-    // MS documentation and example code, but verified empirically
-    std::string starred_path = path + DIRECTORY_SYMBOL + "*";
+    std::string searchPath;
+    FileSysUtilsCombinePaths(path, "*", searchPath);
 
     WIN32_FIND_DATAW file_data;
-    HANDLE file_handle = FindFirstFileW(utf8_to_wide(starred_path).c_str(), &file_data);
+    HANDLE file_handle = FindFirstFileW(utf8_to_wide(searchPath).c_str(), &file_data);
     if (file_handle != INVALID_HANDLE_VALUE) {
         do {
             if (!(file_data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)) {

--- a/src/common/platform_utils.hpp
+++ b/src/common/platform_utils.hpp
@@ -226,10 +226,12 @@ static inline std::string PlatformUtilsGetEnv(const char* name) {
 
     // GetEnvironmentVariable returns string length, excluding null terminator for "get value" call.
     const int length = ::GetEnvironmentVariableW(wname.c_str(), wValueData, (DWORD)wValue.size());
-    if (!length) {
+    if (length == 0) {
         LogError("GetEnvironmentVariable get value error: " + std::to_string(::GetLastError()));
         return {};
     }
+
+    wValue.resize(length); // Strip the null terminator.
 
     return wide_to_utf8(wValue);
 }
@@ -237,7 +239,7 @@ static inline std::string PlatformUtilsGetEnv(const char* name) {
 static inline std::string PlatformUtilsGetSecureEnv(const char* name) {
     // Do not allow high integrity processes to act on data that can be controlled by medium integrity processes.
     if (IsHighIntegrityLevel()) {
-        return nullptr;
+        return {};
     }
 
     // No secure version for Windows so the above integrity check is needed.


### PR DESCRIPTION
The usage of `FindFirstFileW` was incorrectly assuming it just takes a path to a directory. It also requires a filename (which can be a wildcard). In the process of fixing FileSysUtilsFindFilesInPath I found that the std::string that was passed in had a length different than where the null terminator was, which made appending a string break. This null terminator bug was traced to the code that reads the environment variable.