### PR TITLE
Script to build NuGet package from OpenXR-SDK Release

### DIFF
--- a/.azure-pipelines/build_jobs.yml
+++ b/.azure-pipelines/build_jobs.yml
@@ -113,3 +113,24 @@ jobs:
       inputs:
         path: $(System.DefaultWorkingDirectory)/openxr_loader
         artifact: openxr_loader_windows
+
+    - task: PowerShell@2
+      displayName: Stage loader and headers for NuGet
+      inputs:
+        filePath: $(System.DefaultWorkingDirectory)/.azure-pipelines/nuget/stage_nuget.ps1
+        arguments:
+          $(System.DefaultWorkingDirectory)/openxr_loader `
+          $(Build.SourcesDirectory)/specification/Makefile `
+          $(System.DefaultWorkingDirectory)/openxr_loader_staging
+    - task: NuGetCommand@2
+      displayName: Package for NuGet
+      inputs:
+        command: pack
+        packagesToPack: $(System.DefaultWorkingDirectory)/openxr_loader_staging/OpenXR.Loader.nuspec
+        packDestination: $(System.DefaultWorkingDirectory)/nuget
+    - task: PublishPipelineArtifact@1
+      displayName: Publish NuGet Package
+      condition: succeeded()
+      inputs:
+        path: $(System.DefaultWorkingDirectory)/nuget
+        artifact: NuGet

--- a/.azure-pipelines/nuget/NugetTemplate/OpenXR.Loader.nuspec
+++ b/.azure-pipelines/nuget/NugetTemplate/OpenXR.Loader.nuspec
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>OpenXR.Loader</id>
+    <version></version>
+    <authors>Khronos Group</authors>
+    <owners>Khronos Group</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">Apache-2.0</license>
+    <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
+    <projectUrl>https://github.com/KhronosGroup/OpenXR-SDK</projectUrl>
+    <description>Khronos OpenXR loader and headers required to build a Win32 or UWP OpenXR application</description>
+    <tags>native khronos openxr loader</tags>
+  </metadata>
+</package>

--- a/.azure-pipelines/nuget/NugetTemplate/build/native/OpenXR.Loader.props
+++ b/.azure-pipelines/nuget/NugetTemplate/build/native/OpenXR.Loader.props
@@ -1,0 +1,5 @@
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <OpenXRPackageRoot>$(MSBuildThisFileDirectory)..\..\</OpenXRPackageRoot>
+  </PropertyGroup>
+</Project>

--- a/.azure-pipelines/nuget/NugetTemplate/build/native/OpenXR.Loader.targets
+++ b/.azure-pipelines/nuget/NugetTemplate/build/native/OpenXR.Loader.targets
@@ -1,0 +1,38 @@
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+    <Choose>
+        <When Condition="'$(ApplicationType)|$(ApplicationTypeRevision)' == 'Windows Store|10.0'">
+            <PropertyGroup>
+                <OpenXRLoaderBinaryRoot>$(OpenXRPackageRoot)native\$(Platform)_uwp\release</OpenXRLoaderBinaryRoot>
+            </PropertyGroup>
+        </When>
+        <Otherwise>
+            <PropertyGroup>
+                <OpenXRLoaderBinaryRoot>$(OpenXRPackageRoot)native\$(Platform)\release</OpenXRLoaderBinaryRoot>
+            </PropertyGroup>
+        </Otherwise>
+    </Choose>
+
+    <ItemDefinitionGroup>
+        <ClCompile>
+            <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(OpenXRPackageRoot)include</AdditionalIncludeDirectories>
+        </ClCompile>
+        <Link>
+            <AdditionalDependencies>%(AdditionalDependencies);$(OpenXRLoaderBinaryRoot)\lib\openxr_loader.lib</AdditionalDependencies>
+        </Link>
+    </ItemDefinitionGroup>
+
+    <!-- Copy the OpenXR loader DLL to the output directory and include in packaging -->
+    <ItemGroup Condition="'$(OpenXRSkipLoaderCopy)'!='true'">
+        <None Include="$(OpenXRLoaderBinaryRoot)\bin\openxr_loader.dll">
+            <Link>%(Filename)%(Extension)</Link>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+            <DeploymentContent>true</DeploymentContent>
+        </None>
+    </ItemGroup>
+
+    <Target Name="EnsurePropsImported" BeforeTargets="PrepareForBuild">
+        <Error Condition="'$(OpenXRPackageRoot)'==''" Text="OpenXRPackageRoot property missing. Project is malformed. Try removing and re-adding the NuGet reference." />
+    </Target>
+
+</Project>

--- a/.azure-pipelines/nuget/stage_nuget.ps1
+++ b/.azure-pipelines/nuget/stage_nuget.ps1
@@ -1,0 +1,74 @@
+param(
+    [Parameter(Mandatory=$true, HelpMessage="Path to unzipped openxr_loader_windows OpenXR-SDK release asset")]
+    $SDKRelease,
+    [Parameter(Mandatory=$true, HelpMessage="Path to specification Makefile. Needed to extract the version")]
+    $SpecMakefile,
+    [Parameter(Mandatory=$true, HelpMessage="Path create staged nuget directory layout")]
+    $NugetStaging)
+
+$ErrorActionPreference = "Stop"
+
+if (-Not (Test-Path $SDKRelease)) {
+    Throw "SDK Release folder not found: $SDKRelease"
+}
+if (-Not (Test-Path $SpecMakefile)) {
+    Throw "Specification makefile not found: $SpecMakefile"
+}
+
+$NugetTemplate = Join-Path $PSScriptRoot "NugetTemplate"
+
+if (Test-Path $NugetStaging) {
+    Remove-Item $NugetStaging -Recurse
+}
+
+#
+# Extract version from Specification makefile
+#
+$VersionMatch = Select-String -Path $SpecMakefile -Pattern "^SPECREVISION\s*=\s*(.+)"
+$SDKVersion = $VersionMatch.Matches[0].Groups[1]
+
+#
+# Start off using the NuGet template.
+#
+echo "Copy-Item $NugetTemplate $NugetStaging -Recurse"
+Copy-Item $NugetTemplate $NugetStaging -Recurse
+
+#
+# Update the NuSpec
+#
+$NuSpecPath = Resolve-Path (Join-Path $NugetStaging "OpenXR.Loader.nuspec")
+$xml = [xml](Get-Content $NuSpecPath)
+$nsm = New-Object Xml.XmlNamespaceManager($xml.NameTable)
+$nsm.AddNamespace("ng", "http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd")
+$xml.SelectSingleNode("/ng:package/ng:metadata/ng:version", $nsm).InnerText = $SDKVersion
+$xml.Save($NuSpecPath)
+
+#
+# Copy in the headers from the SDK release.
+#
+Copy-Item (Join-Path $SDKRelease "include") (Join-Path $NugetStaging "include") -Recurse
+
+#
+# Copy in the binaries from the SDK release.
+#
+function CopyLoader($Platform)
+{
+    $PlatformSDKPath = Join-Path $SDKRelease "$Platform"
+    $NuGetPlatformPath = Join-Path $NugetStaging "native/$Platform/release"
+
+    $NugetLibPath = Join-Path $NuGetPlatformPath "lib"
+    New-Item $NugetLibPath -ItemType "directory" -Force
+    Copy-Item (Join-Path $PlatformSDKPath "lib/openxr_loader.lib") $NugetLibPath
+
+    $NugetBinPath = Join-Path $NuGetPlatformPath "bin"
+    New-Item $NugetBinPath -ItemType "directory" -Force
+    Copy-Item (Join-Path $PlatformSDKPath "bin/openxr_loader.dll") $NugetBinPath
+}
+
+# Currently there are no non-UWP ARM/ARM64 binaries available from the SDK release.
+CopyLoader "x64"
+CopyLoader "Win32"
+CopyLoader "x64_uwp"
+CopyLoader "Win32_uwp"
+CopyLoader "arm64_uwp"
+CopyLoader "arm_uwp"

--- a/changes/sdk/pr.196.gh.OpenXR-SDK-Source.md
+++ b/changes/sdk/pr.196.gh.OpenXR-SDK-Source.md
@@ -1,0 +1,1 @@
+Modifications to Azure DevOps build pipeline to automatically generate a NuGet package.


### PR DESCRIPTION
This script can be run to generate the official NuGet package. It takes the released .zip file that is generated in the OpenXR-SDK CI as input to generate the .nupkg file.