### PR TITLE
Loader test changes

### DIFF
--- a/src/tests/loader_test/loader_test.cpp
+++ b/src/tests/loader_test/loader_test.cpp
@@ -161,7 +161,7 @@ void TestEnumLayers(uint32_t& total, uint32_t& passed, uint32_t& skipped, uint32
             local_failed++;
         } else {
             local_passed++;
-            cout << "Passed" << endl;
+            cout << "Passed: " << out_layer_value << " layers available." << endl;
         }
 
         // If any implicit layers are found, try property return
@@ -181,6 +181,9 @@ void TestEnumLayers(uint32_t& total, uint32_t& passed, uint32_t& skipped, uint32
             } else {
                 local_passed++;
                 cout << "Passed" << endl;
+                for (const auto& prop : layer_props) {
+                    cout << "           - " << prop.layerName << endl;
+                }
             }
         }
         num_before_explicit = out_layer_value;
@@ -204,8 +207,8 @@ void TestEnumLayers(uint32_t& total, uint32_t& passed, uint32_t& skipped, uint32
             local_failed++;
         } else {
             if (out_layer_value != num_before_explicit + num_valid_jsons) {
-                cout << "Failed, expected count " << std::to_string(num_before_explicit + num_valid_jsons) << ", got "
-                     << std::to_string(out_layer_value) << endl;
+                cout << "Failed, expected count " << (num_before_explicit + num_valid_jsons) << " (" << num_before_explicit
+                     << " seen earlier plus " << num_valid_jsons << " we added), got " << std::to_string(out_layer_value) << endl;
                 local_failed++;
             } else {
                 local_passed++;
@@ -267,6 +270,10 @@ void TestEnumLayers(uint32_t& total, uint32_t& passed, uint32_t& skipped, uint32
             } else if (!found_bad) {
                 cout << "Passed" << endl;
                 local_passed++;
+            }
+
+            for (const auto& prop : layer_props) {
+                cout << "           - " << prop.layerName << endl;
             }
         }
 

--- a/src/tests/loader_test/loader_test.cpp
+++ b/src/tests/loader_test/loader_test.cpp
@@ -178,6 +178,9 @@ void TestEnumLayers(uint32_t& total, uint32_t& passed, uint32_t& skipped, uint32
             if (XR_FAILED(test_result)) {
                 cout << "Failed with return " << std::to_string(test_result) << endl;
                 local_failed++;
+            } else {
+                local_passed++;
+                cout << "Passed" << endl;
             }
         }
         num_before_explicit = out_layer_value;


### PR DESCRIPTION
The first commit is a fix. The second one is extra output to figure out why I was getting a (presumably spurious?) failure when testing on Linux with no runtime installed:

```
~/src/OpenXR-SDK-Source(git✱≠master)❱✔≻ pushd build/src/tests/loader_test; ./loader_test; popd
Starting loader_test
--------------------
    Starting TestEnumLayers
        No explicit layers layer count check: Passed: 2 layers available.
        No explicit layers layer props query: Passed
           - XR_APILAYER_LUNARG_core_validation
           - XR_APILAYER_LUNARG_api_dump
        Simple explicit layers layer count check: Failed, expected count 8 (2 seen earlier plus 6 we added), got 6
        Simple explicit layers layer props query: Passed
           - XR_APILAYER_LUNARG_test_badnegotiate_invalid_api
           - XR_APILAYER_test
           - XR_APILAYER_LUNARG_test_badnegotiate_invalid_gipa
           - XR_APILAYER_LUNARG_test_badnegotiate_invalid_interface
           - XR_APILAYER_LUNARG_test_badnegotiate_always
           - XR_APILAYER_LUNARG_test_good_relative_path
    Finished TestEnumLayers : Failed (Local - Passed: 3, Failed: 1, Skipped: 0)

    Starting TestEnumInstanceExtensions
        JSON test_runtime_badjson_runtime_empty.json extension enum count query (with no explicit API layers): Passed
        JSON test_runtime_badnegotiate_invalid_gipa.json extension enum count query (with no explicit API layers): Passed
        JSON test_runtime_badjson_file_ver_minor_high.json extension enum count query (with no explicit API layers): Passed
        JSON test_runtime_badjson_file_ver_int.json extension enum count query (with no explicit API layers): Passed
        JSON test_runtime_badnegotiate_invalid_interface.json extension enum count query (with no explicit API layers): Passed
        JSON test_runtime_badnegotiate_invalid_api.json extension enum count query (with no explicit API layers): Passed
        JSON test_runtime_badjson_path_no_file.json extension enum count query (with no explicit API layers): Passed
        JSON test_runtime_badjson_path_int.json extension enum count query (with no explicit API layers): Passed
        JSON test_runtime_badjson_runtime_missing.json extension enum count query (with no explicit API layers): Passed
        JSON test_runtime_badjson_file_ver_missing.json extension enum count query (with no explicit API layers): Passed
        JSON test_runtime_badnegotiate_always.json extension enum count query (with no explicit API layers): Passed
        JSON test_runtime_badjson_path_missing.json extension enum count query (with no explicit API layers): Passed
        JSON test_runtime_badjson_file_ver_major_high.json extension enum count query (with no explicit API layers): Passed
        JSON test_runtime_badjson_file_ver_all_low.json extension enum count query (with no explicit API layers): Passed
        JSON test_runtime_badjson_file_ver_string.json extension enum count query (with no explicit API layers): Passed
        JSON test_runtime_badjson_runtime_empty.json extension enum count query (with explicit API layers): Passed
        JSON test_runtime_badnegotiate_invalid_gipa.json extension enum count query (with explicit API layers): Passed
        JSON test_runtime_badjson_file_ver_minor_high.json extension enum count query (with explicit API layers): Passed
        JSON test_runtime_badjson_file_ver_int.json extension enum count query (with explicit API layers): Passed
        JSON test_runtime_badnegotiate_invalid_interface.json extension enum count query (with explicit API layers): Passed
        JSON test_runtime_badnegotiate_invalid_api.json extension enum count query (with explicit API layers): Passed
        JSON test_runtime_badjson_path_no_file.json extension enum count query (with explicit API layers): Passed
        JSON test_runtime_badjson_path_int.json extension enum count query (with explicit API layers): Passed
        JSON test_runtime_badjson_runtime_missing.json extension enum count query (with explicit API layers): Passed
        JSON test_runtime_badjson_file_ver_missing.json extension enum count query (with explicit API layers): Passed
        JSON test_runtime_badnegotiate_always.json extension enum count query (with explicit API layers): Passed
        JSON test_runtime_badjson_path_missing.json extension enum count query (with explicit API layers): Passed
        JSON test_runtime_badjson_file_ver_major_high.json extension enum count query (with explicit API layers): Passed
        JSON test_runtime_badjson_file_ver_all_low.json extension enum count query (with explicit API layers): Passed
        JSON test_runtime_badjson_file_ver_string.json extension enum count query (with explicit API layers): Passed
    Finished TestEnumInstanceExtensions : Passed (Local - Passed: 30, Failed: 0, Skipped: 0)

No installed XR runtime detected - active runtime tests skipped(!)
    Results:
    ------------------------------
        Total Tests:    34
        Tests Passed:   33
        Tests Skipped:  0
        Tests Failed:   1
        Overall Result: Failed
```

Looks like it's losing the somehow-automatically-found layers.