### PR TITLE
hello_xr/vulkan: Fix build with Vulkan headers 1.2.136.

### DIFF
--- a/changes/sdk/pr.181.OpenXR-SDK-Source.md
+++ b/changes/sdk/pr.181.OpenXR-SDK-Source.md
@@ -1,0 +1,4 @@
+---
+- issue.180.OpenXR-SDK-Source
+---
+hello_xr: Fix build with Vulkan headers 1.2.136.

--- a/src/tests/hello_xr/graphicsplugin_vulkan.cpp
+++ b/src/tests/hello_xr/graphicsplugin_vulkan.cpp
@@ -1634,9 +1634,7 @@ struct VulkanGraphicsPlugin : public IGraphicsPlugin {
     _(SURFACE_KHR)           \
     _(SWAPCHAIN_KHR)         \
     _(DISPLAY_KHR)           \
-    _(DISPLAY_MODE_KHR)      \
-    _(OBJECT_TABLE_NVX)      \
-    _(INDIRECT_COMMANDS_LAYOUT_NVX)
+    _(DISPLAY_MODE_KHR)
 
         switch (objectType) {
             default:


### PR DESCRIPTION
Patch from @lubosz

Fixes #180 