### PR TITLE
Arch subdirs

### DIFF
--- a/.azure-pipelines/build_jobs.yml
+++ b/.azure-pipelines/build_jobs.yml
@@ -64,7 +64,7 @@ jobs:
           sourceDir: ${{parameters.sourceDir}}
           buildType: $(buildType)
           generator: "$(generator)"
-          cmakeArgs: $(cmakeArgs) -DBUILD_ALL_EXTENSIONS=ON
+          cmakeArgs: $(cmakeArgs) -DBUILD_ALL_EXTENSIONS=ON -DINSTALL_TO_ARCHITECTURE_PREFIXES=ON
           useVulkan: "true"
 
       - task: PublishPipelineArtifact@1
@@ -104,7 +104,16 @@ jobs:
       - download: current
         patterns: "**/*.h"
         displayName: Download headers
-
+      - download: current
+        patterns: "**/*.cmake"
+        displayName: Download CMake scripts
+      - download: current
+        patterns: "**/*.exe"
+        displayName: Download executables scripts
+      # Use the specified version of Python from the tool cache
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: '3.9' 
       - task: PythonScript@0
         displayName: Move artifact contents
         inputs:

--- a/.azure-pipelines/generate_windows_matrix_build.py
+++ b/.azure-pipelines/generate_windows_matrix_build.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # Copyright (c) 2019 The Khronos Group Inc.
+# SPDX-License-Identifier: Apache-2.0
 
 from itertools import product
 

--- a/.azure-pipelines/organize_windows_artifacts.py
+++ b/.azure-pipelines/organize_windows_artifacts.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # Copyright (c) 2019 The Khronos Group Inc.
+# SPDX-License-Identifier: Apache-2.0
 
 from itertools import product
 from pathlib import Path

--- a/.azure-pipelines/print_windows_artifact_names.py
+++ b/.azure-pipelines/print_windows_artifact_names.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # Copyright (c) 2019 The Khronos Group Inc.
+# SPDX-License-Identifier: Apache-2.0
 
 from itertools import product
 

--- a/.azure-pipelines/shared.py
+++ b/.azure-pipelines/shared.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2019 The Khronos Group Inc.
+# SPDX-License-Identifier: Apache-2.0
 
 import json
 import sys

--- a/changes/sdk/pr.217.gh.OpenXR-SDK-Source.md
+++ b/changes/sdk/pr.217.gh.OpenXR-SDK-Source.md
@@ -1,1 +1,1 @@
-Fix: The D3D12 and Vulcan graphics plugins sometimes did not update their swapchain image context maps due to rare key collisions.
+hello_xr: The D3D12 and Vulkan graphics plugins sometimes did not update their swapchain image context maps due to rare key collisions.

--- a/changes/sdk/pr.224.gh.OpenXR-SDK-Source.md
+++ b/changes/sdk/pr.224.gh.OpenXR-SDK-Source.md
@@ -1,0 +1,4 @@
+---
+- issue.185.gh.OpenXR-SDK-Source
+---
+build/ci: Have Windows loader artifacts organize themselves by architecture/platform, and bundle the CMake config files and a "meta" CMake config.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,10 +29,38 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(GNUInstallDirs)
 include(StdFilesystemFlags)
 
+string(TOUPPER "${CMAKE_GENERATOR_PLATFORM}" CMAKE_GENERATOR_PLATFORM_UPPER)
+
+# Artifact organization
+if(WIN32)
+    option(INSTALL_TO_ARCHITECTURE_PREFIXES "Install platform-specific files to architecture-specific directories." OFF)
+    if(INSTALL_TO_ARCHITECTURE_PREFIXES)
+        unset(_UWP_SUFFIX)
+        if(CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+            set(_UWP_SUFFIX _uwp)
+        endif()
+        if(CMAKE_GENERATOR_PLATFORM_UPPER MATCHES "ARM.*")
+            if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+                set(_PLATFORM ARM64)
+            else()
+                set(_PLATFORM ARM)
+            endif()
+        else()
+            if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+                set(_PLATFORM x64)
+            else()
+                set(_PLATFORM Win32)
+            endif()
+        endif()
+
+        set(CMAKE_INSTALL_BINDIR ${_PLATFORM}${_UWP_SUFFIX}/${CMAKE_INSTALL_BINDIR})
+        set(CMAKE_INSTALL_LIBDIR ${_PLATFORM}${_UWP_SUFFIX}/${CMAKE_INSTALL_LIBDIR})
+    endif()
+endif()
+
 ### Dependencies
 
 # CMake will detect OpenGL/Vulkan which are not compatible with UWP and ARM/ARM64 on Windows so skip it in these cases.
-string(TOUPPER "${CMAKE_GENERATOR_PLATFORM}" CMAKE_GENERATOR_PLATFORM_UPPER)
 if(CMAKE_SYSTEM_NAME STREQUAL "WindowsStore" OR (WIN32 AND CMAKE_GENERATOR_PLATFORM_UPPER MATCHES "ARM.*"))
     set(OPENGL_INCOMPATIBLE TRUE)
     set(VULKAN_INCOMPATIBLE TRUE)

--- a/src/cmake/metaconfig.cmake.in
+++ b/src/cmake/metaconfig.cmake.in
@@ -1,0 +1,25 @@
+# Copyright (c) 2017 The Khronos Group Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# @WARNING@
+
+unset(_UWP_SUFFIX)
+if(CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+    set(_UWP_SUFFIX _uwp)
+endif()
+if(CMAKE_GENERATOR_PLATFORM_UPPER MATCHES "ARM.*")
+    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+        set(_PLATFORM ARM64)
+    else()
+        set(_PLATFORM ARM)
+    endif()
+else()
+    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+        set(_PLATFORM x64)
+    else()
+        set(_PLATFORM Win32)
+    endif()
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/${_PLATFORM}${_UWP_SUFFIX}/lib/@TARGET_SUBDIR@/@FN@.cmake")

--- a/src/loader/CMakeLists.txt
+++ b/src/loader/CMakeLists.txt
@@ -251,7 +251,7 @@ export(
     NAMESPACE OpenXR::
 )
 
-if((CMAKE_SYSTEM_NAME STREQUAL "Windows") OR (CMAKE_SYSTEM_NAME STREQUAL "WindowsStore"))
+if(WIN32 AND NOT INSTALL_TO_ARCHITECTURE_PREFIXES)
     set(TARGET_DESTINATION cmake)
 else()
     set(TARGET_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/openxr/)
@@ -282,3 +282,27 @@ install(
           ${CMAKE_CURRENT_BINARY_DIR}/OpenXRConfigVersion.cmake
     DESTINATION ${TARGET_DESTINATION}
 )
+
+
+# Make the "meta" cmake config/version file to redirect to the right arch/build
+if(WIN32 AND INSTALL_TO_ARCHITECTURE_PREFIXES)
+    set(TARGET_SUBDIR cmake/openxr)
+    set(WARNING "This is a generated file - do not edit!")
+    set(FN OpenXRConfig)
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/../cmake/metaconfig.cmake.in
+        ${CMAKE_CURRENT_BINARY_DIR}/metaconfig.cmake
+        @ONLY)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/metaconfig.cmake
+        DESTINATION .
+        RENAME OpenXRConfig.cmake
+    )
+
+    set(FN OpenXRConfigVersion)
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/../cmake/metaconfig.cmake.in
+        ${CMAKE_CURRENT_BINARY_DIR}/metaconfigversion.cmake
+        @ONLY)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/metaconfigversion.cmake
+        DESTINATION .
+        RENAME OpenXRConfigVersion.cmake
+    )
+endif()


### PR DESCRIPTION
This lets the CMake scripts do the binary moving themselves, and by extension, generate proper CMake config/scripts.

Fixes #185 (the rest of the way)