### PR TITLE
Write output atomically at the end

### DIFF
--- a/specification/scripts/generator.py
+++ b/specification/scripts/generator.py
@@ -580,7 +580,7 @@ class OutputGenerator:
                 directory = Path(self.genOpts.directory)
                 if not Path.exists(directory):
                     os.makedirs(directory)
-            shutil.copy(self.outFile.name, self.genOpts.directory + '/' + self.genOpts.filename)
+            shutil.move(self.outFile.name, self.genOpts.directory + '/' + self.genOpts.filename)
         self.genOpts = None
 
     def beginFeature(self, interface, emit):


### PR DESCRIPTION
The behavior of the generator, to truncate it's output file at the start and then to write it all at the end is annoying when you're debugging one of the generators and also have the output file open in an editor in the debugger, because it keeps forcing the open editor back to the start of an empty file.

This PR resolves the problem by writing output to a tempfile and then at the end atomically replacing existing files with the tempfile.  This allows an open editor in tools like VS Code to retain their existing position in the file.