### PR TITLE
hello_xr: Initialize hand_scale to 1.0

### DIFF
--- a/src/tests/hello_xr/openxr_program.cpp
+++ b/src/tests/hello_xr/openxr_program.cpp
@@ -351,7 +351,7 @@ struct OpenXrProgram : IOpenXrProgram {
         XrAction quitAction;
         std::array<XrPath, Side::COUNT> handSubactionPath;
         std::array<XrSpace, Side::COUNT> handSpace;
-        std::array<float, Side::COUNT> handScale;
+        std::array<float, Side::COUNT> handScale = {{1.0f, 1.0f}};
         std::array<XrBool32, Side::COUNT> handActive;
     };
 


### PR DESCRIPTION
Hand scale was default initialized to 0.0 which made controller cubes
invisible if the grabAction was not available/active on startup.