### PR TITLE
Fix mingw-w64 build errors

### DIFF
--- a/changes/sdk/pr.212.gh.OpenXR-SDK-Source.md
+++ b/changes/sdk/pr.212.gh.OpenXR-SDK-Source.md
@@ -1,0 +1,1 @@
+Fix build errors under mingw-w64.

--- a/src/common/filesystem_utils.cpp
+++ b/src/common/filesystem_utils.cpp
@@ -88,7 +88,7 @@
 #endif
 
 #if defined(XR_USE_PLATFORM_WIN32)
-#include <PathCch.h>
+#include <pathcch.h>
 #endif
 
 #if defined(XR_USE_PLATFORM_WIN32)

--- a/src/tests/hello_xr/logger.cpp
+++ b/src/tests/hello_xr/logger.cpp
@@ -28,7 +28,7 @@ void Write(Level severity, const std::string& msg) {
     const auto now = std::chrono::system_clock::now();
     const time_t now_time = std::chrono::system_clock::to_time_t(now);
     tm now_tm;
-#ifdef _MSC_VER
+#ifdef _WIN32
     localtime_s(&now_tm, &now_time);
 #else
     localtime_r(&now_time, &now_tm);


### PR DESCRIPTION
Fixes building with mingw-w64's headers on a case-sensitive filesystem.