### PR TITLE
Fix hello_xr when running under Linux OpenGL X11

### DIFF
--- a/src/common/gfxwrapper_opengl.h
+++ b/src/common/gfxwrapper_opengl.h
@@ -186,7 +186,7 @@ Platform headers / declarations
 #elif defined(OS_LINUX)
 
 #define OPENGL_VERSION_MAJOR 4
-#define OPENGL_VERSION_MINOR 3
+#define OPENGL_VERSION_MINOR 5
 #define GLSL_VERSION "430"
 #define SPIRV_VERSION "99"
 #define USE_SYNC_OBJECT 0  // 0 = GLsync, 1 = EGLSyncKHR, 2 = storage buffer

--- a/src/tests/hello_xr/graphicsplugin_opengl.cpp
+++ b/src/tests/hello_xr/graphicsplugin_opengl.cpp
@@ -115,13 +115,18 @@ struct OpenGLGraphicsPlugin : public IGraphicsPlugin {
         m_graphicsBinding.hDC = window.context.hDC;
         m_graphicsBinding.hGLRC = window.context.hGLRC;
 #elif defined(XR_USE_PLATFORM_XLIB)
-        // TODO: Just need something other than NULL here for now (for validation).  Eventually need
-        //       to correctly put in a valid pointer to an Display
-        m_graphicsBinding.xDisplay = reinterpret_cast<Display*>(0xFFFFFFFF);
+        m_graphicsBinding.xDisplay = window.context.xDisplay;
+        m_graphicsBinding.visualid = window.context.visualid;
+        m_graphicsBinding.glxFBConfig = window.context.glxFBConfig;
+        m_graphicsBinding.glxDrawable = window.context.glxDrawable;
+        m_graphicsBinding.glxContext = window.context.glxContext;
 #elif defined(XR_USE_PLATFORM_XCB)
-        // TODO: Just need something other than NULL here for now (for validation).  Eventually need
-        //       to correctly put in a valid pointer to an xcb_connection_t
-        m_graphicsBinding.connection = reinterpret_cast<xcb_connection_t*>(0xFFFFFFFF);
+        m_graphicsBinding.connection = window.context.connection;
+        m_graphicsBinding.screenNumber = window.context.screenNumber;
+        m_graphicsBinding.fbconfigid = window.context.fbconfigid;
+        m_graphicsBinding.visualid = window.context.visualid;
+        m_graphicsBinding.glxDrawable = window.context.glxDrawable;
+        m_graphicsBinding.glxContext = window.context.glxContext;
 #elif defined(XR_USE_PLATFORM_WAYLAND)
         // TODO: Just need something other than NULL here for now (for validation).  Eventually need
         //       to correctly put in a valid pointer to an wl_display


### PR DESCRIPTION
This relates to #41, but only fixes it when using Xlib and XCB, not for Wayland. This also fixes a separate issue I had on my own machine with Monado's OpenGL graphics requirements.