### PR TITLE
hello_xr: Fix build issue.

### DIFF
--- a/changes/sdk/pr.170.gh.OpenXR-SDK-Source.md
+++ b/changes/sdk/pr.170.gh.OpenXR-SDK-Source.md
@@ -1,0 +1,1 @@
+Fix issue in `hello_xr` breaking the build in certain limited conditions.

--- a/src/tests/hello_xr/openxr_program.cpp
+++ b/src/tests/hello_xr/openxr_program.cpp
@@ -344,11 +344,11 @@ struct OpenXrProgram : IOpenXrProgram {
     }
 
     using InputState = struct {
-        XrActionSet actionSet;
-        XrAction grabAction;
-        XrAction poseAction;
-        XrAction vibrateAction;
-        XrAction quitAction;
+        XrActionSet actionSet{XR_NULL_HANDLE};
+        XrAction grabAction{XR_NULL_HANDLE};
+        XrAction poseAction{XR_NULL_HANDLE};
+        XrAction vibrateAction{XR_NULL_HANDLE};
+        XrAction quitAction{XR_NULL_HANDLE};
         std::array<XrPath, Side::COUNT> handSubactionPath;
         std::array<XrSpace, Side::COUNT> handSpace;
         std::array<float, Side::COUNT> handScale = {{1.0f, 1.0f}};
@@ -992,7 +992,7 @@ struct OpenXrProgram : IOpenXrProgram {
     bool m_sessionRunning{false};
 
     XrEventDataBuffer m_eventDataBuffer;
-    InputState m_input{XR_NULL_HANDLE};
+    InputState m_input;
 };
 }  // namespace
 


### PR DESCRIPTION
Seen only during Debian autopkgtests: hello_xr would fail to build on its own because of how this was being initialized.