### PR TITLE
Add file formatting checks to CI

### DIFF
--- a/.azure-pipelines/build_jobs.yml
+++ b/.azure-pipelines/build_jobs.yml
@@ -116,7 +116,7 @@ jobs:
       # Use the specified version of Python from the tool cache
       - task: UsePythonVersion@0
         inputs:
-          versionSpec: '3.9' 
+          versionSpec: '3.9'
       - task: PythonScript@0
         displayName: Move artifact contents
         inputs:

--- a/.azure-pipelines/check_file_format.yml
+++ b/.azure-pipelines/check_file_format.yml
@@ -1,0 +1,24 @@
+# Copyright (c) 2020 The Khronos Group Inc.
+# SPDX-License-Identifier: Apache-2.0
+jobs:
+- job: check_file_format
+  displayName: 'Check file formatting'
+  pool:
+    vmImage: 'ubuntu-20.04'
+  container: khronosgroup/docker-images:openxr-sdk
+  steps:
+    - script: sudo apt-get install -qq dos2unix recode
+      displayName: Install dependencies
+    - script: ./file_format.sh
+      displayName: File formatting checks (file_format.sh)
+
+    - script: git diff --patch --exit-code > file_format.patch
+      displayName: Save changes as diff
+    - script: echo "The following files need file formatting:"; sed -n -e "s/^diff.* b\///p" file_format.patch
+      condition: failed()
+    - task: PublishPipelineArtifact@1
+      displayName: Publish diff
+      condition: failed()
+      inputs:
+        path: $(System.DefaultWorkingDirectory)/file_format.patch
+        artifact: file_format_changes

--- a/file_format.sh
+++ b/file_format.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Copyright (c) 2020 The Khronos Group Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# This script ensures proper POSIX text file formatting and a few other things.
+# This is supplementary to clang-format.
+
+# We need dos2unix and recode.
+if [ ! -x "$(command -v dos2unix)" -o ! -x "$(command -v recode)" ]; then
+    printf "Install 'dos2unix' and 'recode' to use this script.\n"
+fi
+
+set -e -uo pipefail
+IFS=$'\n\t'
+
+# Loops through all text files tracked by Git.
+git grep -zIl '' |
+while IFS= read -rd '' f; do
+    # Exclude some files.
+    if [[ "$f" == "external"* ]]; then
+        continue
+    elif [[ "$f" == "src/external"* ]]; then
+        continue
+    fi
+    # Ensure that files are UTF-8 formatted.
+    recode UTF-8 "$f" 2> /dev/null
+    # Ensure that files have LF line endings and do not contain a BOM.
+    dos2unix "$f" 2> /dev/null
+    # Remove trailing space characters and ensures that files end
+    # with newline characters. -l option handles newlines conveniently.
+    perl -i -ple 's/\s*$//g' "$f"
+done
+
+# If no patch has been generated all is OK, clean up, and exit.
+if git diff --exit-code > patch.patch; then
+    printf "Files in this commit comply with the formatting rules.\n"
+    rm -f patch.patch
+    exit 0
+fi
+
+# A patch has been created, notify the user, clean up, and exit.
+printf "\n*** The following differences were found between the code "
+printf "and the formatting rules:\n\n"
+cat patch.patch
+printf "\n*** Aborting, please fix your commit(s) with 'git commit --amend' or 'git rebase -i <hash>'\n"
+rm -f patch.patch
+exit 1

--- a/specification/registry/xr.xml
+++ b/specification/registry/xr.xml
@@ -3528,7 +3528,7 @@ maintained in the default branch of the Khronos OpenXR GitHub project.
 
           <type name="XrEventDataDisplayRefreshRateChangedFB"/>
           <enum offset="0"  extends="XrStructureType"  name="XR_TYPE_EVENT_DATA_DISPLAY_REFRESH_RATE_CHANGED_FB"/>
- 
+
           <command name="xrEnumerateDisplayRefreshRatesFB"/>
           <command name="xrGetDisplayRefreshRateFB"/>
           <command name="xrRequestDisplayRefreshRateFB"/>
@@ -3570,14 +3570,14 @@ maintained in the default branch of the Khronos OpenXR GitHub project.
             <enum value="&quot;XR_HTC_extension_107&quot;" name="XR_HTC_extension_107_EXTENSION_NAME"/>
         </require>
     </extension>
-    
+
     <extension name="XR_HTC_extension_108" number="108" type="instance" supported="disabled">
         <require>
             <enum value="1" name="XR_HTC_extension_108_SPEC_VERSION"/>
             <enum value="&quot;XR_HTC_extension_108&quot;" name="XR_HTC_extension_108_EXTENSION_NAME"/>
         </require>
     </extension>
-    
+
     <extension name="XR_FB_color_space" number="109" type="instance" supported="openxr">
         <require>
             <enum value="1" name="XR_FB_color_space_SPEC_VERSION"/>

--- a/specification/scripts/docgenerator.py
+++ b/specification/scripts/docgenerator.py
@@ -291,7 +291,7 @@ class DocOutputGenerator(OutputGenerator):
             body += ';\n'
         body += '} ' + typeName + ';'
         return body
-    
+
     def genStruct(self, typeinfo, typeName, alias):
         """Generate struct."""
         OutputGenerator.genStruct(self, typeinfo, typeName, alias)

--- a/src/scripts/validation_layer_generator.py
+++ b/src/scripts/validation_layer_generator.py
@@ -501,7 +501,7 @@ class ValidationSourceOutputGenerator(AutomaticSourceOutputGenerator):
                     continue
             if struct_tuple.protect_value:
                 next_chain_info += '#if %s\n' % struct_tuple.protect_string
-                
+
             next_chain_info += self.writeIndent(2)
             next_chain_info += 'case %s:\n' % cur_value.name
             next_chain_info += self.writeIndent(3)


### PR DESCRIPTION
Follow-up to #208. The formatting script runs on every text file except for those in `external/` and `src/external/`.

Fingers crossed that the CI checks will work, in previous implementations I had this script set up through GitHub Actions, but since this repo uses Azure Pipelines I wrote a config for that by copying the clang-format one. It doesn't seem that the new checks are running with this PR, that might change if it's merged but I'm not sure, I'm not familiar with Azure Pipelines.