### PR TITLE
Keep runtime loaded after xrEnumerateInstanceExtensionProperties call

### DIFF
--- a/specification/loader/design.adoc
+++ b/specification/loader/design.adoc
@@ -50,11 +50,8 @@ call if it requires a list of available runtime manifest files.
 [source,c++]
 ----
 static XrResult RuntimeManifestFile::FindManifestFiles(
-            ManifestFileType type,
             std::vector<std::unique_ptr<RuntimeManifestFile>> &manifest_files);
 ----
-  * pname:type indicates the specific type of manifest file being searched for.
-    In this case, it must: be `MANIFEST_TYPE_RUNTIME`.
   * pname:manifest_files is a vector that will be used to store a unique_ptr to
     each valid runtime manifest file found.
 

--- a/src/loader/loader_core.cpp
+++ b/src/loader/loader_core.cpp
@@ -135,7 +135,6 @@ xrEnumerateInstanceExtensionProperties(const char *layerName, uint32_t propertyC
             result = RuntimeInterface::LoadRuntime("xrEnumerateInstanceExtensionProperties");
             if (XR_SUCCEEDED(result)) {
                 RuntimeInterface::GetRuntime().GetInstanceExtensionProperties(extension_properties);
-                RuntimeInterface::UnloadRuntime("xrEnumerateInstanceExtensionProperties");
             } else {
                 LoaderLogger::LogErrorMessage("xrEnumerateInstanceExtensionProperties",
                                               "Failed to find default runtime with RuntimeInterface::LoadRuntime()");

--- a/src/loader/runtime_interface.cpp
+++ b/src/loader/runtime_interface.cpp
@@ -37,12 +37,9 @@
 #include <utility>
 #include <vector>
 
-uint32_t RuntimeInterface::_single_runtime_count = 0;
-
 XrResult RuntimeInterface::LoadRuntime(const std::string& openxr_command) {
     // If something's already loaded, we're done here.
     if (GetInstance() != nullptr) {
-        _single_runtime_count++;
         return XR_SUCCESS;
     }
 
@@ -150,7 +147,6 @@ XrResult RuntimeInterface::LoadRuntime(const std::string& openxr_command) {
 
             // Use this runtime
             GetInstance().reset(new RuntimeInterface(runtime_library, runtime_info.getInstanceProcAddr));
-            _single_runtime_count++;
 
             // Grab the list of extensions this runtime supports for easy filtering after the
             // xrCreateInstance call
@@ -183,13 +179,8 @@ XrResult RuntimeInterface::LoadRuntime(const std::string& openxr_command) {
 }
 
 void RuntimeInterface::UnloadRuntime(const std::string& openxr_command) {
-    if (_single_runtime_count == 1) {
-        _single_runtime_count = 0;
-        GetInstance().reset();
-    } else if (_single_runtime_count > 0) {
-        --_single_runtime_count;
-    }
     LoaderLogger::LogInfoMessage(openxr_command, "RuntimeInterface being unloaded.");
+    GetInstance().reset();
 }
 
 XrResult RuntimeInterface::GetInstanceProcAddr(XrInstance instance, const char* name, PFN_xrVoidFunction* function) {

--- a/src/loader/runtime_interface.cpp
+++ b/src/loader/runtime_interface.cpp
@@ -179,8 +179,10 @@ XrResult RuntimeInterface::LoadRuntime(const std::string& openxr_command) {
 }
 
 void RuntimeInterface::UnloadRuntime(const std::string& openxr_command) {
-    LoaderLogger::LogInfoMessage(openxr_command, "RuntimeInterface being unloaded.");
-    GetInstance().reset();
+    if (GetInstance()) {
+        LoaderLogger::LogInfoMessage(openxr_command, "RuntimeInterface::UnloadRuntime - Unloading RuntimeInterface");
+        GetInstance().reset();
+    }
 }
 
 XrResult RuntimeInterface::GetInstanceProcAddr(XrInstance instance, const char* name, PFN_xrVoidFunction* function) {

--- a/src/loader/runtime_interface.hpp
+++ b/src/loader/runtime_interface.hpp
@@ -70,7 +70,6 @@ class RuntimeInterface {
         return instance;
     }
 
-    static uint32_t _single_runtime_count;
     LoaderPlatformLibraryHandle _runtime_library;
     PFN_xrGetInstanceProcAddr _get_instance_proc_addr;
     std::unordered_map<XrInstance, std::unique_ptr<XrGeneratedDispatchTable>> _dispatch_table_map;

--- a/src/tests/loader_test/CMakeLists.txt
+++ b/src/tests/loader_test/CMakeLists.txt
@@ -24,7 +24,11 @@ add_executable(loader_test
 )
 set_target_properties(loader_test PROPERTIES FOLDER ${TESTS_FOLDER})
 
-add_dependencies(loader_test generate_openxr_header)
+add_dependencies(loader_test
+    generate_openxr_header
+    XrApiLayer_test
+    test_runtime
+)
 if(TARGET openxr-gfxwrapper)
     target_link_libraries(loader_test openxr-gfxwrapper)
 endif()

--- a/src/tests/loader_test/loader_test.cpp
+++ b/src/tests/loader_test/loader_test.cpp
@@ -67,7 +67,7 @@ void ForceLoaderUnloadRuntime() {
     XrInstanceCreateInfo instance_create_info{XR_TYPE_INSTANCE_CREATE_INFO};
     strcpy(instance_create_info.applicationInfo.applicationName, "Force Unload");
     instance_create_info.applicationInfo.applicationVersion = 688;
-    if (SUCCEEDED(xrCreateInstance(&instance_create_info, &instance))) {
+    if (XR_SUCCEEDED(xrCreateInstance(&instance_create_info, &instance))) {
         xrDestroyInstance(instance);
     }
 }


### PR DESCRIPTION
Most apps follow the pattern of calling xrEnumerateInstanceExtensionProperties before xrCreateInstance to inspect available extensions. This type of app will end up loading the runtime three times (and unloading two times) on startup:
1. First call to xrEnumerateInstanceExtensionProperties (two-call idiom, get the count) causes runtime to load an unload.
2. Second call to xrEnumerateInstanceExtensionProperties (two-call idiom, fill the buffer) causes the runtime to load and unload
3. xrCreateInstance causes the runtime to load

This is wildly inefficient. This change will result in the runtime staying alive after the first call to xrEnumerateInstanceExtensionProperties so that the runtime only loads once. The runtime only unloads if xrCreateInstance fails at a late stage (after the runtime was loaded) or on xrDestroyInstance.

The only scenario I can think this would affect is an app that only calls xrEnumerateInstanceExtensionProperties and never calls xrCreateInstance. In the case this type of app stays alive for a long time and the active runtime changes, the loader will not honor the change if an instance is then created. I do not know of an app that behaves this way (except for loader_tests). If this is ever needed, the loader could expose a loader-only function such as xrUnloadRuntime as an escape hatch.