### PR TITLE
Fix implicit API layer manifest example;

### DIFF
--- a/specification/loader/api_layer.adoc
+++ b/specification/loader/api_layer.adoc
@@ -415,12 +415,8 @@ only requirement is that the filename extension is ".json".
                "extension_version": "1"
            }
        ],
-       "enable_environment": {
-           "ENABLE_XR_API_LAYER_TEST_1": ""
-       }
-       "disable_environment": {
-           "DISABLE_XR_API_LAYER_TEST_1": ""
-       }
+       "enable_environment": "ENABLE_XR_API_LAYER_TEST_1",
+       "disable_environment": "DISABLE_XR_API_LAYER_TEST_1"
    }
 }
 ----


### PR DESCRIPTION
When using the implicit API layer example in the docs, the loader fails to load the layer properly, saying

```
Implicit layer /path/to/layer.json is missing "disable_environment"
```

After referring to other API layers, it looks like the key is supposed to be a string instead of an object.  Once this change is made to the manifest, the loader is able to load the layer.  This PR updates the docs to reflect that.