### PR TITLE
Return more descriptive error when no runtime is available

### DIFF
--- a/specification/registry/xr.xml
+++ b/specification/registry/xr.xml
@@ -1181,6 +1181,7 @@ maintained in the master branch of the Khronos OpenXR GitHub project.
         <enum value="-47"   name="XR_ERROR_ACTIONSETS_ALREADY_ATTACHED" comment="The session already has attached action sets." />
         <enum value="-48"   name="XR_ERROR_LOCALIZED_NAME_DUPLICATED" comment="The localized name provided was a duplicate of an already-existing resource."/>
         <enum value="-49"   name="XR_ERROR_LOCALIZED_NAME_INVALID" comment="The localized name provided was invalid."/>
+        <enum value="-50"   name="XR_ERROR_RUNTIME_UNAVAILABLE" comment="The loader was unable to find or load a runtime."/>
         <unused start="-100"/>
     </enums>
     <enums name="XrObjectType" type="enum" comment="Enums to track objects of various types">
@@ -1372,14 +1373,14 @@ maintained in the master branch of the Khronos OpenXR GitHub project.
             <param><type>uint32_t</type>* <name>propertyCountOutput</name></param>
             <param optional="true" len="propertyCapacityInput"><type>XrApiLayerProperties</type>* <name>properties</name></param>
         </command>
-        <command successcodes="XR_SUCCESS" errorcodes="XR_ERROR_OUT_OF_MEMORY,XR_ERROR_API_LAYER_NOT_PRESENT,XR_ERROR_RUNTIME_FAILURE,XR_ERROR_VALIDATION_FAILURE,XR_ERROR_SIZE_INSUFFICIENT">
+        <command successcodes="XR_SUCCESS" errorcodes="XR_ERROR_OUT_OF_MEMORY,XR_ERROR_API_LAYER_NOT_PRESENT,XR_ERROR_RUNTIME_FAILURE,XR_ERROR_VALIDATION_FAILURE,XR_ERROR_SIZE_INSUFFICIENT,XR_ERROR_RUNTIME_UNAVAILABLE">
             <proto><type>XrResult</type> <name>xrEnumerateInstanceExtensionProperties</name></proto>
             <param optional="true" len="null-terminated">const <type>char</type>* <name>layerName</name></param>
             <param optional="true"><type>uint32_t</type> <name>propertyCapacityInput</name></param>
             <param><type>uint32_t</type>* <name>propertyCountOutput</name></param>
             <param optional="true" len="propertyCapacityInput"><type>XrExtensionProperties</type>* <name>properties</name></param>
         </command>
-        <command successcodes="XR_SUCCESS" errorcodes="XR_ERROR_OUT_OF_MEMORY,XR_ERROR_LIMIT_REACHED,XR_ERROR_INSTANCE_LOST,XR_ERROR_RUNTIME_FAILURE,XR_ERROR_INITIALIZATION_FAILED,XR_ERROR_API_VERSION_UNSUPPORTED,XR_ERROR_API_LAYER_NOT_PRESENT,XR_ERROR_EXTENSION_NOT_PRESENT,XR_ERROR_VALIDATION_FAILURE,XR_ERROR_NAME_INVALID">
+        <command successcodes="XR_SUCCESS" errorcodes="XR_ERROR_OUT_OF_MEMORY,XR_ERROR_LIMIT_REACHED,XR_ERROR_INSTANCE_LOST,XR_ERROR_RUNTIME_FAILURE,XR_ERROR_INITIALIZATION_FAILED,XR_ERROR_API_VERSION_UNSUPPORTED,XR_ERROR_API_LAYER_NOT_PRESENT,XR_ERROR_EXTENSION_NOT_PRESENT,XR_ERROR_VALIDATION_FAILURE,XR_ERROR_NAME_INVALID,XR_ERROR_RUNTIME_UNAVAILABLE">
             <proto><type>XrResult</type> <name>xrCreateInstance</name></proto>
             <param>const <type>XrInstanceCreateInfo</type>* <name>createInfo</name></param>
             <param><type>XrInstance</type>* <name>instance</name></param>

--- a/src/loader/manifest_file.cpp
+++ b/src/loader/manifest_file.cpp
@@ -828,15 +828,8 @@ XrResult ApiLayerManifestFile::FindManifestFiles(ManifestFileType type,
     }
 #endif
 
-    switch (type) {
-        case MANIFEST_TYPE_IMPLICIT_API_LAYER:
-        case MANIFEST_TYPE_EXPLICIT_API_LAYER:
-            for (std::string &cur_file : filenames) {
-                ApiLayerManifestFile::CreateIfValid(type, cur_file, manifest_files);
-            }
-            break;
-        default:
-            break;
+    for (std::string &cur_file : filenames) {
+        ApiLayerManifestFile::CreateIfValid(type, cur_file, manifest_files);
     }
 
     return XR_SUCCESS;

--- a/src/loader/manifest_file.hpp
+++ b/src/loader/manifest_file.hpp
@@ -85,7 +85,7 @@ class ManifestFile {
 class RuntimeManifestFile : public ManifestFile {
    public:
     // Factory method
-    static XrResult FindManifestFiles(ManifestFileType type, std::vector<std::unique_ptr<RuntimeManifestFile>> &manifest_files);
+    static XrResult FindManifestFiles(std::vector<std::unique_ptr<RuntimeManifestFile>> &manifest_files);
 
    private:
     RuntimeManifestFile(const std::string &filename, const std::string &library_path);


### PR DESCRIPTION
We have seen many people confused by xrCreateInstance and xrEnumerateInstanceExtensionProperties returning XR_ERROR_INSTANCE_LOST when there was no active runtime on the device. This change adds a new error code XR_ERROR_RUNTIME_UNAVAILABLE returned by these functions when a runtime can't be found or loaded. I also found found and removed some dead code paths and unused variables.