### PR TITLE
Work around std::filesystem::canonical bug on UWP

### DIFF
--- a/changes/sdk/pr.198.gh.OpenXR-SDK-Source.md
+++ b/changes/sdk/pr.198.gh.OpenXR-SDK-Source.md
@@ -1,0 +1,1 @@
+Replace usage of std::filesystem::canonical with PathCchCanonicalize on Windows platform to work around bug on UWP platforms. This also replaces PathCanonicalize with PathCchCanonicalize and adds the appropriate library for linking in.

--- a/src/common/filesystem_utils.cpp
+++ b/src/common/filesystem_utils.cpp
@@ -88,6 +88,10 @@
 #endif
 
 #if defined(XR_USE_PLATFORM_WIN32)
+#include <PathCch.h>
+#endif
+
+#if defined(XR_USE_PLATFORM_WIN32)
 #define PATH_SEPARATOR ';'
 #define DIRECTORY_SYMBOL '\\'
 #define ALTERNATE_DIRECTORY_SYMBOL '/'
@@ -128,7 +132,18 @@ bool FileSysUtilsGetAbsolutePath(const std::string& path, std::string& absolute)
 }
 
 bool FileSysUtilsGetCanonicalPath(const std::string& path, std::string& canonical) {
+#if defined(XR_USE_PLATFORM_WIN32)
+    // std::filesystem::canonical fails on UWP and must be avoided. This alternative will not
+    // follow symbolic links but symbolic links are not needed on Windows since the loader uses
+    // the registry as a form of indirection instead.
+    wchar_t canonical_wide_path[MAX_PATH];
+    if (FAILED(PathCchCanonicalize(canonical_wide_path, MAX_PATH, utf8_to_wide(path).c_str()))) {
+        return false;
+    }
+    canonical = wide_to_utf8(canonical_wide_path);
+#else
     canonical = FS_PREFIX::canonical(path).string();
+#endif
     return true;
 }
 
@@ -216,7 +231,7 @@ bool FileSysUtilsGetAbsolutePath(const std::string& path, std::string& absolute)
 
 bool FileSysUtilsGetCanonicalPath(const std::string& path, std::string& absolute) {
     wchar_t tmp_path[MAX_PATH];
-    if (0 != PathCanonicalizeW(utf8_to_wide(path).c_str(), tmp_path)) {
+    if (SUCCEEDED(PathCchCanonicalize(tmp_path, MAX_PATH, utf8_to_wide(path)))) {
         absolute = wide_to_utf8(tmp_path);
         return true;
     }

--- a/src/common/filesystem_utils.cpp
+++ b/src/common/filesystem_utils.cpp
@@ -231,7 +231,7 @@ bool FileSysUtilsGetAbsolutePath(const std::string& path, std::string& absolute)
 
 bool FileSysUtilsGetCanonicalPath(const std::string& path, std::string& absolute) {
     wchar_t tmp_path[MAX_PATH];
-    if (SUCCEEDED(PathCchCanonicalize(tmp_path, MAX_PATH, utf8_to_wide(path)))) {
+    if (SUCCEEDED(PathCchCanonicalize(tmp_path, MAX_PATH, utf8_to_wide(path).c_str()))) {
         absolute = wide_to_utf8(tmp_path);
         return true;
     }

--- a/src/loader/CMakeLists.txt
+++ b/src/loader/CMakeLists.txt
@@ -183,7 +183,7 @@ elseif(WIN32)
         target_compile_options(openxr_loader PRIVATE /wd6386)
     endif()
 
-    target_link_libraries(openxr_loader PRIVATE advapi32)
+    target_link_libraries(openxr_loader PUBLIC advapi32 pathcch)
 
     # Need to copy DLL to client directories so clients can easily load it.
     if(DYNAMIC_LOADER AND (CMAKE_GENERATOR MATCHES "^Visual Studio.*"))


### PR DESCRIPTION
We found a change in the 1.0.10 loader to use std::filesystem::canonical broke UWP apps on Windows (used mostly for HoloLens 2). Based on my investigation this STL function is broken on the UWP platform and always fails with an access denied error code. I will be opening a bug on the Microsoft STL about this. The use of canonical was introduced for Linux so that a relative path in a JSON manifest would be relative to the real manifest file and not the symbol link path. This functionality is not important on Windows because the registry is used for redirection instead, and so symbol links are not needed and their use is also uncommon on Windows. For this reason PathCchCanonicalize is used instead of std::filesystem::canonical on Windows. This also fixes #197 by replacing use of PathCanonicalize with PathCchCanonicalize which is documented as the recommended API.