### PR TITLE
Remove global static initializers from loader

### DIFF
--- a/src/loader/loader_core.cpp
+++ b/src/loader/loader_core.cpp
@@ -44,11 +44,18 @@
 #include <string>
 #include <utility>
 #include <vector>
-// Global lock to prevent reading JSON manifest files at the same time.
-static std::mutex g_loader_json_mutex;
 
+// Global lock to prevent reading JSON manifest files at the same time.
+std::mutex& GetLoaderJsonMutex() {
+    static std::mutex loader_json_mutex;
+    return loader_json_mutex;
+}
+ 
 // Global lock to prevent simultaneous instance creation/destruction
-static std::mutex g_instance_create_destroy_mutex;
+std::mutex& GetInstanceCreateDestroyMutex() {
+    static std::mutex instance_create_destroy_mutex;
+    return instance_create_destroy_mutex;
+}
 
 // Terminal functions needed by xrCreateInstance.
 XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermGetInstanceProcAddr(XrInstance, const char *, PFN_xrVoidFunction *);
@@ -84,7 +91,7 @@ LOADER_EXPORT XRAPI_ATTR XrResult XRAPI_CALL xrEnumerateApiLayerProperties(uint3
     LoaderLogger::LogVerboseMessage("xrEnumerateApiLayerProperties", "Entering loader trampoline");
 
     // Make sure only one thread is attempting to read the JSON files at a time.
-    std::unique_lock<std::mutex> json_lock(g_loader_json_mutex);
+    std::unique_lock<std::mutex> json_lock(GetLoaderJsonMutex());
 
     XrResult result = ApiLayerInterface::GetApiLayerProperties("xrEnumerateApiLayerProperties", propertyCapacityInput,
                                                                propertyCountOutput, properties);
@@ -118,7 +125,7 @@ xrEnumerateInstanceExtensionProperties(const char *layerName, uint32_t propertyC
 
     {
         // Make sure only one thread is attempting to read the JSON files at a time.
-        std::unique_lock<std::mutex> json_lock(g_loader_json_mutex);
+        std::unique_lock<std::mutex> json_lock(GetLoaderJsonMutex());
 
         // Get the layer extension properties
         result = ApiLayerInterface::GetInstanceExtensionProperties("xrEnumerateInstanceExtensionProperties", layerName,
@@ -235,7 +242,7 @@ LOADER_EXPORT XRAPI_ATTR XrResult XRAPI_CALL xrCreateInstance(const XrInstanceCr
         return XR_ERROR_VALIDATION_FAILURE;
     }
 
-    std::unique_lock<std::mutex> instance_lock(g_instance_create_destroy_mutex);
+    std::unique_lock<std::mutex> instance_lock(GetInstanceCreateDestroyMutex());
 
     // Check if there is already an XrInstance that is alive. If so, another instance cannot be created.
     // The loader does not support multiple simultaneous instances because the loader is intended to be
@@ -252,7 +259,7 @@ LOADER_EXPORT XRAPI_ATTR XrResult XRAPI_CALL xrCreateInstance(const XrInstanceCr
 
     // Make sure only one thread is attempting to read the JSON files and use the instance.
     {
-        std::unique_lock<std::mutex> json_lock(g_loader_json_mutex);
+        std::unique_lock<std::mutex> json_lock(GetLoaderJsonMutex());
         // Load the available runtime
         result = RuntimeInterface::LoadRuntime("xrCreateInstance");
         if (XR_FAILED(result)) {
@@ -329,7 +336,7 @@ LOADER_EXPORT XRAPI_ATTR XrResult XRAPI_CALL xrDestroyInstance(XrInstance instan
         return XR_ERROR_HANDLE_INVALID;
     }
 
-    std::unique_lock<std::mutex> loader_instance_lock(g_instance_create_destroy_mutex);
+    std::unique_lock<std::mutex> loader_instance_lock(GetInstanceCreateDestroyMutex());
 
     LoaderInstance *loader_instance;
     XrResult result = ActiveLoaderInstance::Get(&loader_instance, "xrDestroyInstance");
@@ -657,7 +664,7 @@ XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermCreateDebugUtilsMessengerEXT(XrInstan
         *messenger = reinterpret_cast<XrDebugUtilsMessengerEXT>(temp_mess_ptr);
     }
     if (XR_SUCCEEDED(result)) {
-        LoaderLogger::GetInstance().AddLogRecorderForXrInstance(instance, MakeDebugUtilsLoaderLogRecorder(createInfo, *messenger));
+        LoaderLogger::GetInstance().AddLogRecorder(MakeDebugUtilsLoaderLogRecorder(createInfo, *messenger));
         RuntimeInterface::GetRuntime().TrackDebugMessenger(instance, *messenger);
     }
     LoaderLogger::LogVerboseMessage("xrCreateDebugUtilsMessengerEXT", "Completed loader terminator");

--- a/src/loader/loader_core.cpp
+++ b/src/loader/loader_core.cpp
@@ -46,13 +46,13 @@
 #include <vector>
 
 // Global lock to prevent reading JSON manifest files at the same time.
-std::mutex& GetLoaderJsonMutex() {
+std::mutex &GetLoaderJsonMutex() {
     static std::mutex loader_json_mutex;
     return loader_json_mutex;
 }
- 
+
 // Global lock to prevent simultaneous instance creation/destruction
-std::mutex& GetInstanceCreateDestroyMutex() {
+std::mutex &GetInstanceCreateDestroyMutex() {
     static std::mutex instance_create_destroy_mutex;
     return instance_create_destroy_mutex;
 }

--- a/src/loader/loader_logger.cpp
+++ b/src/loader/loader_logger.cpp
@@ -38,9 +38,6 @@
 #include <utility>
 #include <vector>
 
-std::unique_ptr<LoaderLogger> LoaderLogger::_instance;
-std::once_flag LoaderLogger::_once_flag;
-
 bool LoaderLogRecorder::LogDebugUtilsMessage(XrDebugUtilsMessageSeverityFlagsEXT /*message_severity*/,
                                              XrDebugUtilsMessageTypeFlagsEXT /*message_type*/,
                                              const XrDebugUtilsMessengerCallbackDataEXT* /*callback_data*/) {

--- a/src/loader/loader_logger.hpp
+++ b/src/loader/loader_logger.hpp
@@ -122,8 +122,8 @@ class LoaderLogRecorder {
 class LoaderLogger {
    public:
     static LoaderLogger& GetInstance() {
-        std::call_once(LoaderLogger::_once_flag, []() { _instance.reset(new LoaderLogger); });
-        return *(_instance.get());
+        static LoaderLogger instance;
+        return instance;
     }
 
     void AddLogRecorder(std::unique_ptr<LoaderLogRecorder>&& recorder);
@@ -183,9 +183,6 @@ class LoaderLogger {
 
    private:
     LoaderLogger();
-
-    static std::unique_ptr<LoaderLogger> _instance;
-    static std::once_flag _once_flag;
 
     // List of *all* available recorder objects (including created specifically for an Instance)
     std::vector<std::unique_ptr<LoaderLogRecorder>> _recorders;

--- a/src/loader/runtime_interface.hpp
+++ b/src/loader/runtime_interface.hpp
@@ -40,7 +40,7 @@ class RuntimeInterface {
     // Helper functions for loading and unloading the runtime (but only when necessary)
     static XrResult LoadRuntime(const std::string& openxr_command);
     static void UnloadRuntime(const std::string& openxr_command);
-    static RuntimeInterface& GetRuntime() { return *(_single_runtime_interface.get()); }
+    static RuntimeInterface& GetRuntime() { return *(GetInstance().get()); }
     static XrResult GetInstanceProcAddr(XrInstance instance, const char* name, PFN_xrVoidFunction* function);
 
     // Get the direct dispatch table to this runtime, without API layers or loader terminators.
@@ -65,7 +65,11 @@ class RuntimeInterface {
     RuntimeInterface(LoaderPlatformLibraryHandle runtime_library, PFN_xrGetInstanceProcAddr get_instance_proc_addr);
     void SetSupportedExtensions(std::vector<std::string>& supported_extensions);
 
-    static std::unique_ptr<RuntimeInterface> _single_runtime_interface;
+    static std::unique_ptr<RuntimeInterface>& GetInstance() {
+      static std::unique_ptr<RuntimeInterface> instance;
+      return instance;
+    }
+
     static uint32_t _single_runtime_count;
     LoaderPlatformLibraryHandle _runtime_library;
     PFN_xrGetInstanceProcAddr _get_instance_proc_addr;

--- a/src/loader/runtime_interface.hpp
+++ b/src/loader/runtime_interface.hpp
@@ -66,8 +66,8 @@ class RuntimeInterface {
     void SetSupportedExtensions(std::vector<std::string>& supported_extensions);
 
     static std::unique_ptr<RuntimeInterface>& GetInstance() {
-      static std::unique_ptr<RuntimeInterface> instance;
-      return instance;
+        static std::unique_ptr<RuntimeInterface> instance;
+        return instance;
     }
 
     static uint32_t _single_runtime_count;


### PR DESCRIPTION
This change replaces global static initializers with functions that return static locals.  With this change code that includes OpenXR doesn't have to page in this code and initialize these during startup.