### PR TITLE
replace occurences of #if _WIN32 with #ifdef _WIN32

### DIFF
--- a/changes/sdk/pr.215.gh.OpenXR-SDK-Source.md
+++ b/changes/sdk/pr.215.gh.OpenXR-SDK-Source.md
@@ -1,0 +1,1 @@
+Loader: Replace #if _WIN32 with #ifdef _WIN32.

--- a/src/loader/loader_logger.cpp
+++ b/src/loader/loader_logger.cpp
@@ -120,7 +120,7 @@ LoaderLogger::LoaderLogger() {
         AddLogRecorder(MakeStdErrLoaderLogRecorder(nullptr));
     }
 
-#if _WIN32
+#ifdef _WIN32
     // Add an debugger logger by default so that we at least get errors out to the debugger.
     AddLogRecorder(MakeDebuggerLoaderLogRecorder(nullptr));
 #endif

--- a/src/loader/loader_logger_recorders.hpp
+++ b/src/loader/loader_logger_recorders.hpp
@@ -37,7 +37,7 @@ std::unique_ptr<LoaderLogRecorder> MakeStdOutLoaderLogRecorder(void* user_data, 
 std::unique_ptr<LoaderLogRecorder> MakeDebugUtilsLoaderLogRecorder(const XrDebugUtilsMessengerCreateInfoEXT* create_info,
                                                                    XrDebugUtilsMessengerEXT debug_messenger);
 
-#if _WIN32
+#ifdef _WIN32
 //! Win32 debugger output
 std::unique_ptr<LoaderLogRecorder> MakeDebuggerLoaderLogRecorder(void* user_data);
 #endif


### PR DESCRIPTION
I got this warning while compiling a project including the loader. Looks like it should have been `#ifdef`.
```
In file included from _deps/openxr-src/src/loader/loader_logger_recorders.cpp:22:
_deps/openxr-src/src/loader/loader_logger_recorders.hpp:40:5: warning: "_WIN32" is not defined, evaluates to 0 [-Wundef]
   40 | #if _WIN32
      |     ^~~~~~
```