### PR TITLE
Remove shwapi dependency

### DIFF
--- a/src/common/filesystem_utils.cpp
+++ b/src/common/filesystem_utils.cpp
@@ -152,7 +152,10 @@ bool FileSysUtilsFindFilesInPath(const std::string& path, std::vector<std::strin
 
 #elif defined(XR_OS_WINDOWS)
 
-bool FileSysUtilsIsRegularFile(const std::string& path) { return !FileSysUtilsIsDirectory(path); }
+bool FileSysUtilsIsRegularFile(const std::string& path) { 
+    const DWORD attr = GetFileAttributesW(utf8_to_wide(path).c_str());
+    return attr != INVALID_FILE_ATTRIBUTES && !(attr & FILE_ATTRIBUTE_DIRECTORY);
+}
 
 bool FileSysUtilsIsDirectory(const std::string& path) {
     const DWORD attr = GetFileAttributesW(utf8_to_wide(path).c_str());

--- a/src/common/filesystem_utils.cpp
+++ b/src/common/filesystem_utils.cpp
@@ -152,14 +152,16 @@ bool FileSysUtilsFindFilesInPath(const std::string& path, std::vector<std::strin
 
 #elif defined(XR_OS_WINDOWS)
 
-// For pre C++17 compiler that doesn't support experimental filesystem
-#include <shlwapi.h>
+bool FileSysUtilsIsRegularFile(const std::string& path) { return !FileSysUtilsIsDirectory(path); }
 
-bool FileSysUtilsIsRegularFile(const std::string& path) { return (1 != PathIsDirectoryW(utf8_to_wide(path).c_str())); }
+bool FileSysUtilsIsDirectory(const std::string& path) {
+    const DWORD attr = GetFileAttributesW(utf8_to_wide(path).c_str());
+    return attr != INVALID_FILE_ATTRIBUTES && (attr & FILE_ATTRIBUTE_DIRECTORY);
+}
 
-bool FileSysUtilsIsDirectory(const std::string& path) { return (1 == PathIsDirectoryW(utf8_to_wide(path).c_str())); }
-
-bool FileSysUtilsPathExists(const std::string& path) { return (1 == PathFileExistsW(utf8_to_wide(path).c_str())); }
+bool FileSysUtilsPathExists(const std::string& path) {
+    return (GetFileAttributesW(utf8_to_wide(path).c_str()) != INVALID_FILE_ATTRIBUTES);
+}
 
 bool FileSysUtilsIsAbsolutePath(const std::string& path) {
     if ((path[0] == '\\') || (path[1] == ':' && (path[2] == '\\' || path[2] == '/'))) {

--- a/src/common/filesystem_utils.cpp
+++ b/src/common/filesystem_utils.cpp
@@ -152,6 +152,8 @@ bool FileSysUtilsFindFilesInPath(const std::string& path, std::vector<std::strin
 
 #elif defined(XR_OS_WINDOWS)
 
+// For pre C++17 compiler that doesn't support experimental filesystem
+
 bool FileSysUtilsIsRegularFile(const std::string& path) { 
     const DWORD attr = GetFileAttributesW(utf8_to_wide(path).c_str());
     return attr != INVALID_FILE_ATTRIBUTES && !(attr & FILE_ATTRIBUTE_DIRECTORY);

--- a/src/loader/CMakeLists.txt
+++ b/src/loader/CMakeLists.txt
@@ -166,7 +166,6 @@ elseif(WIN32)
         endforeach()
     endif()
 
-    target_link_libraries(openxr_loader shlwapi)
     target_compile_options(openxr_loader PRIVATE)
     generate_export_header(openxr_loader)
     # set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS false)


### PR DESCRIPTION
Rather than use the shwapi APIs (PathIsDirectoryW/PathFileExistsW) this changes to use GetFileAttributesW instead (kernel32.dll). This removes a dependency and also makes the loader WACK (Windows App Cert Kit) compliant.