### PR TITLE
Fix loader test

### DIFF
--- a/src/scripts/generate_runtime_manifest.py
+++ b/src/scripts/generate_runtime_manifest.py
@@ -45,6 +45,19 @@ def main(argv):
         elif opt in ("-b", "--bad"):
             generate_badjson_jsons = True
 
+    file_text  = '{\n'
+    file_text += '    "file_format_version": "%s",\n' % cur_runtime_json_version
+    file_text += '    "runtime": {\n'
+    file_text += '        "library_path": "%s",\n' % library_location
+    file_text += '        "functions": {\n'
+    file_text += '           "xrNegotiateLoaderRuntimeInterface":\n'
+    file_text += '               "xrNegotiateLoaderRuntimeInterface"\n'
+    file_text += '       }\n'
+    file_text += '    }\n'
+    file_text += '}\n'
+    with open(output_file, 'w') as f:
+        f.write(file_text)
+
     if generate_badjson_jsons:
         # Bad File format versions
         ####################################

--- a/src/tests/loader_test/loader_test.cpp
+++ b/src/tests/loader_test/loader_test.cpp
@@ -130,7 +130,6 @@ void TestEnumLayers(uint32_t& total, uint32_t& passed, uint32_t& skipped, uint32
 #endif
     try {
         XrResult test_result = XR_SUCCESS;
-        uint32_t num_before_explicit = 0;
         std::vector<XrApiLayerProperties> layer_props;
 
 #if FILTER_OUT_LOADER_ERRORS == 1
@@ -186,9 +185,8 @@ void TestEnumLayers(uint32_t& total, uint32_t& passed, uint32_t& skipped, uint32
                 }
             }
         }
-        num_before_explicit = out_layer_value;
 
-        // Tests with some explicit layers added
+        // Tests with some explicit layers instead
         in_layer_value = 0;
         out_layer_value = 0;
         subtest_name = "Simple explicit layers";
@@ -206,9 +204,8 @@ void TestEnumLayers(uint32_t& total, uint32_t& passed, uint32_t& skipped, uint32
             cout << "Failed with return " << std::to_string(test_result) << endl;
             local_failed++;
         } else {
-            if (out_layer_value != num_before_explicit + num_valid_jsons) {
-                cout << "Failed, expected count " << (num_before_explicit + num_valid_jsons) << " (" << num_before_explicit
-                     << " seen earlier plus " << num_valid_jsons << " we added), got " << std::to_string(out_layer_value) << endl;
+            if (out_layer_value != num_valid_jsons) {
+                cout << "Failed, expected count " << num_valid_jsons << ", got " << std::to_string(out_layer_value) << endl;
                 local_failed++;
             } else {
                 local_passed++;
@@ -463,6 +460,11 @@ void TestEnumInstanceExtensions(uint32_t& total, uint32_t& passed, uint32_t& ski
                 }
             }
         }
+    } catch (std::exception const& e) {
+        cout << "Exception triggered during test (" << e.what() << "), automatic failure" << endl;
+        local_failed++;
+        local_total++;
+
     } catch (...) {
         cout << "Exception triggered during test, automatic failure" << endl;
         local_failed++;

--- a/src/tests/loader_test/test_runtimes/CMakeLists.txt
+++ b/src/tests/loader_test/test_runtimes/CMakeLists.txt
@@ -34,7 +34,6 @@ set_target_properties(test_runtime PROPERTIES FOLDER ${TESTS_FOLDER})
 add_dependencies(test_runtime
     xr_global_generated_files
     generate_openxr_header
-    generated_rt_json_files
 )
 target_include_directories(test_runtime
     PRIVATE ${PROJECT_SOURCE_DIR}/src
@@ -85,8 +84,5 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     )
 endif()
 
-add_custom_target(generated_rt_json_files DEPENDS
-    ${PROJECT_BINARY_DIR}/src/tests/loader_test/resources/runtimes/test_runtime.json
-)
-set_target_properties(generated_rt_json_files PROPERTIES FOLDER ${CODEGEN_FOLDER})
-
+# Add generated file to our sources so we depend on it, and thus trigger geenration.
+target_sources(test_runtime PRIVATE ${PROJECT_BINARY_DIR}/src/tests/loader_test/resources/runtimes/test_runtime.json)


### PR DESCRIPTION
Fixes #167 and makes the dummy runtime a little bit more useful - so you can run the openxr_runtime_list app against it.