### PR TITLE
Single instance loader with forward compatibility

### DIFF
--- a/specification/loader/api_layer.adoc
+++ b/specification/loader/api_layer.adoc
@@ -15,11 +15,15 @@ cooperate to ensure the correct sequencing of calls from one entity to the
 next. This group effort for call chain sequencing is hereinafter referred to as
 *distributed dispatch*.
 
+If an API layer does not wish to intercept a command, it must forward the
+request made to its `xrGetInstanceProcAddr` implementation (provided through
+pname:getInstanceProcAddr) down to the next `xrGetInstanceProcAddr`
+implementation in the call chain (provided to the API layer through
+pname:nextGetInstanceProcAddr).
+
 In distributed dispatch each API layer is responsible for properly calling the next
 entity in the call chain. This means that a dispatch mechanism is required for
-all OpenXR commands that an API layer intercepts. If an OpenXR command is not
-intercepted by an API layer, or if an API layer chooses to terminate the function by not
-calling down the chain, then no dispatch is needed for that particular function.
+all OpenXR commands that an API layer intercepts.
 
 For example, if the enabled API layers intercepted only certain functions,
 the call chain would look as follows:
@@ -872,7 +876,7 @@ struct XrApiLayerCreateInfo {
   * pname:structVersion is the version of the structure being supplied by the
     loader.
   * pname:structSize is the size of the structure supplied by the loader.
-  * pname:loaderInstance is the `XrInstance` used by the loader.
+  * pname:loaderInstance is deprecated and must be ignored.
   * pname:settings_file_location is the location of any API layer settings file
     that can be used.  This is currently unused.
   * pname:nextInfo is a pointer to the slink:XrApiLayerNextInfo structure which

--- a/specification/loader/application.adoc
+++ b/specification/loader/application.adoc
@@ -124,11 +124,6 @@ which could potentially increase performance.  In that case, most commands
 would use the following call chain:
 
 image::images/app_dispatch_table_call_chain.svg[align="center", title="Call Chain For Application Dispatch"]
- 
-Instance commands (i.e. those commands taking an `XrInstance` as its primary
-parameter), will always require a trampoline because they need to convert
-the instance to access the appropriate dispatch table, and to pass down the
-`XrInstance` value that was actually created in the API layers/runtime below it.
 
 
 [[openxr-loader-library-name]]
@@ -142,7 +137,7 @@ common OSs:
 |====
 | Operating System   | Loader Library Name
 | Windows
-    | openxr-loader-<major>_<minor>.lib/.dll
+    | openxr-loader.lib/.dll
 | Linux
     | libopenxr_loader.so.<major>
 |====

--- a/specification/loader/design.adoc
+++ b/specification/loader/design.adoc
@@ -242,12 +242,7 @@ static XrResult ApiLayerInterface::LoadApiLayers(
 ==== The LoaderInstance Class ====
 
 The primary OpenXR object is the `XrInstance`, and from that most other data
-is either queried or created.  In many ways, the `XrInstance` object is a
-loader object that manages all the other underlying OpenXR objects/handles.
-Because of this, a large amount of data needs to be associated with it by
-the loader.
-In order to do this, the loader maps an internal `LoaderInstance` object
-pointer to the returned `XrInstance` value.
+is either queried or created.
 
 A `LoaderInstance` is created during the OpenXR `xrCreateInstance` call, and
 destroyed during the `xrDestroyInstance` call.
@@ -258,10 +253,19 @@ During `xrCreateInstance` the loader code calls
 [source,c++]
 ----
 static XrResult LoaderInstance::CreateInstance(
-        std::vector<std::unique_ptr<ApiLayerInterface>>& api_layer_interfaces,
-        const XrInstanceCreateInfo* info,
-        XrInstance* instance);
+        PFN_xrGetInstanceProcAddr get_instance_proc_addr_term,
+        PFN_xrCreateInstance create_instance_term,
+        PFN_xrCreateApiLayerInstance create_api_layer_instance_term,
+        std::vector<std::unique_ptr<ApiLayerInterface>> layer_interfaces,
+        const XrInstanceCreateInfo* createInfo,
+        std::unique_ptr<LoaderInstance>* loader_instance);
 ----
+  * pname:get_instance_proc_addr_term is the function pointer to the
+    terminator for xrGetInstanceProcAddr.
+  * pname:create_instance_term is the function pointer to the
+    terminator for xrCreateInstance.
+  * pname:create_api_layer_instance_term is the function pointer to the
+    terminator for xrCreateApiLayerInstance.
   * pname:api_layer_interfaces is a vector that contains a unique_ptr to all
     `ApiLayerInterface` objects that are valid and enabled.  All of these
     pointers will be moved to the `LoaderInstance` on successful completion
@@ -279,8 +283,8 @@ work:
   `xrGetInstanceProcAddr` that passes through all enabled API layers and the
   runtime.
 * Create the instance using the generated `xrCreateInstance` call chain.
-* Create a parallel `LoaderInstance*` associated with the returned
-  `XrInstance` using a C++ "unordered_map"
+* Create a parallel `LoaderInstance` associated with the returned
+  `XrInstance`.
 * Generate a top-level dispatch table containing all the supported commands.
 ** This table is built by using the generated `xrGetInstanceProcAddr`
    call chain
@@ -564,81 +568,10 @@ they can be referenced in the `xr_loader_generated.cpp` source file which
 is used for `xrGetInstanceProcAddr` as well as setting up the loader
 dispatch table.
 
-Also included is a utility function prototype that will initialize a
-`LoaderInstance` dispatch table:
-
-[[LoaderGenInitInstanceDispatchTable]]
-[source,c++]
-----
-void LoaderGenInitInstanceDispatchTable(
-        XrInstance runtime_instance,
-        std::unique_ptr<XrGeneratedDispatchTable>& table);
-----
-  * pname:runtime_instance is the `XrInstance` returned by the runtime
-    on the related call to fname:xrCreateInstance and that should be
-    used to initialize pname:table.
-  * pname:table is the dispatch table to initialize.
-
-Additionally, this file contains extern prototypes for instances of the
-`HandleLoaderMap<>` class template, containing mainly an `unordered_map`
-and a `mutex`, that are used for storing the created OpenXR Object handles
-and relating them to their parent `XrInstance`.  There should be one
-`HandleLoaderMap<>` instance for each OpenXR Object Handle type.  See the
-<<functional-flow, Functional Flow>> section for more information about
-the usage of these.
-
-This file also contains the prototype of a function that is used to
-clean up the OpenXR Object unordered_maps entries related to a
-`LoaderInstance` that is being deleted:
-
-[[LoaderCleanUpMapsForInstance]]
-[source,c++]
-----
-void LoaderCleanUpMapsForInstance(
-        class LoaderInstance *instance);
-----
-  * pname:loader_instance is a pointer to the `LoaderInstance`
-    that is going away and needs all references removed from all the
-    global state.
-
 ==== xr_loader_generated.cpp ====
 
 The `xr_loader_generated.cpp` source file contains the implementation
 of all generated OpenXR trampoline functions.
-
-For example, it contains the implementations of
-flink:LoaderGenInitInstanceDispatchTable and
-flink:LoaderCleanUpMapsForInstance.
-
-It also includes a function automatically generated for the `ApiLayerInterface`
-class that will update a dispatch table for that class,
-`ApiLayerInterface`::fname:GenUpdateInstanceDispatchTable.  The function
-calls the API layer's version of `xrGetInstanceProcAddr` to populate the various
-entries in a `XrGeneratedDispatchTable`.
-
-[source,c++]
-----
-void ApiLayerInterface::GenUpdateInstanceDispatchTable(
-        XrInstance instance,
-        std::unique_ptr<XrGeneratedDispatchTable>& table);
-----
-  * pname:instance is the instance returned by the next component in the call-chain
-    during fname:xrCreateInstance and is used with the next component's
-    fname:xrGetInstanceProcAddr call.
-  * pname:table is a reference to the table to update with the
-    `ApiLayerInterface` 's API layer version of the fname:xrGetInstanceProcAddr.
-
-Because this is an API layer, it will only populate the entry of a dispatch table if
-the API layer's `xrGetInstanceProcAddr` returns non-`NULL` for that command.  This is
-because the loader calls this command to generate the top-level dispatch table
-when setting up the <<openxr-call-chains,call chain>>.  The loader starts
-by creating a dispatch table pointing to the runtime commands.  It then
-reverse increments through all enabled API layers, calling `ApiLayerInterface`::
-fname:GenUpdateInstanceDispatchTable for each API layer, which replaces only
-the commands that the specific API layer implements.  This results in a
-dispatch table whose elements point to only the first implementation of each
-OpenXR command.
-
 
 [[manually-implemented-code]]
 === Manually Implemented Code ===
@@ -675,174 +608,14 @@ implemented in the loader.
       chain back to the standard `xrCreateInstance` path.
 |====
 
-
 [[functional-flow]]
 === Functional Flow ===
 
-The OpenXR loader makes all its decisions using OpenXR objects.
-The loader's main goal when dealing with OpenXR objects is to find the
-parent `LoaderInstance` for a given object.
-This parent `LoaderInstance` stores the dispatch table to use when calling any
-OpenXR command, so without the instance, the loader has no knowledge of where
-to send a command.
-This is because an application may create more than one `XrInstance`, with
-some of the instances having API layers enabled and some without.
-Without knowing which parent instance to use, the loader could end up calling
-an incorrect sequence of commands.
-
-
-==== Correlating an Object to Its Parent XrInstance ====
-
-The loader automatic generated code tracks all OpenXR Object Handle types
-using an `HandleLoaderMap<>` containing an
-https://en.cppreference.com/w/cpp/container/unordered_map[unordered_map]
-and a mutex.
-Each type has it's own `HandleLoaderMap<>` associated with it.
-This `HandleLoaderMap<>` correlates an object against its parent `LoaderInstance` pointer.
-
-[example]
-.HandleLoaderMap Correlating XrSession to LoaderInstance*
-====
-[source,c++]
-----
-HandleLoaderMap<XrSession> g_session_map;
-----
-====
-
-Automatic code generation is used by capturing every `xrCreate` call,
-determining the parent object type and then determining the created object
-type.
-When triggered, the call first proceeds normally down the call chain.
-However, upon returning, an entry is created in this `HandleLoaderMap`.
-When a handle is received, the loader first looks up the parent
-`LoaderInstance` pointer using the `HandleLoaderMap` associated with the handle
-type.
-Once we have the parent object's `LoaderInstance*`, we create an entry using
-this value in our new object type's `HandleLoaderMap`.
-
-[example]
-.HandleLoaderMap Creation examples
-====
-
-Here's an example of how the automatically generated code looks for both
-accessing and creating an object which receives the `LoaderInstance*` as its
-parent.
-To determine the `LoaderInstance*` associated with the incoming `XrInstance`,
-you can see the lookup using the `g_instance_map` HandleLoaderMap.
-Then, a new value associates the recently created `XrSession` with the
-same `LoaderInstance*`.
-
-[source,c++]
-----
-XRAPI_ATTR XrResult XRAPI_CALL xrCreateSession(
-    XrInstance                                  instance,
-    const XrSessionCreateInfo*                  createInfo,
-    XrSession*                                  session) XRLOADER_ABI_TRY {
-
-    LoaderInstance *loader_instance = g_instance_map.Get(instance);
-    if (nullptr == loader_instance) {
-        LoaderLogger::LogValidationErrorMessage(
-            "VUID-xrCreateSession-instance-parameter", "xrCreateSession",
-            "instance is not a valid XrInstance",
-            {XrSdkLogObjectInfo{instance, XR_OBJECT_TYPE_INSTANCE}});
-        return XR_ERROR_HANDLE_INVALID;
-    }
-    const std::unique_ptr<XrGeneratedDispatchTable> &dispatch_table =
-        loader_instance->DispatchTable();
-    XrResult result = XR_SUCCESS;
-    result = dispatch_table->CreateSession(instance, createInfo, session);
-    if (XR_SUCCESS == result && nullptr != session) {
-        XrResult insert_result =
-            g_session_map.Insert(*session, *loader_instance);
-        if (XR_FAILED(insert_result)) {
-            LoaderLogger::LogErrorMessage("xrCreateSession",
-                                          "Failed inserting new session into "
-                                          "map: may be null or not unique");
-        }
-    }
-    return result;
-}
-XRLOADER_ABI_CATCH_FALLBACK
-----
-====
-
-Of course, all this is cleaned up when the appropriate `xrDestroy` command
-is called.
-
-[example]
-====
-[source,c++]
-----
-XRAPI_ATTR XrResult XRAPI_CALL xrDestroySession(
-    XrSession                                   session)
-    XRLOADER_ABI_TRY {
-    LoaderInstance *loader_instance = g_session_map.Get(session);
-    // Destroy the mapping entry for this item if it was valid.
-    if (nullptr != loader_instance) {
-        g_session_map.Erase(session);
-    }
-    if (nullptr == loader_instance) {
-        LoaderLogger::LogValidationErrorMessage(
-            "VUID-xrDestroySession-session-parameter", "xrDestroySession",
-            "session is not a valid XrSession",
-            {XrSdkLogObjectInfo{session, XR_OBJECT_TYPE_SESSION}});
-        return XR_ERROR_HANDLE_INVALID;
-    }
-    const std::unique_ptr<XrGeneratedDispatchTable> &dispatch_table =
-        loader_instance->DispatchTable();
-    XrResult result = XR_SUCCESS;
-    result = dispatch_table->DestroySession(session);
-    return result;
-}
-XRLOADER_ABI_CATCH_FALLBACK
-----
-====
-
-If a call to `xrDestroyInstance` is made before any objects related to the
-`XrInstance` have been destroyed, they are still properly cleaned up by the
-loader.
-This is because the loader's `xrDestroyInstance` command calls
-flink:LoaderCleanUpMapsForInstance to clean up all unordered_maps entries
-associated with the instance before it's destroyed.
-
-
-==== Protecting the Unordered_Map Content ====
-
-In order to properly protect the contents of the unordered_map in a
-multithreading scenario, we use a std::mutex per unordered_map to
-control when the loader writes to, or reads from, the unordered_map.
-
-In general, use of these mutexes is handled automatically by the
-`HandleLoaderMap<>` class template.
-
-==== Potential Problems ====
-
-The OpenXR loader could run into issues, even with this design, under
-certain scenarios:
-
-.Loader Problem Scenario 1
-
-If an application creates its own OpenXR command dispatch table, but still
-also uses OpenXR commands exported directly from the loader, we could see an
-issue.  The issue arises if the application calls `xrCreate` for an object
-using the dispatch table it generated.  This would cause the `xrCreate`
-command to bypass the loader's trampoline call (which is where the
-unordered_map behavior exists). In this case, the loader would not create an
-entry in the unordered_map. The problem becomes obvious if the user calls a
-loader export which uses that command.  Now, the loader has no way of finding
-the parent instance.  The loader could make a logical guess, but it may choose
-the wrong parent instance if more than one has been created.
-
-[WARNING]
-.TODO (i/761)
-====
-* What do we do here?
-** I suggest we disallow mixing and matching using loader exports with
-   application generated dispatch tables.
-** At least where commands could take a different path for `xrCreate`
-   and usage.
-====
-
+The loader supports a single XrInstance at a time in order to avoid
+tracingk handle values and their relationship to the `LoaderInstance`. Every
+XR function call is assumed to be for the single XrInstance that has been
+created. This enables the loader to work with future extensions and handle types
+without change.
 
 [[platform-specific-behavior]]
 === Platform-Specific Behavior ===

--- a/specification/loader/overview.adoc
+++ b/specification/loader/overview.adoc
@@ -138,7 +138,7 @@ that includes each function selected by the layer. At `xrCreateInstance` time th
 loader initializes all enabled API layers and creates call
 chains for each OpenXR command, with each entry of the resulting dispatch table 
 pointing to the first element of that chain. The loader builds an individual 
-dispatch table for each `XrInstance` that is created.
+dispatch table for the `XrInstance` that is created.
 
 When an application calls an OpenXR command, this typically will first hit a
 _trampoline_ function in the loader.  These _trampoline_ functions are small,
@@ -149,7 +149,5 @@ process data before proceeding to the appropriate runtime.
 
 image::images/call_chain_example.svg[align="center", title="Example Call Chain"]
 
-The loader associates all OpenXR objects with their parent `XrInstance` on 
-creation. For OpenXR API commands which don't include an `XrInstance` explicitly, 
-the loader uses the stored parent information to identify the appropriate 
-call chain to be dispatched.
+The loader only allows a single outstanding `XrInstance` and uses the generated
+dispatch table for that `XrInstance` for all OpenXR API commands.

--- a/src/api_layers/api_dump.cpp
+++ b/src/api_layers/api_dump.cpp
@@ -454,8 +454,7 @@ XrResult ApiDumpLayerXrCreateApiLayerInstance(const XrInstanceCreateInfo *info, 
         // Validate the API layer info and next API layer info structures before we try to use them
         if (nullptr == apiLayerInfo || XR_LOADER_INTERFACE_STRUCT_API_LAYER_CREATE_INFO != apiLayerInfo->structType ||
             XR_API_LAYER_CREATE_INFO_STRUCT_VERSION > apiLayerInfo->structVersion ||
-            sizeof(XrApiLayerCreateInfo) > apiLayerInfo->structSize || nullptr == apiLayerInfo->loaderInstance ||
-            nullptr == apiLayerInfo->nextInfo ||
+            sizeof(XrApiLayerCreateInfo) > apiLayerInfo->structSize || nullptr == apiLayerInfo->nextInfo ||
             XR_LOADER_INTERFACE_STRUCT_API_LAYER_NEXT_INFO != apiLayerInfo->nextInfo->structType ||
             XR_API_LAYER_NEXT_INFO_STRUCT_VERSION > apiLayerInfo->nextInfo->structVersion ||
             sizeof(XrApiLayerNextInfo) > apiLayerInfo->nextInfo->structSize ||

--- a/src/common/platform_utils.hpp
+++ b/src/common/platform_utils.hpp
@@ -242,7 +242,8 @@ static inline std::string PlatformUtilsGetEnv(const char* name) {
     const std::wstring wname = utf8_to_wide(name);
     const DWORD valSize = ::GetEnvironmentVariableW(wname.c_str(), nullptr, 0);
     // GetEnvironmentVariable returns 0 when environment variable does not exist or there is an error.
-    if (valSize == 0) {
+    // The size includes the null-terminator, so a size of 1 is means the variable was explicitly set to empty.
+    if (valSize == 0 || valSize == 1) {
         return {};
     }
 

--- a/src/loader/api_layer_interface.hpp
+++ b/src/loader/api_layer_interface.hpp
@@ -53,7 +53,6 @@ class ApiLayerInterface {
     std::string LayerName() { return _layer_name; }
 
     // Generated methods
-    void GenUpdateInstanceDispatchTable(XrInstance instance, std::unique_ptr<XrGeneratedDispatchTable>& table);
     bool SupportsExtension(const std::string& extension_name) const;
 
    private:

--- a/src/loader/loader_core.cpp
+++ b/src/loader/loader_core.cpp
@@ -42,12 +42,25 @@
 #include <string>
 #include <utility>
 #include <vector>
-
 // Global lock to prevent reading JSON manifest files at the same time.
 static std::mutex g_loader_json_mutex;
 
 // Global lock to prevent simultaneous instance creation/destruction
-static std::mutex g_loader_instance_mutex;
+static std::mutex g_instance_create_destroy_mutex;
+
+// Terminal functions needed by xrCreateInstance.
+XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermGetInstanceProcAddr(XrInstance, const char *, PFN_xrVoidFunction *);
+XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermCreateInstance(const XrInstanceCreateInfo *, XrInstance *);
+XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermCreateApiLayerInstance(const XrInstanceCreateInfo *, const struct XrApiLayerCreateInfo *,
+                                                                  XrInstance *);
+XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermSetDebugUtilsObjectNameEXT(XrInstance, const XrDebugUtilsObjectNameInfoEXT *);
+XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermCreateDebugUtilsMessengerEXT(XrInstance, const XrDebugUtilsMessengerCreateInfoEXT *,
+                                                                        XrDebugUtilsMessengerEXT *);
+XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermDestroyDebugUtilsMessengerEXT(XrDebugUtilsMessengerEXT);
+XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermSubmitDebugUtilsMessageEXT(XrInstance instance,
+                                                                      XrDebugUtilsMessageSeverityFlagsEXT messageSeverity,
+                                                                      XrDebugUtilsMessageTypeFlagsEXT messageTypes,
+                                                                      const XrDebugUtilsMessengerCallbackDataEXT *callbackData);
 
 // Utility template function meant to validate if a fixed size string contains
 // a null-terminator.
@@ -220,10 +233,22 @@ LOADER_EXPORT XRAPI_ATTR XrResult XRAPI_CALL xrCreateInstance(const XrInstanceCr
         return XR_ERROR_VALIDATION_FAILURE;
     }
 
+    std::unique_lock<std::mutex> instance_lock(g_instance_create_destroy_mutex);
+
+    // Check if there is already an XrInstance that is alive. If so, another instance cannot be created.
+    // The loader does not support multiple simultaneous instances because the loader is intended to be
+    // usable by apps using future OpenXR APIs (through xrGetInstanceProcAddr). Because the loader would
+    // not be aware of new handle types, it would not be able to look up the appropriate dispatch table
+    // in some cases.
+    if (ActiveLoaderInstance::IsAvailable()) {  // If there is an XrInstance already alive.
+        LoaderLogger::LogErrorMessage("xrCreateInstance", "Loader does not support simultaneous XrInstances");
+        return XR_ERROR_LIMIT_REACHED;
+    }
+
     std::vector<std::unique_ptr<ApiLayerInterface>> api_layer_interfaces;
+    XrResult result;
 
     // Make sure only one thread is attempting to read the JSON files and use the instance.
-    XrResult result;
     {
         std::unique_lock<std::mutex> json_lock(g_loader_json_mutex);
         // Load the available runtime
@@ -248,17 +273,21 @@ LOADER_EXPORT XRAPI_ATTR XrResult XRAPI_CALL xrCreateInstance(const XrInstanceCr
         return result;
     }
 
-    std::unique_lock<std::mutex> instance_lock(g_loader_instance_mutex);
-
     // Create the loader instance (only send down first runtime interface)
-    XrInstance created_instance = XR_NULL_HANDLE;
-    result = LoaderInstance::CreateInstance(std::move(api_layer_interfaces), info, &created_instance);
+
+    LoaderInstance *loader_instance = nullptr;
+    {
+        std::unique_ptr<LoaderInstance> owned_loader_instance;
+        result = LoaderInstance::CreateInstance(LoaderXrTermGetInstanceProcAddr, LoaderXrTermCreateInstance,
+                                                LoaderXrTermCreateApiLayerInstance, std::move(api_layer_interfaces), info,
+                                                &owned_loader_instance);
+        if (XR_SUCCEEDED(result)) {
+            loader_instance = owned_loader_instance.get();
+            result = ActiveLoaderInstance::Set(std::move(owned_loader_instance), "xrCreateInstance");
+        }
+    }
 
     if (XR_SUCCEEDED(result)) {
-        *instance = created_instance;
-
-        LoaderInstance *loader_instance = g_instance_map.Get(created_instance);
-
         // Create a debug utils messenger if the create structure is in the "next" chain
         const auto *next_header = reinterpret_cast<const XrBaseInStructure *>(info->next);
         const XrDebugUtilsMessengerCreateInfoEXT *dbg_utils_create_info = nullptr;
@@ -267,7 +296,7 @@ LOADER_EXPORT XRAPI_ATTR XrResult XRAPI_CALL xrCreateInstance(const XrInstanceCr
                 LoaderLogger::LogInfoMessage("xrCreateInstance", "Found XrDebugUtilsMessengerCreateInfoEXT in \'next\' chain.");
                 dbg_utils_create_info = reinterpret_cast<const XrDebugUtilsMessengerCreateInfoEXT *>(next_header);
                 XrDebugUtilsMessengerEXT messenger;
-                result = xrCreateDebugUtilsMessengerEXT(*instance, dbg_utils_create_info, &messenger);
+                result = xrCreateDebugUtilsMessengerEXT(loader_instance->GetInstanceHandle(), dbg_utils_create_info, &messenger);
                 if (XR_FAILED(result)) {
                     return XR_ERROR_VALIDATION_FAILURE;
                 }
@@ -276,6 +305,13 @@ LOADER_EXPORT XRAPI_ATTR XrResult XRAPI_CALL xrCreateInstance(const XrInstanceCr
             }
             next_header = reinterpret_cast<const XrBaseInStructure *>(next_header->next);
         }
+    }
+
+    if (XR_SUCCEEDED(result)) {
+        *instance = loader_instance->GetInstanceHandle();
+    } else {
+        // Ensure the global loader instance is destroyed if something went wrong.
+        ActiveLoaderInstance::Remove();
     }
 
     LoaderLogger::LogVerboseMessage("xrCreateInstance", "Completed loader trampoline");
@@ -287,14 +323,16 @@ LOADER_EXPORT XRAPI_ATTR XrResult XRAPI_CALL xrDestroyInstance(XrInstance instan
     LoaderLogger::LogVerboseMessage("xrDestroyInstance", "Entering loader trampoline");
     // Runtimes may detect XR_NULL_HANDLE provided as a required handle parameter and return XR_ERROR_HANDLE_INVALID. - 2.9
     if (XR_NULL_HANDLE == instance) {
+        LoaderLogger::LogErrorMessage("xrDestroyInstance", "Instance handle is XR_NULL_HANDLE.");
         return XR_ERROR_HANDLE_INVALID;
     }
 
-    LoaderInstance *const loader_instance = g_instance_map.Get(instance);
-    if (loader_instance == nullptr) {
-        LoaderLogger::LogValidationErrorMessage("VUID-xrDestroyInstance-instance-parameter", "xrDestroyInstance",
-                                                "invalid instance");
-        return XR_ERROR_HANDLE_INVALID;
+    std::unique_lock<std::mutex> loader_instance_lock(g_instance_create_destroy_mutex);
+
+    LoaderInstance *loader_instance;
+    XrResult result = ActiveLoaderInstance::Get(&loader_instance, "xrDestroyInstance");
+    if (XR_FAILED(result)) {
+        return result;
     }
 
     const std::unique_ptr<XrGeneratedDispatchTable> &dispatch_table = loader_instance->DispatchTable();
@@ -310,12 +348,10 @@ LOADER_EXPORT XRAPI_ATTR XrResult XRAPI_CALL xrDestroyInstance(XrInstance instan
         LoaderLogger::LogErrorMessage("xrDestroyInstance", "Unknown error occurred calling down chain");
     }
 
-    // Cleanup any map entries that may still be using this instance
-    LoaderCleanUpMapsForInstance(loader_instance);
+    // Get rid of the loader instance. This will make it possible to create another instance in the future.
+    ActiveLoaderInstance::Remove();
 
     // Lock the instance create/destroy mutex
-    std::unique_lock<std::mutex> loader_instance_lock(g_loader_instance_mutex);
-    delete loader_instance;
     LoaderLogger::LogVerboseMessage("xrDestroyInstance", "Completed loader trampoline");
 
     // Finally, unload the runtime if necessary
@@ -380,7 +416,6 @@ static XrResult ValidateInstanceCreateInfo(const XrInstanceCreateInfo *info) {
 XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermCreateInstance(const XrInstanceCreateInfo *createInfo,
                                                           XrInstance *instance) XRLOADER_ABI_TRY {
     LoaderLogger::LogVerboseMessage("xrCreateInstance", "Entering loader terminator");
-    LoaderInstance *loader_instance = reinterpret_cast<LoaderInstance *>(*instance);
     XrResult result = ValidateInstanceCreateInfo(createInfo);
     if (XR_FAILED(result)) {
         LoaderLogger::LogValidationErrorMessage("VUID-xrCreateInstance-info-parameter", "xrCreateInstance",
@@ -388,7 +423,6 @@ XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermCreateInstance(const XrInstanceCreate
         return result;
     }
     result = RuntimeInterface::GetRuntime().CreateInstance(createInfo, instance);
-    loader_instance->SetRuntimeInstance(*instance);
     LoaderLogger::LogVerboseMessage("xrCreateInstance", "Completed loader terminator");
     return result;
 }
@@ -401,11 +435,47 @@ XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermCreateApiLayerInstance(const XrInstan
 }
 
 XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermDestroyInstance(XrInstance instance) XRLOADER_ABI_TRY {
-    XrResult result;
     LoaderLogger::LogVerboseMessage("xrDestroyInstance", "Entering loader terminator");
-    result = RuntimeInterface::GetRuntime().DestroyInstance(instance);
+    XrResult result = RuntimeInterface::GetRuntime().DestroyInstance(instance);
     LoaderLogger::LogVerboseMessage("xrDestroyInstance", "Completed loader terminator");
     return result;
+}
+XRLOADER_ABI_CATCH_FALLBACK
+
+XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermGetInstanceProcAddr(XrInstance instance, const char *name,
+                                                               PFN_xrVoidFunction *function) XRLOADER_ABI_TRY {
+    // A few instance commands need to go through a loader terminator.
+    // Otherwise, go directly to the runtime version of the command if it exists.
+    // But first set the function pointer to NULL so that the fall-through below actually works.
+    *function = nullptr;
+
+    // NOTE: ActiveLoaderInstance cannot be used in this function because it is called before an instance is made active.
+
+    if (0 == strcmp(name, "xrGetInstanceProcAddr")) {
+        *function = reinterpret_cast<PFN_xrVoidFunction>(LoaderXrTermGetInstanceProcAddr);
+    } else if (0 == strcmp(name, "xrCreateInstance")) {
+        *function = reinterpret_cast<PFN_xrVoidFunction>(LoaderXrTermCreateInstance);
+    } else if (0 == strcmp(name, "xrDestroyInstance")) {
+        *function = reinterpret_cast<PFN_xrVoidFunction>(LoaderXrTermDestroyInstance);
+    } else if (0 == strcmp(name, "xrSetDebugUtilsObjectNameEXT")) {
+        *function = reinterpret_cast<PFN_xrVoidFunction>(LoaderXrTermSetDebugUtilsObjectNameEXT);
+    } else if (0 == strcmp(name, "xrCreateDebugUtilsMessengerEXT")) {
+        *function = reinterpret_cast<PFN_xrVoidFunction>(LoaderXrTermCreateDebugUtilsMessengerEXT);
+    } else if (0 == strcmp(name, "xrDestroyDebugUtilsMessengerEXT")) {
+        *function = reinterpret_cast<PFN_xrVoidFunction>(LoaderXrTermDestroyDebugUtilsMessengerEXT);
+    } else if (0 == strcmp(name, "xrSubmitDebugUtilsMessageEXT")) {
+        *function = reinterpret_cast<PFN_xrVoidFunction>(LoaderXrTermSubmitDebugUtilsMessageEXT);
+    } else if (0 == strcmp(name, "xrCreateApiLayerInstance")) {
+        // Special layer version of xrCreateInstance terminator.  If we get called this by a layer,
+        // we simply re-direct the information back into the standard xrCreateInstance terminator.
+        *function = reinterpret_cast<PFN_xrVoidFunction>(LoaderXrTermCreateApiLayerInstance);
+    }
+
+    if (nullptr != *function) {
+        return XR_SUCCESS;
+    }
+
+    return RuntimeInterface::GetInstanceProcAddr(instance, name, function);
 }
 XRLOADER_ABI_CATCH_FALLBACK
 
@@ -416,11 +486,15 @@ XRAPI_ATTR XrResult XRAPI_CALL xrCreateDebugUtilsMessengerEXT(XrInstance instanc
                                                               XrDebugUtilsMessengerEXT *messenger) XRLOADER_ABI_TRY {
     LoaderLogger::LogVerboseMessage("xrCreateDebugUtilsMessengerEXT", "Entering loader trampoline");
 
-    LoaderInstance *loader_instance = g_instance_map.Get(instance);
-    if (loader_instance == nullptr) {
-        LoaderLogger::LogValidationErrorMessage("VUID-xrCreateDebugUtilsMessengerEXT-instance-parameter",
-                                                "xrCreateDebugUtilsMessengerEXT", "invalid instance");
+    if (instance == XR_NULL_HANDLE) {
+        LoaderLogger::LogErrorMessage("xrCreateDebugUtilsMessengerEXT", "Instance handle is XR_NULL_HANDLE.");
         return XR_ERROR_HANDLE_INVALID;
+    }
+
+    LoaderInstance *loader_instance;
+    XrResult result = ActiveLoaderInstance::Get(&loader_instance, "xrCreateDebugUtilsMessengerEXT");
+    if (XR_FAILED(result)) {
+        return result;
     }
 
     if (!loader_instance->ExtensionIsEnabled(XR_EXT_DEBUG_UTILS_EXTENSION_NAME)) {
@@ -432,17 +506,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrCreateDebugUtilsMessengerEXT(XrInstance instanc
         return XR_ERROR_FUNCTION_UNSUPPORTED;
     }
 
-    const std::unique_ptr<XrGeneratedDispatchTable> &dispatch_table = loader_instance->DispatchTable();
-    XrResult result = XR_SUCCESS;
-    result = dispatch_table->CreateDebugUtilsMessengerEXT(instance, createInfo, messenger);
-    if (XR_SUCCEEDED(result) && nullptr != messenger) {
-        result = g_debugutilsmessengerext_map.Insert(*messenger, *loader_instance);
-        if (XR_FAILED(result)) {
-            LoaderLogger::LogErrorMessage("xrCreateDebugUtilsMessengerEXT",
-                                          "Failed inserting new messenger into map: may be null or not unique");
-            return result;
-        }
-    }
+    result = loader_instance->DispatchTable()->CreateDebugUtilsMessengerEXT(instance, createInfo, messenger);
     LoaderLogger::LogVerboseMessage("xrCreateDebugUtilsMessengerEXT", "Completed loader trampoline");
     return result;
 }
@@ -454,16 +518,15 @@ XRLOADER_ABI_CATCH_BAD_ALLOC_OOM XRLOADER_ABI_CATCH_FALLBACK
     // Also, is the loader really doing all this every call?
     LoaderLogger::LogVerboseMessage("xrDestroyDebugUtilsMessengerEXT", "Entering loader trampoline");
 
-    if (XR_NULL_HANDLE == messenger) {
-        return XR_SUCCESS;
+    if (messenger == XR_NULL_HANDLE) {
+        LoaderLogger::LogErrorMessage("xrDestroyDebugUtilsMessengerEXT", "Messenger handle is XR_NULL_HANDLE.");
+        return XR_ERROR_HANDLE_INVALID;
     }
 
-    LoaderInstance *loader_instance = g_debugutilsmessengerext_map.Get(messenger);
-    if (loader_instance == nullptr) {
-        LoaderLogger::LogValidationErrorMessage("VUID-xrDestroyDebugUtilsMessengerEXT-messenger-parameter",
-                                                "xrDestroyDebugUtilsMessengerEXT", "invalid messenger");
-
-        return XR_ERROR_HANDLE_INVALID;
+    LoaderInstance *loader_instance;
+    XrResult result = ActiveLoaderInstance::Get(&loader_instance, "xrDestroyDebugUtilsMessengerEXT");
+    if (XR_FAILED(result)) {
+        return result;
     }
 
     if (!loader_instance->ExtensionIsEnabled(XR_EXT_DEBUG_UTILS_EXTENSION_NAME)) {
@@ -475,8 +538,7 @@ XRLOADER_ABI_CATCH_BAD_ALLOC_OOM XRLOADER_ABI_CATCH_FALLBACK
         return XR_ERROR_FUNCTION_UNSUPPORTED;
     }
 
-    const std::unique_ptr<XrGeneratedDispatchTable> &dispatch_table = loader_instance->DispatchTable();
-    XrResult result = dispatch_table->DestroyDebugUtilsMessengerEXT(messenger);
+    result = loader_instance->DispatchTable()->DestroyDebugUtilsMessengerEXT(messenger);
     LoaderLogger::LogVerboseMessage("xrDestroyDebugUtilsMessengerEXT", "Completed loader trampoline");
     return result;
 }
@@ -564,24 +626,28 @@ XRLOADER_ABI_CATCH_FALLBACK
 
 XRAPI_ATTR XrResult XRAPI_CALL xrSessionBeginDebugUtilsLabelRegionEXT(XrSession session,
                                                                       const XrDebugUtilsLabelEXT *labelInfo) XRLOADER_ABI_TRY {
-    LoaderInstance *loader_instance = g_session_map.Get(session);
-    if (nullptr == loader_instance) {
-        LoaderLogger::LogValidationErrorMessage("VUID-xrSessionBeginDebugUtilsLabelRegionEXT-session-parameter",
-                                                "xrSessionBeginDebugUtilsLabelRegionEXT", "session is not a valid XrSession",
-                                                {XrSdkLogObjectInfo{session, XR_OBJECT_TYPE_SESSION}});
+    if (session == XR_NULL_HANDLE) {
+        LoaderLogger::LogErrorMessage("xrSessionBeginDebugUtilsLabelRegionEXT", "Session handle is XR_NULL_HANDLE.");
         return XR_ERROR_HANDLE_INVALID;
+    }
+
+    if (nullptr == labelInfo) {
+        LoaderLogger::LogValidationErrorMessage("VUID-xrSessionBeginDebugUtilsLabelRegionEXT-labelInfo-parameter",
+                                                "xrSessionBeginDebugUtilsLabelRegionEXT", "labelInfo must be non-NULL",
+                                                {XrSdkLogObjectInfo{session, XR_OBJECT_TYPE_SESSION}});
+        return XR_ERROR_VALIDATION_FAILURE;
+    }
+
+    LoaderInstance *loader_instance;
+    XrResult result = ActiveLoaderInstance::Get(&loader_instance, "xrSessionBeginDebugUtilsLabelRegionEXT");
+    if (XR_FAILED(result)) {
+        return result;
     }
     if (!loader_instance->ExtensionIsEnabled(XR_EXT_DEBUG_UTILS_EXTENSION_NAME)) {
         LoaderLogger::LogValidationErrorMessage("TBD", "xrSessionBeginDebugUtilsLabelRegionEXT",
                                                 "Extension entrypoint called without enabling appropriate extension",
                                                 {XrSdkLogObjectInfo{session, XR_OBJECT_TYPE_SESSION}});
         return XR_ERROR_FUNCTION_UNSUPPORTED;
-    }
-    if (nullptr == labelInfo) {
-        LoaderLogger::LogValidationErrorMessage("VUID-xrSessionBeginDebugUtilsLabelRegionEXT-labelInfo-parameter",
-                                                "xrSessionBeginDebugUtilsLabelRegionEXT", "labelInfo must be non-NULL",
-                                                {XrSdkLogObjectInfo{session, XR_OBJECT_TYPE_SESSION}});
-        return XR_ERROR_VALIDATION_FAILURE;
     }
 
     LoaderLogger::GetInstance().BeginLabelRegion(session, labelInfo);
@@ -594,19 +660,23 @@ XRAPI_ATTR XrResult XRAPI_CALL xrSessionBeginDebugUtilsLabelRegionEXT(XrSession 
 XRLOADER_ABI_CATCH_FALLBACK
 
 XRAPI_ATTR XrResult XRAPI_CALL xrSessionEndDebugUtilsLabelRegionEXT(XrSession session) XRLOADER_ABI_TRY {
-    LoaderInstance *loader_instance = g_session_map.Get(session);
-    if (nullptr == loader_instance) {
-        LoaderLogger::LogValidationErrorMessage("VUID-xrSessionEndDebugUtilsLabelRegionEXT-session-parameter",
-                                                "xrSessionEndDebugUtilsLabelRegionEXT", "session is not a valid XrSession",
-                                                {XrSdkLogObjectInfo{session, XR_OBJECT_TYPE_SESSION}});
+    if (session == XR_NULL_HANDLE) {
+        LoaderLogger::LogErrorMessage("xrSessionEndDebugUtilsLabelRegionEXT", "Session handle is XR_NULL_HANDLE.");
         return XR_ERROR_HANDLE_INVALID;
     }
+
+    LoaderInstance *loader_instance;
+    XrResult result = ActiveLoaderInstance::Get(&loader_instance, "xrSessionEndDebugUtilsLabelRegionEXT");
+    if (XR_FAILED(result)) {
+        return result;
+    }
+
     if (!loader_instance->ExtensionIsEnabled(XR_EXT_DEBUG_UTILS_EXTENSION_NAME)) {
         return XR_ERROR_FUNCTION_UNSUPPORTED;
     }
     LoaderLogger::GetInstance().EndLabelRegion(session);
     const std::unique_ptr<XrGeneratedDispatchTable> &dispatch_table = loader_instance->DispatchTable();
-    if (nullptr != dispatch_table->SessionBeginDebugUtilsLabelRegionEXT) {
+    if (nullptr != dispatch_table->SessionEndDebugUtilsLabelRegionEXT) {
         return dispatch_table->SessionEndDebugUtilsLabelRegionEXT(session);
     }
     return XR_SUCCESS;
@@ -615,13 +685,17 @@ XRLOADER_ABI_CATCH_FALLBACK
 
 XRAPI_ATTR XrResult XRAPI_CALL xrSessionInsertDebugUtilsLabelEXT(XrSession session,
                                                                  const XrDebugUtilsLabelEXT *labelInfo) XRLOADER_ABI_TRY {
-    LoaderInstance *loader_instance = g_session_map.Get(session);
-    if (nullptr == loader_instance) {
-        LoaderLogger::LogValidationErrorMessage("VUID-xrSessionInsertDebugUtilsLabelEXT-session-parameter",
-                                                "xrSessionInsertDebugUtilsLabelEXT", "session is not a valid XrSession",
-                                                {XrSdkLogObjectInfo{session, XR_OBJECT_TYPE_SESSION}});
+    if (session == XR_NULL_HANDLE) {
+        LoaderLogger::LogErrorMessage("xrSessionInsertDebugUtilsLabelEXT", "Session handle is XR_NULL_HANDLE.");
         return XR_ERROR_HANDLE_INVALID;
     }
+
+    LoaderInstance *loader_instance;
+    XrResult result = ActiveLoaderInstance::Get(&loader_instance, "xrSessionInsertDebugUtilsLabelEXT");
+    if (XR_FAILED(result)) {
+        return result;
+    }
+
     if (!loader_instance->ExtensionIsEnabled(XR_EXT_DEBUG_UTILS_EXTENSION_NAME)) {
         LoaderLogger::LogValidationErrorMessage("TBD", "xrSessionInsertDebugUtilsLabelEXT",
                                                 "Extension entrypoint called without enabling appropriate extension",
@@ -636,10 +710,103 @@ XRAPI_ATTR XrResult XRAPI_CALL xrSessionInsertDebugUtilsLabelEXT(XrSession sessi
     }
 
     LoaderLogger::GetInstance().InsertLabel(session, labelInfo);
+
     const std::unique_ptr<XrGeneratedDispatchTable> &dispatch_table = loader_instance->DispatchTable();
     if (nullptr != dispatch_table->SessionInsertDebugUtilsLabelEXT) {
         return dispatch_table->SessionInsertDebugUtilsLabelEXT(session, labelInfo);
     }
+
     return XR_SUCCESS;
+}
+XRLOADER_ABI_CATCH_FALLBACK
+
+LOADER_EXPORT XRAPI_ATTR XrResult XRAPI_CALL xrGetInstanceProcAddr(XrInstance instance, const char *name,
+                                                                   PFN_xrVoidFunction *function) XRLOADER_ABI_TRY {
+    // Initialize the function to nullptr in case it does not get caught in a known case
+    *function = nullptr;
+
+    if (nullptr == function) {
+        LoaderLogger::LogValidationErrorMessage("VUID-xrGetInstanceProcAddr-function-parameter", "xrGetInstanceProcAddr",
+                                                "Invalid Function pointer");
+        return XR_ERROR_VALIDATION_FAILURE;
+    }
+
+    if (nullptr == name) {
+        LoaderLogger::LogValidationErrorMessage("VUID-xrGetInstanceProcAddr-function-parameter", "xrGetInstanceProcAddr",
+                                                "Invalid Name pointer");
+        return XR_ERROR_VALIDATION_FAILURE;
+    }
+
+    if (instance == XR_NULL_HANDLE) {
+        // Null instance is allowed for 3 specific API entry points, otherwise return error
+        if (strcmp(name, "xrCreateInstance") != 0 && strcmp(name, "xrEnumerateApiLayerProperties") != 0 &&
+            strcmp(name, "xrEnumerateInstanceExtensionProperties") != 0) {
+            std::string error_str = "XR_NULL_HANDLE for instance but query for ";
+            error_str += name;
+            error_str += " requires a valid instance";
+            LoaderLogger::LogValidationErrorMessage("VUID-xrGetInstanceProcAddr-instance-parameter", "xrGetInstanceProcAddr",
+                                                    error_str);
+            return XR_ERROR_HANDLE_INVALID;
+        }
+    }
+
+    // These functions must always go through the loader's implementation (trampoline).
+    if (strcmp(name, "xrGetInstanceProcAddr") == 0) {
+        *function = reinterpret_cast<PFN_xrVoidFunction>(xrGetInstanceProcAddr);
+        return XR_SUCCESS;
+    } else if (strcmp(name, "xrEnumerateApiLayerProperties") == 0) {
+        *function = reinterpret_cast<PFN_xrVoidFunction>(xrEnumerateApiLayerProperties);
+        return XR_SUCCESS;
+    } else if (strcmp(name, "xrEnumerateInstanceExtensionProperties") == 0) {
+        *function = reinterpret_cast<PFN_xrVoidFunction>(xrEnumerateInstanceExtensionProperties);
+        return XR_SUCCESS;
+    } else if (strcmp(name, "xrCreateInstance") == 0) {
+        *function = reinterpret_cast<PFN_xrVoidFunction>(xrCreateInstance);
+        return XR_SUCCESS;
+    } else if (strcmp(name, "xrDestroyInstance") == 0) {
+        *function = reinterpret_cast<PFN_xrVoidFunction>(xrDestroyInstance);
+        return XR_SUCCESS;
+    }
+
+    // Remainder of the functions require the LoaderInstance.
+    LoaderInstance *loader_instance = nullptr;
+    XrResult result = ActiveLoaderInstance::Get(&loader_instance, "xrGetInstanceProcAddr");
+    if (XR_FAILED(result)) {
+        return result;
+    }
+
+    // XR_EXT_debug_utils is built into the loader and handled partly through the xrGetInstanceProcAddress terminator,
+    // but the check to see if the extension is enabled must be done here where ActiveLoaderInstance is safe to use.
+    if (*function == nullptr) {
+        if (strcmp(name, "xrCreateDebugUtilsMessengerEXT") == 0) {
+            *function = reinterpret_cast<PFN_xrVoidFunction>(xrCreateDebugUtilsMessengerEXT);
+        } else if (strcmp(name, "xrDestroyDebugUtilsMessengerEXT") == 0) {
+            *function = reinterpret_cast<PFN_xrVoidFunction>(xrDestroyDebugUtilsMessengerEXT);
+        } else if (strcmp(name, "xrSessionBeginDebugUtilsLabelRegionEXT") == 0) {
+            *function = reinterpret_cast<PFN_xrVoidFunction>(xrSessionBeginDebugUtilsLabelRegionEXT);
+        } else if (strcmp(name, "xrSessionEndDebugUtilsLabelRegionEXT") == 0) {
+            *function = reinterpret_cast<PFN_xrVoidFunction>(xrSessionEndDebugUtilsLabelRegionEXT);
+        } else if (strcmp(name, "xrSessionInsertDebugUtilsLabelEXT") == 0) {
+            *function = reinterpret_cast<PFN_xrVoidFunction>(xrSessionInsertDebugUtilsLabelEXT);
+        } else if (strcmp(name, "xrSetDebugUtilsObjectNameEXT") == 0) {
+            *function = reinterpret_cast<PFN_xrVoidFunction>(xrSetDebugUtilsObjectNameEXT);
+        } else if (strcmp(name, "xrSubmitDebugUtilsMessageEXT") == 0) {
+            *function = reinterpret_cast<PFN_xrVoidFunction>(xrSubmitDebugUtilsMessageEXT);
+        }
+
+        if (*function != nullptr && !loader_instance->ExtensionIsEnabled("XR_EXT_debug_utils")) {
+            // The function matches one of the XR_EXT_debug_utils functions but the extension is not enabled.
+            *function = nullptr;
+            return XR_ERROR_FUNCTION_UNSUPPORTED;
+        }
+    }
+
+    if (*function != nullptr) {
+        // The loader has a trampoline or implementation of this function.
+        return XR_SUCCESS;
+    }
+
+    // If the function is not supported by the loader, call down to the next layer.
+    return loader_instance->GetInstanceProcAddr(name, function);
 }
 XRLOADER_ABI_CATCH_FALLBACK

--- a/src/loader/loader_instance.cpp
+++ b/src/loader/loader_instance.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2017-2019 The Khronos Group Inc.
+// Copyright (c) 2017-2019 The Khronos Group Inc.
 // Copyright (c) 2017-2019 Valve Corporation
 // Copyright (c) 2017-2019 LunarG, Inc.
 //
@@ -39,6 +40,36 @@
 #include <string>
 #include <utility>
 #include <vector>
+
+namespace {
+std::unique_ptr<LoaderInstance> g_current_loader_instance;
+}
+
+namespace ActiveLoaderInstance {
+XrResult Set(std::unique_ptr<LoaderInstance> loader_instance, const char* log_function_name) {
+    if (g_current_loader_instance != nullptr) {
+        LoaderLogger::LogErrorMessage(log_function_name, "Active XrInstance handle already exists");
+        return XR_ERROR_LIMIT_REACHED;
+    }
+
+    g_current_loader_instance = std::move(loader_instance);
+    return XR_SUCCESS;
+}
+
+XrResult Get(LoaderInstance** loader_instance, const char* log_function_name) {
+    *loader_instance = g_current_loader_instance.get();
+    if (*loader_instance == nullptr) {
+        LoaderLogger::LogErrorMessage(log_function_name, "No active XrInstance handle.");
+        return XR_ERROR_HANDLE_INVALID;
+    }
+
+    return XR_SUCCESS;
+}
+
+bool IsAvailable() { return g_current_loader_instance != nullptr; }
+
+void Remove() { g_current_loader_instance.release(); }
+}  // namespace ActiveLoaderInstance
 
 // Extensions that are supported by the loader, but may not be supported
 // the the runtime.
@@ -111,197 +142,163 @@ class InstanceCreateInfoManager {
 }  // namespace
 
 // Factory method
-XrResult LoaderInstance::CreateInstance(std::vector<std::unique_ptr<ApiLayerInterface>>&& api_layer_interfaces,
-                                        const XrInstanceCreateInfo* info, XrInstance* instance) {
-    XrResult last_error = XR_SUCCESS;
+XrResult LoaderInstance::CreateInstance(PFN_xrGetInstanceProcAddr get_instance_proc_addr_term,
+                                        PFN_xrCreateInstance create_instance_term,
+                                        PFN_xrCreateApiLayerInstance create_api_layer_instance_term,
+                                        std::vector<std::unique_ptr<ApiLayerInterface>> api_layer_interfaces,
+                                        const XrInstanceCreateInfo* info, std::unique_ptr<LoaderInstance>* loader_instance) {
     LoaderLogger::LogVerboseMessage("xrCreateInstance", "Entering LoaderInstance::CreateInstance");
 
+    // Check the list of enabled extensions to make sure something supports them, and, if we do,
+    // add it to the list of enabled extensions
+    XrResult last_error = XR_SUCCESS;
+    for (uint32_t ext = 0; ext < info->enabledExtensionCount; ++ext) {
+        bool found = false;
+        // First check the runtime
+        if (RuntimeInterface::GetRuntime().SupportsExtension(info->enabledExtensionNames[ext])) {
+            found = true;
+        }
+        // Next check the loader
+        if (!found) {
+            for (auto& loader_extension : LoaderInstance::LoaderSpecificExtensions()) {
+                if (strcmp(loader_extension.extensionName, info->enabledExtensionNames[ext]) == 0) {
+                    found = true;
+                    break;
+                }
+            }
+        }
+        // Finally, check the enabled layers
+        if (!found) {
+            for (auto& layer_interface : api_layer_interfaces) {
+                if (layer_interface->SupportsExtension(info->enabledExtensionNames[ext])) {
+                    found = true;
+                    break;
+                }
+            }
+        }
+        if (!found) {
+            std::string msg = "LoaderInstance::CreateInstance, no support found for requested extension: ";
+            msg += info->enabledExtensionNames[ext];
+            LoaderLogger::LogErrorMessage("xrCreateInstance", msg);
+            last_error = XR_ERROR_EXTENSION_NOT_PRESENT;
+            break;
+        }
+    }
+
     // Topmost means "closest to the application"
-    PFN_xrCreateInstance topmost_ci_fp = LoaderXrTermCreateInstance;
-    PFN_xrCreateApiLayerInstance topmost_cali_fp = LoaderXrTermCreateApiLayerInstance;
-
-    // Create the loader instance
-    std::unique_ptr<LoaderInstance> loader_instance(new LoaderInstance(std::move(api_layer_interfaces)));
-    *instance = reinterpret_cast<XrInstance>(loader_instance.get());
-
-    // Remove the loader-supported-extensions (debug utils), if it's in the list of enabled extensions but not supported by
-    // the runtime.
-    InstanceCreateInfoManager create_info_manager{info};
-    const XrInstanceCreateInfo* modified_create_info = info;
-    if (info->enabledExtensionCount > 0) {
-        std::vector<const char*> extensions_to_skip;
-        for (const auto& ext : LoaderInstance::LoaderSpecificExtensions()) {
-            if (!RuntimeInterface::GetRuntime().SupportsExtension(ext.extensionName)) {
-                extensions_to_skip.emplace_back(ext.extensionName);
-            }
-        }
-        modified_create_info = create_info_manager.FilterOutExtensions(extensions_to_skip);
-    }
-
-    // Only start the xrCreateApiLayerInstance stack if we have layers.
-    std::vector<std::unique_ptr<ApiLayerInterface>>& layer_interfaces = loader_instance->LayerInterfaces();
-    if (!layer_interfaces.empty()) {
-        // Initialize an array of ApiLayerNextInfo structs
-        std::unique_ptr<XrApiLayerNextInfo[]> next_info_list(new XrApiLayerNextInfo[layer_interfaces.size()]);
-        auto ni_index = static_cast<uint32_t>(layer_interfaces.size() - 1);
-        for (uint32_t i = 0; i <= ni_index; i++) {
-            next_info_list[i].structType = XR_LOADER_INTERFACE_STRUCT_API_LAYER_NEXT_INFO;
-            next_info_list[i].structVersion = XR_API_LAYER_NEXT_INFO_STRUCT_VERSION;
-            next_info_list[i].structSize = sizeof(XrApiLayerNextInfo);
-        }
-
-        // Go through all layers, and override the instance pointers with the layer version.  However,
-        // go backwards through the layer list so we replace in reverse order so the layers can call their next function
-        // appropriately.
-        XrApiLayerNextInfo* prev_nextinfo = nullptr;
-        PFN_xrGetInstanceProcAddr prev_gipa_fp = LoaderXrTermGetInstanceProcAddr;
-        PFN_xrCreateApiLayerInstance prev_cali_fp = LoaderXrTermCreateApiLayerInstance;
-        for (auto layer_interface = layer_interfaces.rbegin(); layer_interface != layer_interfaces.rend(); ++layer_interface) {
-            // Collect current layer's function pointers
-            PFN_xrGetInstanceProcAddr cur_gipa_fp = (*layer_interface)->GetInstanceProcAddrFuncPointer();
-            PFN_xrCreateApiLayerInstance cur_cali_fp = (*layer_interface)->GetCreateApiLayerInstanceFuncPointer();
-            // Update topmosts
-            cur_gipa_fp(XR_NULL_HANDLE, "xrCreateInstance", reinterpret_cast<PFN_xrVoidFunction*>(&topmost_ci_fp));
-            topmost_cali_fp = cur_cali_fp;
-
-            // Fill in layer info and link previous (lower) layer fxn pointers
-            strncpy(next_info_list[ni_index].layerName, (*layer_interface)->LayerName().c_str(), XR_MAX_API_LAYER_NAME_SIZE - 1);
-            next_info_list[ni_index].layerName[XR_MAX_API_LAYER_NAME_SIZE - 1] = '\0';
-            next_info_list[ni_index].next = prev_nextinfo;
-            next_info_list[ni_index].nextGetInstanceProcAddr = prev_gipa_fp;
-            next_info_list[ni_index].nextCreateApiLayerInstance = prev_cali_fp;
-
-            // Update saved pointers for next iteration
-            prev_nextinfo = &next_info_list[ni_index];
-            prev_gipa_fp = cur_gipa_fp;
-            prev_cali_fp = cur_cali_fp;
-            ni_index--;
-        }
-
-        // Populate the ApiLayerCreateInfo struct and pass to topmost CreateApiLayerInstance()
-        XrApiLayerCreateInfo api_layer_ci = {};
-        api_layer_ci.structType = XR_LOADER_INTERFACE_STRUCT_API_LAYER_CREATE_INFO;
-        api_layer_ci.structVersion = XR_API_LAYER_CREATE_INFO_STRUCT_VERSION;
-        api_layer_ci.structSize = sizeof(XrApiLayerCreateInfo);
-        api_layer_ci.loaderInstance = reinterpret_cast<void*>(loader_instance.get());
-        api_layer_ci.settings_file_location[0] = '\0';
-        api_layer_ci.nextInfo = next_info_list.get();
-        //! @todo do we filter our create info extension list here?
-        //! Think that actually each layer might need to filter...
-        last_error = topmost_cali_fp(modified_create_info, &api_layer_ci, instance);
-
-    } else {
-        last_error = topmost_ci_fp(modified_create_info, instance);
-    }
+    PFN_xrGetInstanceProcAddr topmost_gipa = get_instance_proc_addr_term;
+    XrInstance instance{XR_NULL_HANDLE};
 
     if (XR_SUCCEEDED(last_error)) {
-        // Check the list of enabled extensions to make sure something supports them, and, if we do,
-        // add it to the list of enabled extensions
-        for (uint32_t ext = 0; ext < info->enabledExtensionCount; ++ext) {
-            bool found = false;
-            // First check the runtime
-            if (RuntimeInterface::GetRuntime().SupportsExtension(info->enabledExtensionNames[ext])) {
-                found = true;
-            }
-            // Next check the loader
-            if (!found) {
-                for (auto& loader_extension : LoaderInstance::LoaderSpecificExtensions()) {
-                    if (strcmp(loader_extension.extensionName, info->enabledExtensionNames[ext]) == 0) {
-                        found = true;
-                        break;
-                    }
+        // Remove the loader-supported-extensions (debug utils), if it's in the list of enabled extensions but not supported by
+        // the runtime.
+        InstanceCreateInfoManager create_info_manager{info};
+        const XrInstanceCreateInfo* modified_create_info = info;
+        if (info->enabledExtensionCount > 0) {
+            std::vector<const char*> extensions_to_skip;
+            for (const auto& ext : LoaderInstance::LoaderSpecificExtensions()) {
+                if (!RuntimeInterface::GetRuntime().SupportsExtension(ext.extensionName)) {
+                    extensions_to_skip.emplace_back(ext.extensionName);
                 }
             }
-            // Finally, check the enabled layers
-            if (!found) {
-                for (auto& layer_interface : layer_interfaces) {
-                    if (layer_interface->SupportsExtension(info->enabledExtensionNames[ext])) {
-                        found = true;
-                        break;
-                    }
-                }
-            }
-            if (!found) {
-                std::string msg = "LoaderInstance::CreateInstance, no support found for requested extension: ";
-                msg += info->enabledExtensionNames[ext];
-                LoaderLogger::LogErrorMessage("xrCreateInstance", msg);
-                last_error = XR_ERROR_EXTENSION_NOT_PRESENT;
-                break;
-            }
-            loader_instance->AddEnabledExtension(info->enabledExtensionNames[ext]);
+            modified_create_info = create_info_manager.FilterOutExtensions(extensions_to_skip);
         }
-    } else {
-        LoaderLogger::LogErrorMessage("xrCreateInstance", "LoaderInstance::CreateInstance chained CreateInstance call failed");
-    }
 
-    if (XR_SUCCEEDED(last_error)) {
-        // Create the top-level dispatch table for the instance.  This will contain the function pointers to the
-        // first instantiation of every command, whether that is in a layer, or a runtime.
-        last_error = loader_instance->CreateDispatchTable(*instance);
-        if (XR_FAILED(last_error)) {
-            LoaderLogger::LogErrorMessage("xrCreateInstance",
-                                          "LoaderInstance::CreateInstance failed creating top-level dispatch table");
+        // Only start the xrCreateApiLayerInstance stack if we have layers.
+        if (!api_layer_interfaces.empty()) {
+            // Initialize an array of ApiLayerNextInfo structs
+            std::unique_ptr<XrApiLayerNextInfo[]> next_info_list(new XrApiLayerNextInfo[api_layer_interfaces.size()]);
+            auto ni_index = static_cast<uint32_t>(api_layer_interfaces.size() - 1);
+            for (uint32_t i = 0; i <= ni_index; i++) {
+                next_info_list[i].structType = XR_LOADER_INTERFACE_STRUCT_API_LAYER_NEXT_INFO;
+                next_info_list[i].structVersion = XR_API_LAYER_NEXT_INFO_STRUCT_VERSION;
+                next_info_list[i].structSize = sizeof(XrApiLayerNextInfo);
+            }
+
+            // Go through all layers, and override the instance pointers with the layer version.  However,
+            // go backwards through the layer list so we replace in reverse order so the layers can call their next function
+            // appropriately.
+            PFN_xrCreateApiLayerInstance topmost_cali_fp = create_api_layer_instance_term;
+            XrApiLayerNextInfo* topmost_nextinfo = nullptr;
+            for (auto layer_interface = api_layer_interfaces.rbegin(); layer_interface != api_layer_interfaces.rend();
+                 ++layer_interface) {
+                // Collect current layer's function pointers
+                PFN_xrGetInstanceProcAddr cur_gipa_fp = (*layer_interface)->GetInstanceProcAddrFuncPointer();
+                PFN_xrCreateApiLayerInstance cur_cali_fp = (*layer_interface)->GetCreateApiLayerInstanceFuncPointer();
+
+                // Fill in layer info and link previous (lower) layer fxn pointers
+                strncpy(next_info_list[ni_index].layerName, (*layer_interface)->LayerName().c_str(),
+                        XR_MAX_API_LAYER_NAME_SIZE - 1);
+                next_info_list[ni_index].layerName[XR_MAX_API_LAYER_NAME_SIZE - 1] = '\0';
+                next_info_list[ni_index].next = topmost_nextinfo;
+                next_info_list[ni_index].nextGetInstanceProcAddr = topmost_gipa;
+                next_info_list[ni_index].nextCreateApiLayerInstance = topmost_cali_fp;
+
+                // Update saved pointers for next iteration
+                topmost_nextinfo = &next_info_list[ni_index];
+                topmost_gipa = cur_gipa_fp;
+                topmost_cali_fp = cur_cali_fp;
+                ni_index--;
+            }
+
+            // Populate the ApiLayerCreateInfo struct and pass to topmost CreateApiLayerInstance()
+            XrApiLayerCreateInfo api_layer_ci = {};
+            api_layer_ci.structType = XR_LOADER_INTERFACE_STRUCT_API_LAYER_CREATE_INFO;
+            api_layer_ci.structVersion = XR_API_LAYER_CREATE_INFO_STRUCT_VERSION;
+            api_layer_ci.structSize = sizeof(XrApiLayerCreateInfo);
+            api_layer_ci.loaderInstance = nullptr;  // Not used.
+            api_layer_ci.settings_file_location[0] = '\0';
+            api_layer_ci.nextInfo = next_info_list.get();
+            //! @todo do we filter our create info extension list here?
+            //! Think that actually each layer might need to filter...
+            last_error = topmost_cali_fp(modified_create_info, &api_layer_ci, &instance);
+
         } else {
-            last_error = g_instance_map.Insert(*instance, *loader_instance);
-            if (XR_FAILED(last_error)) {
-                LoaderLogger::LogErrorMessage(
-                    "xrCreateInstance",
-                    "LoaderInstance::CreateInstance failed inserting new instance into map: may be null or not unique");
-            }
+            // The loader's terminator is the topmost CreateInstance if there are no layers.
+            last_error = create_instance_term(modified_create_info, &instance);
+        }
+
+        if (XR_FAILED(last_error)) {
+            LoaderLogger::LogErrorMessage("xrCreateInstance", "LoaderInstance::CreateInstance chained CreateInstance call failed");
         }
     }
 
     if (XR_SUCCEEDED(last_error)) {
+        loader_instance->reset(new LoaderInstance(instance, info, topmost_gipa, std::move(api_layer_interfaces)));
+
         std::ostringstream oss;
         oss << "LoaderInstance::CreateInstance succeeded with ";
-        oss << loader_instance->LayerInterfaces().size();
+        oss << (*loader_instance)->LayerInterfaces().size();
         oss << " layers enabled and runtime interface - created instance = ";
-        oss << HandleToHexString(*instance);
+        oss << HandleToHexString((*loader_instance)->GetInstanceHandle());
         LoaderLogger::LogInfoMessage("xrCreateInstance", oss.str());
-        // Make the unique_ptr no longer delete this.
-        // Don't need to save the return value because we already set *instance
-        (void)loader_instance.release();
     }
-
-    // Always clear the input lists.  Either we use them or we don't.
-    api_layer_interfaces.clear();
 
     return last_error;
 }
 
-LoaderInstance::LoaderInstance(std::vector<std::unique_ptr<ApiLayerInterface>>&& api_layer_interfaces)
-    : _unique_id(0xDECAFBAD),
-      _api_version(XR_CURRENT_API_VERSION),
+XrResult LoaderInstance::GetInstanceProcAddr(const char* name, PFN_xrVoidFunction* function) {
+    return _topmost_gipa(_runtime_instance, name, function);
+}
+
+LoaderInstance::LoaderInstance(XrInstance instance, const XrInstanceCreateInfo* create_info, PFN_xrGetInstanceProcAddr topmost_gipa,
+                               std::vector<std::unique_ptr<ApiLayerInterface>> api_layer_interfaces)
+    : _runtime_instance(instance),
+      _topmost_gipa(topmost_gipa),
       _api_layer_interfaces(std::move(api_layer_interfaces)),
-      _dispatch_valid(false),
-      _messenger(XR_NULL_HANDLE) {}
+      _dispatch_table(new XrGeneratedDispatchTable{}) {
+    for (uint32_t ext = 0; ext < create_info->enabledExtensionCount; ++ext) {
+        _enabled_extensions.push_back(create_info->enabledExtensionNames[ext]);
+    }
+
+    GeneratedXrPopulateDispatchTable(_dispatch_table.get(), instance, topmost_gipa);
+}
 
 LoaderInstance::~LoaderInstance() {
     std::ostringstream oss;
     oss << "Destroying LoaderInstance = ";
     oss << PointerToHexString(this);
     LoaderLogger::LogInfoMessage("xrDestroyInstance", oss.str());
-}
-
-XrResult LoaderInstance::CreateDispatchTable(XrInstance instance) {
-    XrResult res = XR_SUCCESS;
-    // Create the top-level dispatch table.  First, we want to start with a dispatch table generated
-    // using the commands from the runtime, with the exception of commands that we need a terminator
-    // for.  The loaderGenInitInstanceDispatchTable utility function handles that automatically for us.
-    std::unique_ptr<XrGeneratedDispatchTable> new_instance_dispatch_table(new XrGeneratedDispatchTable());
-    LoaderGenInitInstanceDispatchTable(_runtime_instance, new_instance_dispatch_table);
-
-    // Go through all layers, and override the instance pointers with the layer version.  However,
-    // go backwards through the layer list so we replace in reverse order so the layers can call their next function
-    // appropriately.
-    if (!_api_layer_interfaces.empty()) {
-        (*_api_layer_interfaces.begin())->GenUpdateInstanceDispatchTable(instance, new_instance_dispatch_table);
-    }
-
-    // Set the top-level instance dispatch table to the top-most commands now that we've figured them out.
-    _dispatch_table = std::move(new_instance_dispatch_table);
-    _dispatch_valid = true;
-    return res;
 }
 
 bool LoaderInstance::ExtensionIsEnabled(const std::string& extension) {

--- a/src/loader/loader_instance.hpp
+++ b/src/loader/loader_instance.hpp
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "extra_algorithms.h"
+#include "loader_interfaces.h"
 
 #include <openxr/openxr.h>
 
@@ -31,125 +32,56 @@
 #include <unordered_map>
 #include <vector>
 
-class LoaderInstance;
 class ApiLayerInterface;
 struct XrGeneratedDispatchTable;
+class LoaderInstance;
 
-typedef std::unique_lock<std::mutex> UniqueLock;
-template <typename HandleType>
-class HandleLoaderMap {
-   public:
-    using handle_t = HandleType;
-    using map_t = std::unordered_map<HandleType, LoaderInstance*>;
-    using value_t = typename map_t::value_type;
+// Manage the single loader instance that is available.
+namespace ActiveLoaderInstance {
+// Set the active loader instance. This will fail if there is already an active loader instance.
+XrResult Set(std::unique_ptr<LoaderInstance> loader_instance, const char* log_function_name);
 
-    /// Lookup a handle.
-    /// Returns nullptr if not found.
-    LoaderInstance* Get(HandleType handle);
+// Returns true if there is an active loader instance.
+bool IsAvailable();
 
-    /// Insert an info for the supplied handle.
-    /// Returns XR_ERROR_RUNTIME_FAILURE if it's null.
-    /// Does not error if already there, because the loader is not currently very good at cleaning up handles.
-    XrResult Insert(HandleType handle, LoaderInstance& loader);
+// Get the active LoaderInstance.
+XrResult Get(LoaderInstance** loader_instance, const char* log_function_name);
 
-    /// Remove the info associated with the supplied handle.
-    /// Returns XR_ERROR_RUNTIME_FAILURE if it's null or not there.
-    XrResult Erase(HandleType handle);
+// Destroy the currently active LoaderInstance if there is one. This will make the loader able to create a new XrInstance if needed.
+void Remove();
+};  // namespace ActiveLoaderInstance
 
-    /// Removes handles associated with a loader instance.
-    void RemoveHandlesForLoader(LoaderInstance& loader);
-
-   protected:
-    map_t instance_map_;
-    std::mutex mutex_;
-};
-
+// Manages information needed by the loader for an XrInstance, such as what extensions are available and the dispatch table.
 class LoaderInstance {
    public:
     // Factory method
-    static XrResult CreateInstance(std::vector<std::unique_ptr<ApiLayerInterface>>&& layer_interfaces,
-                                   const XrInstanceCreateInfo* createInfo, XrInstance* instance);
+    static XrResult CreateInstance(PFN_xrGetInstanceProcAddr get_instance_proc_addr_term, PFN_xrCreateInstance create_instance_term,
+                                   PFN_xrCreateApiLayerInstance create_api_layer_instance_term,
+                                   std::vector<std::unique_ptr<ApiLayerInterface>> layer_interfaces,
+                                   const XrInstanceCreateInfo* createInfo, std::unique_ptr<LoaderInstance>* loader_instance);
+    static const std::array<XrExtensionProperties, 1>& LoaderSpecificExtensions();
 
-    LoaderInstance(std::vector<std::unique_ptr<ApiLayerInterface>>&& api_layer_interfaces);
     virtual ~LoaderInstance();
 
-    bool IsValid() { return _unique_id == 0xDECAFBAD; }
-    XrVersion ApiVersion() { return _api_version; }
-    XrResult CreateDispatchTable(XrInstance instance);
-    void SetRuntimeInstance(XrInstance instance) { _runtime_instance = instance; }
+    XrInstance GetInstanceHandle() { return _runtime_instance; }
     const std::unique_ptr<XrGeneratedDispatchTable>& DispatchTable() { return _dispatch_table; }
     std::vector<std::unique_ptr<ApiLayerInterface>>& LayerInterfaces() { return _api_layer_interfaces; }
-    void AddEnabledExtension(const std::string& extension) { return _enabled_extensions.push_back(extension); }
     bool ExtensionIsEnabled(const std::string& extension);
-    static const std::array<XrExtensionProperties, 1>& LoaderSpecificExtensions();
     XrDebugUtilsMessengerEXT DefaultDebugUtilsMessenger() { return _messenger; }
     void SetDefaultDebugUtilsMessenger(XrDebugUtilsMessengerEXT messenger) { _messenger = messenger; }
+    XrResult GetInstanceProcAddr(const char* name, PFN_xrVoidFunction* function);
 
    private:
-    uint32_t _unique_id;  // 0xDECAFBAD - for debugging
-    XrVersion _api_version;
-    std::vector<std::unique_ptr<ApiLayerInterface>> _api_layer_interfaces;
-    XrInstance _runtime_instance;
-    bool _dispatch_valid;
-    std::unique_ptr<XrGeneratedDispatchTable> _dispatch_table;
+    LoaderInstance(XrInstance instance, const XrInstanceCreateInfo* createInfo, PFN_xrGetInstanceProcAddr topmost_gipa,
+                   std::vector<std::unique_ptr<ApiLayerInterface>> api_layer_interfaces);
+
+   private:
+    XrInstance _runtime_instance{XR_NULL_HANDLE};
+    PFN_xrGetInstanceProcAddr _topmost_gipa{nullptr};
     std::vector<std::string> _enabled_extensions;
+    std::vector<std::unique_ptr<ApiLayerInterface>> _api_layer_interfaces;
+
+    std::unique_ptr<XrGeneratedDispatchTable> _dispatch_table;
     // Internal debug messenger created during xrCreateInstance
-    XrDebugUtilsMessengerEXT _messenger;
+    XrDebugUtilsMessengerEXT _messenger{XR_NULL_HANDLE};
 };
-
-template <typename HandleType>
-inline LoaderInstance* HandleLoaderMap<HandleType>::Get(HandleType handle) {
-    if (handle == XR_NULL_HANDLE) {
-        return nullptr;
-    }
-    // Try to find the handle in the appropriate map
-    UniqueLock lock(mutex_);
-    auto entry_returned = instance_map_.find(handle);
-    if (entry_returned == instance_map_.end()) {
-        return nullptr;
-    }
-    return entry_returned->second;
-}
-
-template <typename HandleType>
-inline XrResult HandleLoaderMap<HandleType>::Insert(HandleType handle, LoaderInstance& loader) {
-    if (handle == XR_NULL_HANDLE) {
-        // Internal error in loader or runtime.
-        return XR_ERROR_RUNTIME_FAILURE;
-    }
-    UniqueLock lock(mutex_);
-    //! @todo This check is currently disabled, because the loader is not good at cleaning up handles when their parent handles are
-    //! destroyed.
-#if 0
-    auto entry_returned = instance_map_.find(handle);
-    if (entry_returned != instance_map_.end()) {
-        // Internal error in loader or runtime.
-        return XR_ERROR_RUNTIME_FAILURE;
-    }
-#endif
-    instance_map_[handle] = &loader;
-    return XR_SUCCESS;
-}
-
-template <typename HandleType>
-inline XrResult HandleLoaderMap<HandleType>::Erase(HandleType handle) {
-    if (handle == XR_NULL_HANDLE) {
-        // Internal error in loader or runtime.
-        return XR_ERROR_RUNTIME_FAILURE;
-    }
-    UniqueLock lock(mutex_);
-    auto entry_returned = instance_map_.find(handle);
-    if (entry_returned == instance_map_.end()) {
-        // Internal error in loader or runtime.
-        return XR_ERROR_RUNTIME_FAILURE;
-    }
-    instance_map_.erase(handle);
-    return XR_SUCCESS;
-}
-
-template <typename HandleType>
-inline void HandleLoaderMap<HandleType>::RemoveHandlesForLoader(LoaderInstance& loader) {
-    UniqueLock lock(mutex_);
-    auto search_value = &loader;
-    map_erase_if(instance_map_, [=](value_t const& data) { return data.second && data.second == search_value; });
-}

--- a/src/loader/runtime_interface.cpp
+++ b/src/loader/runtime_interface.cpp
@@ -39,9 +39,6 @@ std::unique_ptr<RuntimeInterface> RuntimeInterface::_single_runtime_interface;
 uint32_t RuntimeInterface::_single_runtime_count = 0;
 
 XrResult RuntimeInterface::LoadRuntime(const std::string& openxr_command) {
-    XrResult last_error = XR_SUCCESS;
-    bool any_loaded = false;
-
     // If something's already loaded, we're done here.
     if (_single_runtime_interface != nullptr) {
         _single_runtime_count++;
@@ -49,9 +46,10 @@ XrResult RuntimeInterface::LoadRuntime(const std::string& openxr_command) {
     }
 
     std::vector<std::unique_ptr<RuntimeManifestFile>> runtime_manifest_files = {};
+    bool any_loaded = false;
 
     // Find the available runtimes which we may need to report information for.
-    last_error = RuntimeManifestFile::FindManifestFiles(MANIFEST_TYPE_RUNTIME, runtime_manifest_files);
+    XrResult last_error = RuntimeManifestFile::FindManifestFiles(MANIFEST_TYPE_RUNTIME, runtime_manifest_files);
     if (XR_FAILED(last_error)) {
         LoaderLogger::LogErrorMessage(openxr_command, "RuntimeInterface::LoadRuntimes - unknown error");
         last_error = XR_ERROR_FILE_ACCESS_ERROR;

--- a/src/loader/runtime_interface.hpp
+++ b/src/loader/runtime_interface.hpp
@@ -40,6 +40,8 @@ class RuntimeInterface {
     static void UnloadRuntime(const std::string& openxr_command);
     static RuntimeInterface& GetRuntime() { return *(_single_runtime_interface.get()); }
     static XrResult GetInstanceProcAddr(XrInstance instance, const char* name, PFN_xrVoidFunction* function);
+
+    // Get the direct dispatch table to this runtime, without API layers or loader terminators.
     static const XrGeneratedDispatchTable* GetDispatchTable(XrInstance instance);
     static const XrGeneratedDispatchTable* GetDebugUtilsMessengerDispatchTable(XrDebugUtilsMessengerEXT messenger);
 

--- a/src/scripts/loader_source_generator.py
+++ b/src/scripts/loader_source_generator.py
@@ -26,45 +26,21 @@ from automatic_source_generator import (AutomaticSourceOutputGenerator,
                                         undecorate)
 from generator import write
 
-# The following commands are manually implemented in the loader as trampoline
-# and terminator calls since they take an instance handle.
-MANUAL_LOADER_INSTANCE_FUNCS = set((
+# The following commands are manually implemented in the loader.
+MANUAL_LOADER_FUNCS = set((
     'xrGetInstanceProcAddr',
     'xrEnumerateApiLayerProperties',
     'xrEnumerateInstanceExtensionProperties',
     'xrCreateInstance',
     'xrDestroyInstance',
-    # Extensions
-    #  XR_EXT_debug_utils (both trampoline and terminator are manually defined)
+
+    # For XR_EXT_debug_utils:
     'xrCreateDebugUtilsMessengerEXT',
     'xrDestroyDebugUtilsMessengerEXT',
-))
-
-# The following commands are manually implemented in the loader as trampoline
-# calls since they do not take an instance handle.
-MANUAL_LOADER_NONINSTANCE_FUNCS = set((
     'xrSessionBeginDebugUtilsLabelRegionEXT',
     'xrSessionEndDebugUtilsLabelRegionEXT',
     'xrSessionInsertDebugUtilsLabelEXT',
 ))
-
-MANUAL_LOADER_FUNCS = MANUAL_LOADER_INSTANCE_FUNCS.union(MANUAL_LOADER_NONINSTANCE_FUNCS)
-
-# The terminators for the following commands are manually implemented in the
-# loader.
-MANUAL_LOADER_INSTANCE_TERMINATOR_FUNCS = set((
-    'xrSubmitDebugUtilsMessageEXT',
-    'xrSetDebugUtilsObjectNameEXT',
-))
-
-VALID_FOR_NULL_INSTANCE_GIPA = set((
-    'xrEnumerateInstanceExtensionProperties',
-    'xrEnumerateInstanceLayerProperties',
-    'xrCreateInstance',
-))
-
-# Nothing currently needs a special-cased terminator
-NEEDS_TERMINATOR = set()
 
 # This is a list of extensions that the loader implements.  This means that
 # the runtime underneath may not support these extensions and the terminators
@@ -173,16 +149,12 @@ class LoaderSourceOutputGenerator(AutomaticSourceOutputGenerator):
             file_data += 'extern "C" { \n'
             file_data += '#endif\n'
             file_data += self.outputLoaderManualFuncs()
-            file_data += self.outputLoaderGeneratedPrototypes()
             file_data += '#ifdef __cplusplus\n'
             file_data += '} // extern "C"\n'
             file_data += '#endif\n'
-            file_data += self.outputLoaderMapExterns()
 
         elif self.genOpts.filename == 'xr_generated_loader.cpp':
-            file_data += self.outputLoaderMapDefines()
             file_data += self.outputLoaderGeneratedFuncs()
-            file_data += self.outputLoaderExportFuncs()
 
         write(file_data, file=self.outFile)
 
@@ -203,9 +175,7 @@ class LoaderSourceOutputGenerator(AutomaticSourceOutputGenerator):
                 commands = self.ext_commands
 
             for cur_cmd in commands:
-                if cur_cmd.name in MANUAL_LOADER_FUNCS or \
-                    cur_cmd.name in MANUAL_LOADER_INSTANCE_TERMINATOR_FUNCS or \
-                        cur_cmd.has_instance:
+                if not cur_cmd.name in MANUAL_LOADER_FUNCS:
                     if cur_cmd.ext_name != cur_extension_name:
                         if self.isCoreExtensionName(cur_cmd.ext_name):
                             manual_funcs += '\n// ---- Core %s loader manual functions\n' % cur_cmd.ext_name[11:].replace(
@@ -223,101 +193,12 @@ class LoaderSourceOutputGenerator(AutomaticSourceOutputGenerator):
                     manual_funcs += func_proto
                     manual_funcs += '\n'
 
-                    # If this is a command is implemented in the loader manually, but not only for
-                    # loader, add a prototype for the terminator (unless it doesn't have a terminator)
-                    if ((cur_cmd.name in MANUAL_LOADER_INSTANCE_FUNCS or cur_cmd.name in MANUAL_LOADER_INSTANCE_TERMINATOR_FUNCS)
-                            and cur_cmd.name not in self.no_trampoline_or_terminator):
-                        manual_funcs += self.getProto(cur_cmd, allow_export=False).replace(
-                            "XRAPI_CALL xr", "XRAPI_CALL LoaderXrTerm")
-                        manual_funcs += '\n'
-
                     if cur_cmd.protect_value:
                         manual_funcs += '#endif // %s\n' % cur_cmd.protect_string
 
-        # Add one that we need for layer termination
-        manual_funcs += '\n// Special use function to handle creating API Layer information during xrCreateInstance\n'
-        manual_funcs += 'XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermCreateApiLayerInstance(const XrInstanceCreateInfo* info,\n'
-        manual_funcs += '                                                                  const struct XrApiLayerCreateInfo* apiLayerInfo,\n'
-        manual_funcs += '                                                                  XrInstance* instance);\n'
-        manual_funcs += '\n'
         return manual_funcs
 
-    # Create a prototype for initializing the instance dispatch table for the loader.
-    #   self            the LoaderSourceOutputGenerator object
-    def outputLoaderGeneratedPrototypes(self):
-        generated_protos = '\n// Generated loader terminator prototypes\n'
-        for x in range(0, 2):
-            if x == 0:
-                commands = self.core_commands
-            else:
-                commands = self.ext_commands
-
-            for cur_cmd in commands:
-                if cur_cmd.name in NEEDS_TERMINATOR:
-                    if cur_cmd.protect_value:
-                        generated_protos += '#if %s\n' % cur_cmd.protect_string
-                    # Output the standard API form of the command
-                    raise RuntimeError
-                    generated_protos += cur_cmd.cdecl.replace(
-                        "XRAPI_CALL xr", "XRAPI_CALL LoaderGenTermXr")
-                    generated_protos += '\n'
-                    if cur_cmd.protect_value:
-                        generated_protos += '#endif // %s\n' % cur_cmd.protect_string
-
-        generated_protos += '// Instance Init Dispatch Table (put all terminators in first)\n'
-        generated_protos += 'void LoaderGenInitInstanceDispatchTable(XrInstance runtime_instance,\n'
-        generated_protos += '                                        std::unique_ptr<XrGeneratedDispatchTable>& table);\n\n'
-        return generated_protos
-
-    # Output global externs of unordered_maps and mutexes for each handle type.
-    #   self            the LoaderSourceOutputGenerator object
-    def outputLoaderMapExterns(self):
-        map_externs = '\n// Unordered maps and mutexes to lookup the instance for a given object type\n'
-        for handle in self.api_handles:
-            if handle.protect_value:
-                map_externs += '#if %s\n' % handle.protect_string
-            base_handle_name = undecorate(handle.name)
-            map_externs += 'extern HandleLoaderMap<%s> g_%s_map;\n' % (
-                handle.name, base_handle_name)
-            if handle.protect_value:
-                map_externs += '#endif // %s\n' % handle.protect_string
-        map_externs += '\n'
-        map_externs += '// Function used to clean up any residual map values that point to an instance prior to that\n'
-        map_externs += '// instance being deleted.\n'
-        map_externs += 'void LoaderCleanUpMapsForInstance(LoaderInstance *instance);\n'
-        map_externs += '\n'
-        return map_externs
-
-    # Instantiate the unordered_maps and mutexes for each of the object types.  Also, output a utility
-    # function that can be used to clean up everything for a particular instance if we get a xrDestroyInstance
-    # call.
-    #   self            the LoaderSourceOutputGenerator object
-    def outputLoaderMapDefines(self):
-        map_defines = '// Unordered maps to lookup the instance for a given object type\n'
-        for handle in self.api_handles:
-            base_handle_name = undecorate(handle.name)
-            if handle.protect_value:
-                map_defines += '#if %s\n' % handle.protect_string
-            map_defines += 'HandleLoaderMap<%s> g_%s_map;\n' % (
-                handle.name, base_handle_name)
-            if handle.protect_value:
-                map_defines += '#endif // %s\n' % handle.protect_string
-        map_defines += '\n'
-        map_defines += '// Function used to clean up any residual map values that point to an instance prior to that\n'
-        map_defines += '// instance being deleted.\n'
-        map_defines += 'void LoaderCleanUpMapsForInstance(LoaderInstance *instance) {\n'
-        for handle in self.api_handles:
-            if handle.protect_value:
-                map_defines += '#if %s\n' % handle.protect_string
-            base_handle_name = undecorate(handle.name)
-            map_defines += '    g_%s_map.RemoveHandlesForLoader(*instance);\n' % base_handle_name
-            if handle.protect_value:
-                map_defines += '#endif // %s\n' % handle.protect_string
-        map_defines += '}\n\n'
-
-        return map_defines
-
-    # Output loader generated functions.  This has special cases for create and destroy commands
+   # Output loader generated functions.  This has special cases for create and destroy commands
     # since we have to associate the created objects with the original instance during the create,
     # and then remove that association in the delete.
     #   self            the LoaderSourceOutputGenerator object
@@ -346,18 +227,15 @@ class LoaderSourceOutputGenerator(AutomaticSourceOutputGenerator):
                 # Remove 'xr' from proto name
                 base_name = cur_cmd.name[2:]
 
-                just_return_call = False
                 has_return = False
 
                 if cur_cmd.is_create_connect or cur_cmd.is_destroy_disconnect:
                     has_return = True
                 elif cur_cmd.return_type is not None:
                     has_return = True
-                    just_return_call = True
 
                 tramp_variable_defines = ''
                 tramp_param_replace = []
-                func_follow_up = ''
                 base_handle_name = ''
 
                 for count, param in enumerate(cur_cmd.params):
@@ -381,74 +259,17 @@ class LoaderSourceOutputGenerator(AutomaticSourceOutputGenerator):
                         if param.is_handle:
                             base_handle_name = undecorate(param.type)
                             first_handle_name = self.getFirstHandleName(param)
-                            if pointer_count == 1 and param.pointer_count_var is not None:
-                                if not param.is_optional:
-                                    # Check we have at least 1 in the array.
-                                    tramp_variable_defines += '    if (0 == %s) {\n' % param.pointer_count_var
-                                    tramp_variable_defines += generateErrorMessage(
-                                        3,
-                                        [cur_cmd.name, param.pointer_count_var, 'parameter'],
-                                        cur_cmd,
-                                        '"%s is 0, but %s is not optional"' % (param.pointer_count_var, param.name),
-                                        [(first_handle_name, self.genXrObjectType(param.type))]
-                                    )
-                                    tramp_variable_defines += '    }\n'
-                            tramp_variable_defines += '    LoaderInstance *loader_instance = g_%s_map.Get(%s);\n' % (
-                                base_handle_name, first_handle_name)
-                            if cur_cmd.is_destroy_disconnect:
-                                tramp_variable_defines += '    // Destroy the mapping entry for this item if it was valid.\n'
-                                tramp_variable_defines += '    if (nullptr != loader_instance) {\n'
-                                tramp_variable_defines += '            g_%s_map.Erase(%s);\n' % (
-                                    base_handle_name, first_handle_name)
-                                tramp_variable_defines += '    }\n'
+
+                            tramp_variable_defines += '    LoaderInstance* loader_instance;\n'
+                            tramp_variable_defines += '    XrResult result = ActiveLoaderInstance::Get(&loader_instance, "%s");\n' % (cur_cmd.name)
+                            tramp_variable_defines += '    if (XR_SUCCEEDED(result)) {\n'
+
                             # These should be mutually exclusive - verify it.
                             assert((not cur_cmd.is_destroy_disconnect) or
                                    (pointer_count == 0))
-
-                            if pointer_count == 1:
-                                # NOTE - @ 10-June-2019 this stanza is never exercised in loader code-gen. Consider whether necessary. DJH
-                                tramp_variable_defines += '    for (uint32_t i = 1; i < %s; ++i) {\n' % param.pointer_count_var
-                                tramp_variable_defines += '        LoaderInstance *elt_loader_instance = g_%s_map.Get(%s[i]);\n' % (
-                                    base_handle_name, param.name)
-                                tramp_variable_defines += '        if (elt_loader_instance == nullptr || elt_loader_instance != loader_instance) {\n'
-                                tramp_variable_defines += '            auto elt_name = "%s[" + std::to_string(i) + "]";\n' % param.name
-                                tramp_variable_defines += '            if (elt_loader_instance == nullptr) {\n'
-                                tramp_variable_defines += generateErrorMessage(
-                                    '                    ',
-                                    [cur_cmd.name, param.name, 'parameter'],
-                                    cur_cmd,
-                                    'elt_name + " is not a valid %s"' % (param.name),
-                                    [(first_handle_name + '[i]', self.genXrObjectType(param.type))]
-                                )
-                                tramp_variable_defines += '            } else {\n'
-                                tramp_variable_defines += generateErrorMessage(
-                                    '                    ',
-                                    [cur_cmd.name, param.name, 'parameter'],
-                                    cur_cmd,
-                                    '"%s[" + std::to_string(i) + "] belongs to a different instance than %s[0]"' % (param.name, param.name),
-                                    [(first_handle_name + '[i]', self.genXrObjectType(param.type))]
-                                )
-                                tramp_variable_defines += '            }\n'
-                                if has_return:
-                                    tramp_variable_defines += '            return XR_ERROR_HANDLE_INVALID;\n'
-                                tramp_variable_defines += '        }\n'
-                                tramp_variable_defines += '    }\n'
-                            tramp_variable_defines += '    if (nullptr == loader_instance) {\n'
-                            tramp_variable_defines += generateErrorMessage(
-                                '            ',
-                                [cur_cmd.name, param.name, 'parameter'],
-                                cur_cmd,
-                                '"%s is not a valid %s"' % (first_handle_name, param.type),
-                                [(first_handle_name, self.genXrObjectType(param.type))]
-                            )
-                            if has_return:
-                                tramp_variable_defines += '        return XR_ERROR_HANDLE_INVALID;\n'
-                            tramp_variable_defines += '    }\n'
                         else:
                             tramp_variable_defines += self.printCodeGenErrorMessage(
                                 'Command %s does not have an OpenXR Object handle as the first parameter.' % cur_cmd.name)
-
-                        tramp_variable_defines += '    const std::unique_ptr<XrGeneratedDispatchTable>& dispatch_table = loader_instance->DispatchTable();\n'
 
                     tramp_param_replace.append(
                         self.MemberOrParam(type=param.type,
@@ -470,31 +291,7 @@ class LoaderSourceOutputGenerator(AutomaticSourceOutputGenerator):
                                            valid_extension_structs=None,
                                            cdecl=param.cdecl,
                                            values=param.values))
-
-                    if count == len(cur_cmd.params) - 1:
-                        if param.is_handle:
-                            base_handle_name = undecorate(param.type)
-                            if cur_cmd.is_create_connect:
-                                func_follow_up += '        if (XR_SUCCESS == result && nullptr != %s) {\n' % param.name
-                                func_follow_up += '            XrResult insert_result = g_%s_map.Insert(*%s, *loader_instance);\n' % (
-                                    base_handle_name, param.name)
-                                func_follow_up += '            if (XR_FAILED(insert_result)) {\n'
-                                func_follow_up += '                LoaderLogger::LogErrorMessage(\n'
-                                func_follow_up += '                    "%s",\n' % cur_cmd.name
-                                func_follow_up += '                    "Failed inserting new %s into map: may be null or not unique");\n' % base_handle_name
-                                func_follow_up += '            }\n'
-                                func_follow_up += '        }\n'
                     count = count + 1
-
-                if has_return and not just_return_call:
-                    return_prefix = '        '
-                    return_prefix += cur_cmd.return_type.text
-                    return_prefix += ' result'
-                    if cur_cmd.return_type.text == 'XrResult':
-                        return_prefix += ' = XR_SUCCESS;\n'
-                    else:
-                        return_prefix += ';\n'
-                    tramp_variable_defines += return_prefix
 
                 if cur_cmd.protect_value:
                     generated_funcs += '#if %s\n' % cur_cmd.protect_string
@@ -505,27 +302,24 @@ class LoaderSourceOutputGenerator(AutomaticSourceOutputGenerator):
 
                 # If this is not core, but an extension, check to make sure the extension is enabled.
                 if x == 1:
-                    generated_funcs += '    if (!loader_instance->ExtensionIsEnabled("%s")) {\n' % (
+                    generated_funcs += '        if (!loader_instance->ExtensionIsEnabled("%s")) {\n' % (
                         cur_cmd.ext_name)
-                    generated_funcs += '        LoaderLogger::LogValidationErrorMessage("VUID-%s-extension-notenabled",\n' % cur_cmd.name
-                    generated_funcs += '                                                "%s",\n' % cur_cmd.name
-                    generated_funcs += '                                                "The %s extension has not been enabled prior to calling %s");\n' % (
+                    generated_funcs += '            LoaderLogger::LogValidationErrorMessage("VUID-%s-extension-notenabled",\n' % cur_cmd.name
+                    generated_funcs += '                                                    "%s",\n' % cur_cmd.name
+                    generated_funcs += '                                                    "The %s extension has not been enabled prior to calling %s");\n' % (
                         cur_cmd.ext_name, cur_cmd.name)
                     if has_return:
-                        generated_funcs += '        return XR_ERROR_FUNCTION_UNSUPPORTED;\n'
+                        generated_funcs += '            return XR_ERROR_FUNCTION_UNSUPPORTED;\n'
                     else:
-                        generated_funcs += '        return;\n'
-                    generated_funcs += '    }\n\n'
+                        generated_funcs += '            return;\n'
+                    generated_funcs += '        }\n\n'
 
                 if has_return:
-                    if just_return_call:
-                        generated_funcs += '    return '
-                    else:
-                        generated_funcs += '    result = '
+                    generated_funcs += '        result = '
                 else:
-                    generated_funcs += '    '
+                    generated_funcs += '        '
 
-                generated_funcs += 'dispatch_table->'
+                generated_funcs += 'loader_instance->DispatchTable()->'
                 generated_funcs += base_name
                 generated_funcs += '('
                 count = 0
@@ -536,355 +330,15 @@ class LoaderSourceOutputGenerator(AutomaticSourceOutputGenerator):
                     count = count + 1
                 generated_funcs += ');\n'
 
-                generated_funcs += func_follow_up
+                generated_funcs += '    }\n'
 
-                if has_return and not just_return_call:
+
+                if has_return:
                     generated_funcs += '    return result;\n'
 
-                generated_funcs += '}\nXRLOADER_ABI_CATCH_FALLBACK\n\n'
+                generated_funcs += '}\nXRLOADER_ABI_CATCH_FALLBACK\n'
 
-                # If this is a function that needs a terminator, provide the call to it, not the runtime.
-                # Only a few items need a terminator.  Usually something we want to be able to return information
-                # to the API layers and act as an interceptor prior to the runtime.
-                if cur_cmd.name in NEEDS_TERMINATOR:
-                    # Not currently used.
-                    raise NotImplementedError
-                    term_decl = cur_cmd.cdecl.replace(";", " {\n")
-                    term_decl = term_decl.replace(" xr", " LoaderGenTermXr")
-                    generated_funcs += term_decl
-
-                    loader_override_func = False
-
-                    if cur_cmd.ext_name in EXTENSIONS_LOADER_IMPLEMENTS or loader_override_func:
-                        generated_funcs += '    if (nullptr != dispatch_table->%s) {\n' % base_name
-
-                    if has_return:
-                        if just_return_call:
-                            generated_funcs += '    return '
-                        else:
-                            generated_funcs += '    result = '
-                    else:
-                        generated_funcs += '    '
-
-                    generated_funcs += 'dispatch_table->'
-                    generated_funcs += base_name
-                    generated_funcs += '('
-                    count = 0
-                    for param in cur_cmd.params:
-                        if count > 0:
-                            generated_funcs += ', '
-                        generated_funcs += param.name
-                        count = count + 1
-                    generated_funcs += ');\n'
-
-                    if cur_cmd.ext_name in EXTENSIONS_LOADER_IMPLEMENTS or loader_override_func:
-                        generated_funcs += '    }\n'
-
-                    if has_return and not just_return_call:
-                        generated_funcs += '    return result;\n'
-                    generated_funcs += '}\n'
                 if cur_cmd.protect_value:
                     generated_funcs += '#endif // %s\n' % cur_cmd.protect_string
                 generated_funcs += '\n'
         return generated_funcs
-
-    # Output the source of all the loader export functions.  This includes:
-    #  - The Loader's xrGetInstanceProcAddr trampoline
-    #  - The Loader's xrGetInstanceProcAddr terminator
-    #  - A Utility function for initializing a dispatch table
-    #  - A Utility function for updating a dispatch table
-    #   self            the LoaderSourceOutputGenerator object
-    def outputLoaderExportFuncs(self):
-        cur_extension_name = ''
-
-        export_funcs = '\n'
-        export_funcs += 'LOADER_EXPORT XRAPI_ATTR XrResult XRAPI_CALL xrGetInstanceProcAddr(XrInstance instance, const char* name,\n'
-        export_funcs += '                                                                   PFN_xrVoidFunction* function) XRLOADER_ABI_TRY {\n'
-        indent = 1
-        export_funcs += self.writeIndent(indent)
-        export_funcs += 'if (nullptr == function) {\n'
-        export_funcs += self.writeIndent(indent + 1)
-        export_funcs += 'LoaderLogger::LogValidationErrorMessage("VUID-xrGetInstanceProcAddr-function-parameter",\n'
-        export_funcs += self.writeIndent(indent + 1)
-        export_funcs += '                                        "xrGetInstanceProcAddr", "Invalid Function pointer");\n'
-        export_funcs += self.writeIndent(indent + 1)
-        export_funcs += '    return XR_ERROR_VALIDATION_FAILURE;\n'
-        export_funcs += self.writeIndent(indent)
-        export_funcs += '}\n'
-        export_funcs += self.writeIndent(indent)
-        export_funcs += 'if (nullptr == name) {\n'
-        export_funcs += self.writeIndent(indent + 1)
-        export_funcs += 'LoaderLogger::LogValidationErrorMessage("VUID-xrGetInstanceProcAddr-function-parameter",\n'
-        export_funcs += self.writeIndent(indent + 1)
-        export_funcs += '                                        "xrGetInstanceProcAddr", "Invalid Name pointer");\n'
-        export_funcs += self.writeIndent(indent + 1)
-        export_funcs += '    return XR_ERROR_VALIDATION_FAILURE;\n'
-        export_funcs += self.writeIndent(indent)
-        export_funcs += '}\n'
-        export_funcs += self.writeIndent(indent)
-        export_funcs += '// Initialize the function to nullptr in case it does not get caught in a known case\n'
-        export_funcs += self.writeIndent(indent)
-        export_funcs += '*function = nullptr;\n'
-        export_funcs += self.writeIndent(indent)
-        export_funcs += 'if (name[0] == \'x\' && name[1] == \'r\') {\n'
-        indent = indent + 1
-        export_funcs += self.writeIndent(indent)
-        export_funcs += 'std::string func_name = &name[2];\n'
-        export_funcs += self.writeIndent(indent)
-        export_funcs += 'LoaderInstance * const loader_instance = g_instance_map.Get(instance);\n'
-        export_funcs += self.writeIndent(indent)
-        export_funcs += 'if (instance == XR_NULL_HANDLE) {\n'
-        indent = indent + 1
-        export_funcs += self.writeIndent(indent)
-        export_funcs += '// Null instance is allowed for 3 specific API entry points, otherwise return error\n'
-        export_funcs += self.writeIndent(indent)
-        export_funcs += 'if (!((func_name == "CreateInstance") ||\n'
-        export_funcs += self.writeIndent(indent)
-        export_funcs += '      (func_name == "EnumerateApiLayerProperties") ||\n'
-        export_funcs += self.writeIndent(indent)
-        export_funcs += '      (func_name == "EnumerateInstanceExtensionProperties"))) {\n'
-        indent = indent + 1
-        export_funcs += self.writeIndent(indent)
-        export_funcs += 'std::string error_str = "XR_NULL_HANDLE for instance but query for ";\n'
-        export_funcs += self.writeIndent(indent)
-        export_funcs += 'error_str += name;\n'
-        export_funcs += self.writeIndent(indent)
-        export_funcs += 'error_str += " requires a valid instance";\n'
-        export_funcs += self.writeIndent(indent)
-        export_funcs += 'LoaderLogger::LogValidationErrorMessage("VUID-xrGetInstanceProcAddr-instance-parameter",\n'
-        export_funcs += self.writeIndent(indent)
-        export_funcs += '                                        "xrGetInstanceProcAddr", error_str);\n'
-        export_funcs += self.writeIndent(indent)
-        export_funcs += 'return XR_ERROR_HANDLE_INVALID;\n'
-        indent = indent - 1
-        export_funcs += self.writeIndent(indent)
-        export_funcs += '}\n'
-        indent = indent - 1
-        export_funcs += self.writeIndent(indent)
-        export_funcs += '}\n'
-        export_funcs += self.writeIndent(indent)
-        export_funcs += 'else if (loader_instance == nullptr) {\n'
-        indent = indent + 1
-        export_funcs += self.writeIndent(indent)
-        export_funcs += 'std::string error_str = "Invalid handle for instance (query for ";\n'
-        export_funcs += self.writeIndent(indent)
-        export_funcs += 'error_str += name;\n'
-        export_funcs += self.writeIndent(indent)
-        export_funcs += 'error_str += " )";\n'
-        export_funcs += self.writeIndent(indent)
-        export_funcs += 'LoaderLogger::LogValidationErrorMessage("VUID-xrGetInstanceProcAddr-instance-parameter",\n'
-        export_funcs += self.writeIndent(indent)
-        export_funcs += '                                        "xrGetInstanceProcAddr", error_str);\n'
-        export_funcs += self.writeIndent(indent)
-        export_funcs += 'return XR_ERROR_HANDLE_INVALID;\n'
-        indent = indent - 1
-        export_funcs += self.writeIndent(indent)
-        export_funcs += '}\n'
-
-        count = 0
-        for x in range(0, 2):
-            if x == 0:
-                commands = self.core_commands
-            else:
-                commands = self.ext_commands
-
-            for cur_cmd in commands:
-                if cur_cmd.ext_name != cur_extension_name:
-                    if self.isCoreExtensionName(cur_cmd.ext_name):
-                        export_funcs += '\n'
-                        export_funcs += self.writeIndent(indent)
-                        export_funcs += '// ---- Core %s commands\n\n' % cur_cmd.ext_name[11:].replace(
-                            "_", ".")
-                    else:
-                        export_funcs += '\n'
-                        export_funcs += self.writeIndent(indent)
-                        export_funcs += '// ---- %s extension commands\n\n' % cur_cmd.ext_name
-                    cur_extension_name = cur_cmd.ext_name
-
-                # Remove 'xr' from proto name
-                base_name = cur_cmd.name[2:]
-
-                if cur_cmd.protect_value:
-                    export_funcs += '#if %s\n' % cur_cmd.protect_string
-
-                if count == 0:
-                    export_funcs += self.writeIndent(indent)
-                    export_funcs += 'if (func_name == "%s") {\n' % (base_name)
-                else:
-                    export_funcs += self.writeIndent(indent)
-                    export_funcs += '} else if (func_name == "%s") {\n' % (
-                        base_name)
-                indent = indent + 1
-                count = count + 1
-
-                # Instance commands always need to start with trampoline to properly de-reference instance
-                if self.isCoreExtensionName(cur_cmd.ext_name):
-                    if cur_cmd.has_instance or cur_cmd.name in MANUAL_LOADER_FUNCS:
-                        export_funcs += self.writeIndent(indent)
-                        export_funcs += '*function = reinterpret_cast<PFN_xrVoidFunction>(%s);\n' % (
-                            cur_cmd.name)
-                    else:
-                        export_funcs += self.writeIndent(indent)
-                        export_funcs += '*function = reinterpret_cast<PFN_xrVoidFunction>(loader_instance->DispatchTable()->%s);\n' % (
-                            base_name)
-                else:
-                    export_funcs += self.writeIndent(indent)
-                    export_funcs += 'if (loader_instance->ExtensionIsEnabled("%s")) {\n' % (
-                        cur_cmd.ext_name)
-                    export_funcs += self.writeIndent(indent + 1)
-                    if cur_cmd.has_instance or cur_cmd.name in MANUAL_LOADER_FUNCS:
-                        export_funcs += '*function = reinterpret_cast<PFN_xrVoidFunction>(%s);\n' % (
-                            cur_cmd.name)
-                    else:
-                        export_funcs += '*function = reinterpret_cast<PFN_xrVoidFunction>(loader_instance->DispatchTable()->%s);\n' % (
-                            base_name)
-                    export_funcs += self.writeIndent(indent)
-                    export_funcs += '}\n'
-
-                if cur_cmd.protect_value:
-                    export_funcs += '#endif // %s\n' % cur_cmd.protect_string
-
-                indent = indent - 1
-        export_funcs += self.writeIndent(indent)
-        export_funcs += '}\n'
-        indent = indent - 1
-        export_funcs += self.writeIndent(indent)
-        export_funcs += '}\n'
-        export_funcs += self.writeIndent(indent)
-        export_funcs += 'if (*function == nullptr) {\n'
-        export_funcs += self.writeIndent(indent + 1)
-        export_funcs += 'return XR_ERROR_FUNCTION_UNSUPPORTED;\n'
-        export_funcs += self.writeIndent(indent)
-        export_funcs += '}\n'
-        export_funcs += self.writeIndent(indent)
-        export_funcs += 'return XR_SUCCESS;\n'
-        export_funcs += '}\n'
-        export_funcs += 'XRLOADER_ABI_CATCH_FALLBACK\n'
-
-        export_funcs += '\n// Terminator GetInstanceProcAddr function\n'
-        export_funcs += 'XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermGetInstanceProcAddr(XrInstance instance, const char* name,\n'
-        export_funcs += '                                                               PFN_xrVoidFunction* function) XRLOADER_ABI_TRY {\n'
-
-        count = 0
-        for x in range(0, 2):
-            if x == 0:
-                commands = self.core_commands
-            else:
-                commands = self.ext_commands
-
-            for cur_cmd in commands:
-                # Remove 'xr' from proto name
-                base_name = cur_cmd.name[2:]
-
-                # If this is a function that needs a terminator, provide the call to it, not the runtime.
-                # Anything with an XrInstance requires a terminator so we can unwrap it properly for the
-                # runtime.
-                if ((cur_cmd.name in MANUAL_LOADER_INSTANCE_FUNCS or cur_cmd.name in MANUAL_LOADER_INSTANCE_TERMINATOR_FUNCS)
-                        and cur_cmd.name not in self.no_trampoline_or_terminator) or cur_cmd.name in NEEDS_TERMINATOR:
-                    if cur_cmd.protect_value:
-                        export_funcs += '#if %s\n' % cur_cmd.protect_string
-                    if count == 0:
-                        export_funcs += '\n    // A few instance commands need to go through a loader terminator.\n'
-                        export_funcs += '    // Otherwise, go directly to the runtime version of the command if it exists.\n'
-                        export_funcs += '    // But first set the function pointer to NULL so that the fall-through below actually works.\n'
-                        export_funcs += '    *function = nullptr;\n\n'
-                        export_funcs += '    if (0 == strcmp(name, "%s")) {\n' % (
-                            cur_cmd.name)
-                    else:
-                        export_funcs += '    } else if (0 == strcmp(name, "%s")) {\n' % (
-                            cur_cmd.name)
-                    # If generated, the function should start with the prefix "LoaderGenTermXr"
-                    if cur_cmd.name in NEEDS_TERMINATOR:
-                        export_funcs += '        *function = reinterpret_cast<PFN_xrVoidFunction>(LoaderGenTermXr%s);\n' % (
-                            base_name)
-                    # Otherwise, the function should start with "LoaderXrTerm"
-                    else:
-                        export_funcs += '        *function = reinterpret_cast<PFN_xrVoidFunction>(LoaderXrTerm%s);\n' % (
-                            base_name)
-                    if cur_cmd.protect_value:
-                        export_funcs += '#endif // %s\n' % cur_cmd.protect_string
-                    count = count + 1
-
-        export_funcs += '    } else if (0 == strcmp(name, "xrCreateApiLayerInstance")) {\n'
-        export_funcs += '        // Special layer version of xrCreateInstance terminator.  If we get called this by a layer,\n'
-        export_funcs += '        // we simply re-direct the information back into the standard xrCreateInstance terminator.\n'
-        export_funcs += '        *function = reinterpret_cast<PFN_xrVoidFunction>(LoaderXrTermCreateApiLayerInstance);\n'
-        export_funcs += '    }\n'
-        export_funcs += '    if (nullptr != *function) {\n'
-        export_funcs += '        return XR_SUCCESS;\n'
-        export_funcs += '    }\n'
-        export_funcs += '    return RuntimeInterface::GetInstanceProcAddr(instance, name, function);\n'
-        export_funcs += '}\n'
-        export_funcs += 'XRLOADER_ABI_CATCH_FALLBACK\n\n'
-
-        export_funcs += '// Instance Init Dispatch Table (put all terminators in first)\n'
-        export_funcs += 'void LoaderGenInitInstanceDispatchTable(XrInstance instance, std::unique_ptr<XrGeneratedDispatchTable>& table) {\n'
-
-        count = 0
-        for x in range(0, 2):
-            if x == 0:
-                commands = self.core_commands
-            else:
-                commands = self.ext_commands
-
-            for cur_cmd in commands:
-                if cur_cmd.ext_name != cur_extension_name:
-                    if self.isCoreExtensionName(cur_cmd.ext_name):
-                        export_funcs += '\n    // ---- Core %s commands\n' % cur_cmd.ext_name[11:]
-                    else:
-                        export_funcs += '\n    // ---- %s extension commands\n' % cur_cmd.ext_name
-                    cur_extension_name = cur_cmd.ext_name
-
-                # Remove 'xr' from proto name
-                base_name = cur_cmd.name[2:]
-
-                if cur_cmd.protect_value:
-                    export_funcs += '#if %s\n' % cur_cmd.protect_string
-
-                if cur_cmd.name in self.no_trampoline_or_terminator:
-                    export_funcs += '    table->%s = nullptr;\n' % base_name
-                else:
-                    export_funcs += '    LoaderXrTermGetInstanceProcAddr(instance, "%s", reinterpret_cast<PFN_xrVoidFunction*>(&table->%s));\n' % (
-                        cur_cmd.name, base_name)
-
-                if cur_cmd.protect_value:
-                    export_funcs += '#endif // %s\n' % cur_cmd.protect_string
-        export_funcs += '}\n\n'
-        export_funcs += '// Instance Update Dispatch Table with an API Layer Interface\n'
-        export_funcs += 'void ApiLayerInterface::GenUpdateInstanceDispatchTable(XrInstance instance, std::unique_ptr<XrGeneratedDispatchTable>& table) {\n'
-        export_funcs += '    PFN_xrVoidFunction cur_func_ptr;\n'
-        count = 0
-        for x in range(0, 2):
-            if x == 0:
-                commands = self.core_commands
-            else:
-                commands = self.ext_commands
-
-            for cur_cmd in commands:
-                if cur_cmd.ext_name != cur_extension_name:
-                    if self.isCoreExtensionName(cur_cmd.ext_name):
-                        export_funcs += '\n    // ---- Core %s commands\n' % cur_cmd.ext_name[11:]
-                    else:
-                        export_funcs += '\n    // ---- %s extension commands\n' % cur_cmd.ext_name
-                    cur_extension_name = cur_cmd.ext_name
-
-                # Remove 'xr' from proto name
-                base_name = cur_cmd.name[2:]
-
-                if cur_cmd.protect_value:
-                    export_funcs += '#if %s\n' % cur_cmd.protect_string
-
-                if cur_cmd.name not in self.no_trampoline_or_terminator:
-                    if cur_cmd.name == 'xrGetInstanceProcAddr':
-                        export_funcs += '    table->GetInstanceProcAddr = _get_instance_proc_addr;\n'
-                    else:
-                        export_funcs += '    _get_instance_proc_addr(instance, "%s", &cur_func_ptr);\n' % cur_cmd.name
-                        export_funcs += '    if (nullptr != cur_func_ptr) {\n'
-                        export_funcs += '        table->%s = reinterpret_cast<PFN_%s>(cur_func_ptr);\n' % (
-                            base_name, cur_cmd.name)
-                        export_funcs += '    }\n'
-
-                    if cur_cmd.protect_value:
-                        export_funcs += '#endif // %s\n' % cur_cmd.protect_string
-        export_funcs += '}\n'
-        return export_funcs

--- a/src/tests/loader_test/test_layers/layer_test.cpp
+++ b/src/tests/loader_test/test_layers/layer_test.cpp
@@ -19,6 +19,7 @@
 
 #include <cstring>
 #include <iostream>
+#include <map>
 
 #include "xr_dependencies.h"
 #include <openxr/openxr.h>
@@ -30,16 +31,33 @@
 #elif defined(__SUNPRO_C) && (__SUNPRO_C >= 0x590)
 #define LAYER_EXPORT __attribute__((visibility("default")))
 #else
-#define LAYER_EXPORT
+#define LAYER_EXPORT __declspec(dllexport)
 #endif
 
 extern "C" {
+std::map<XrInstance, PFN_xrGetInstanceProcAddr> g_next_gipa_map;
 
-XrResult LayerTestXrCreateInstance(const XrInstanceCreateInfo *info, XrInstance *instance) { return XR_SUCCESS; }
+XRAPI_ATTR XrResult XRAPI_CALL LayerTestXrCreateInstance(const XrInstanceCreateInfo *info, XrInstance *instance) {
+    // In a layer, LayerTestXrCreateApiLayerInstance is called instead of this function. This should not be called.
+    return XR_ERROR_FUNCTION_UNSUPPORTED;
+}
 
-XrResult LayerTestXrDestroyInstance(XrInstance instance) { return XR_SUCCESS; }
+XRAPI_ATTR XrResult XRAPI_CALL LayerTestXrDestroyInstance(XrInstance instance) {
+    // Call down to the next xrDestroyInstance.
+    PFN_xrVoidFunction nextDestroyInstance{nullptr};
+    XrResult res = g_next_gipa_map[instance](instance, "xrDestroyInstance", &nextDestroyInstance);
+    if (XR_SUCCEEDED(res)) {
+        res = reinterpret_cast<PFN_xrDestroyInstance>(nextDestroyInstance)(instance);
+    }
 
-XrResult LayerTestXrGetInstanceProcAddr(XrInstance instance, const char *name, PFN_xrVoidFunction *function) {
+    if (XR_SUCCEEDED(res)) {
+        g_next_gipa_map.erase(instance);
+    }
+
+    return res;
+}
+
+XRAPI_ATTR XrResult XRAPI_CALL LayerTestXrGetInstanceProcAddr(XrInstance instance, const char *name, PFN_xrVoidFunction *function) {
     if (0 == strcmp(name, "xrGetInstanceProcAddr")) {
         *function = reinterpret_cast<PFN_xrVoidFunction>(LayerTestXrGetInstanceProcAddr);
     } else if (0 == strcmp(name, "xrCreateInstance")) {
@@ -50,7 +68,36 @@ XrResult LayerTestXrGetInstanceProcAddr(XrInstance instance, const char *name, P
         *function = nullptr;
     }
 
-    return *function ? XR_SUCCESS : XR_ERROR_FUNCTION_UNSUPPORTED;
+    if (*function != nullptr) {
+        return XR_SUCCESS;
+    }
+
+    // If the function is not intercepted in this layer, call down to the next layer.
+    auto it = g_next_gipa_map.find(instance);
+    if (it == std::end(g_next_gipa_map)) {
+        return XR_ERROR_HANDLE_INVALID;
+    }
+
+    return it->second(instance, name, function);
+}
+
+XRAPI_ATTR XrResult XRAPI_CALL LayerTestXrCreateApiLayerInstance(const XrInstanceCreateInfo *info,
+                                                                 const XrApiLayerCreateInfo *apiLayerInfo, XrInstance *instance) {
+    // Call down to the next layer's xrCreateApiLayerInstance.
+    // Clone the XrApiLayerCreateInfo, but move to the next XrApiLayerNextInfo in the chain. nextInfo will be null
+    // if the loader's terminator function is going to be called (between the layer and the runtime) but this is OK
+    // because the loader's terminator function won't use it.
+    XrApiLayerCreateInfo newApiLayerInfo = *apiLayerInfo;
+    newApiLayerInfo.nextInfo = apiLayerInfo->nextInfo->next;
+
+    const XrResult res = apiLayerInfo->nextInfo->nextCreateApiLayerInstance(info, &newApiLayerInfo, instance);
+    if (XR_FAILED(res)) {
+        return res;  // The next layer's xrCreateApiLayerInstance failed.
+    }
+
+    g_next_gipa_map[*instance] = apiLayerInfo->nextInfo->nextGetInstanceProcAddr;
+
+    return XR_SUCCESS;
 }
 
 // Function used to negotiate an interface betewen the loader and a layer.  Each library exposing one or
@@ -71,7 +118,8 @@ LAYER_EXPORT XrResult xrNegotiateLoaderApiLayerInterface(const XrNegotiateLoader
 
     layerRequest->layerInterfaceVersion = XR_CURRENT_LOADER_API_LAYER_VERSION;
     layerRequest->layerApiVersion = XR_MAKE_VERSION(0, 1, 0);
-    layerRequest->getInstanceProcAddr = reinterpret_cast<PFN_xrGetInstanceProcAddr>(LayerTestXrGetInstanceProcAddr);
+    layerRequest->getInstanceProcAddr = LayerTestXrGetInstanceProcAddr;
+    layerRequest->createApiLayerInstance = LayerTestXrCreateApiLayerInstance;
 
     return XR_SUCCESS;
 }


### PR DESCRIPTION
The loader currently has a design which makes it incompatible with extensions/core api newer than the loader for two reasons:

1. The loader keeps a handle map in order to map an input handle (first parameter to a function) into a dispatch table for a known instance. Every instance can potentially have a different dispatch table depending on which extensions and layers are enabled. If a future extension  function (accessed through xrGetInstanceProcAddr) creates a handle, the loader won't know about this and won't be able to look up a handle in the dispatch table map.
2. The loader's implementation of xrGetInstanceProcAddr uses a strict set of function names mapped to the dispatch table. If a function name is not a known one, it will fail.

My main goal is to make the loader forward compatible so that it can be used with extensions that come out after the loader has been built. One use case is so that complex engines with many separate components can work without coordinating which loader to package. A secondary goal is to shrink and simplify the loader to minimize the chance for it to contain bugs (which would ship with the app).

The high level changes are:

* LoaderInstance is no longer tracked through a per-handle map. Instead there is a ActiveLoaderInstance which allows only one outstanding XrInstance handle at a time. If xrCreateInstance is called when another XrInstance is still alive, it will fail with XR_ERROR_LIMIT_REACHED. For this reason, care must be taken not to leak XrInstance handles.
* xrGetInstanceProcAddr no longer maps function name to dispatch table entry. Instead it uses the "topmost" xrGetInstanceProcAddr. Topmost means the API layer closest to the application or the runtime if there are no API layers. In practice this looks like: app -> openxr_loader!xrGetInstanceProcAddr (trampoline) -> [0..N API layers!xrGetInstanceProcAddr] -> openxr_loader!LoaderXrTermGetInstanceProcAddr (terminator) -> runtime!xrGetInstanceProcAddr.
* Similarly, the way the dispatch table is generated now uses the same "topmost" xrGetInstanceProcAddr. Previously the loader will populate the dispatch table from the terminator+runtime, then iterate through the API layers in reverse allowing them to sparsely replace any function pointers that they supported (see LoaderInstance::CreateDispatchTable). This required a lot of generated code which is now gone. The only benefit that I could see to it was that if an API layer did not forward calls for unsupported functions then it would break the loader, but this is not a valid implementation. I did find the 'loader_test/test_layers' implementation, used for testing the loader, had this kind of bug (which I've fixed). All other layers implemented it correctly. Now the loader can re-use the GeneratedXrPopulateDispatchTable function to generate the dispatch table instead.
* The amount of Python code to generate loader code has shrunk from ~900 lines to ~350. It no longer automatically generates many of the dispatch table generating functions now that GeneratedXrPopulateDispatchTable is being reused with the "topmost" xrGetInstanceProcAddr. * The specification requires that xrGetInstanceProcAddr return XR_ERROR_FUNCTION_UNSUPPORTED for any function in an extension that is not enabled. Previously the loader did this check for all functions in the generated code. Now, the loader relies on the API layers and runtimes to enforce this. The loader will still do this for the debug utils extension because it supports it. In the spirit of being forward compatible, it is not possible for the loader to know which functions are in extensions that it does not know about, so I think this makes sense.

Design decisions:
* I have kept the implementation of LoaderInstance decoupled from the 'singleton' instance requirement in the loader.
* I kept kept the implementation of RuntimeInterface as-is, with its support for multiple instances. In practice though, it will only ever have a single instance in its maps.

In the future, if there is need by apps to have multiple simultaneous XrInstances, then an alternative loader design will be required in order to do this. So far from survey of those using the loader, we have not yet heard of a need for this though.