### PR TITLE
cmake: Check for C++-17 and conditionally enable it

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,6 +22,15 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
+include(CheckCXXCompilerFlag)
+
+if("${CMAKE_MAJOR_VERSION}" EQUAL 3 AND "${CMAKE_MINOR_VERSION}" GREATER 7)
+    check_cxx_compiler_flag(-std=c++17 HAVE_FLAG_STD_CXX17)
+    if(HAVE_FLAG_STD_CXX17)
+        set(CMAKE_CXX_STANDARD 17)
+    endif()
+endif()
+
 include(GNUInstallDirs)
 
 ### Dependencies

--- a/src/loader/CMakeLists.txt
+++ b/src/loader/CMakeLists.txt
@@ -143,11 +143,19 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     endif()
 
     set_target_properties(openxr_loader PROPERTIES SOVERSION "${MAJOR}" VERSION "${MAJOR}.${MINOR}.${PATCH}")
-    target_link_libraries(
-        openxr_loader
-        PRIVATE stdc++fs
-        PUBLIC m
-    )
+
+    if(HAVE_FLAG_STD_CXX17)
+        target_link_libraries(
+            openxr_loader
+            PUBLIC m
+        )
+    else()
+        target_link_libraries(
+            openxr_loader
+            PRIVATE stdc++fs
+            PUBLIC m
+        )
+    endif()
 
     add_custom_target(
         libopenxr_loader.so.${MAJOR}.${MINOR} ALL


### PR DESCRIPTION
In GCC __cplusplus will be 201703 only if the -std=c++17 option is passed to the
compiler. Without this option the filesystem_utils.cpp won't compile under GCC
9.3.0, giving the following error:

src/common/filesystem_utils.cpp:74:10: fatal error: experimental/filesystem: No
such file or directory