### PR TITLE
Fix update of swapchain image context map

### DIFF
--- a/changes/sdk/pr.217.gh.OpenXR-SDK-Source.md
+++ b/changes/sdk/pr.217.gh.OpenXR-SDK-Source.md
@@ -1,0 +1,1 @@
+Fix: The D3D12 and Vulcan graphics plugins sometimes did not update their swapchain image context maps due to rare key collisions.

--- a/src/tests/hello_xr/graphicsplugin_d3d12.cpp
+++ b/src/tests/hello_xr/graphicsplugin_d3d12.cpp
@@ -317,7 +317,7 @@ struct D3D12GraphicsPlugin : public IGraphicsPlugin {
 
         // Map every swapchainImage base pointer to this context
         for (auto& base : bases) {
-            m_swapchainImageContextMap.emplace(std::make_pair(base, &swapchainImageContext));
+            m_swapchainImageContextMap[base] = &swapchainImageContext;
         }
 
         return bases;

--- a/src/tests/hello_xr/graphicsplugin_vulkan.cpp
+++ b/src/tests/hello_xr/graphicsplugin_vulkan.cpp
@@ -1524,7 +1524,7 @@ struct VulkanGraphicsPlugin : public IGraphicsPlugin {
 
         // Map every swapchainImage base pointer to this context
         for (auto& base : bases) {
-            m_swapchainImageContextMap.emplace(std::make_pair(base, &swapchainImageContext));
+            m_swapchainImageContextMap[base] = &swapchainImageContext;
         }
 
         return bases;


### PR DESCRIPTION
Adapted from [OpenXR-CTS PR#4](https://github.com/KhronosGroup/OpenXR-CTS/pull/4) as the conformance test suite shares ancestry with hello_xr.
