### PR TITLE
Remove canonicalization in Windows loader

### DIFF
--- a/changes/sdk/pr.239.gh.OpenXR-SDK-Source.md
+++ b/changes/sdk/pr.239.gh.OpenXR-SDK-Source.md
@@ -1,0 +1,1 @@
+Loader: Fix loader failing to load on Windows 7 due to pathcch dependency.

--- a/src/loader/CMakeLists.txt
+++ b/src/loader/CMakeLists.txt
@@ -193,7 +193,7 @@ elseif(WIN32)
         target_compile_options(openxr_loader PRIVATE /wd6386)
     endif()
 
-    target_link_libraries(openxr_loader PUBLIC advapi32 pathcch)
+    target_link_libraries(openxr_loader PUBLIC advapi32)
 
     # Need to copy DLL to client directories so clients can easily load it.
     if(DYNAMIC_LOADER AND (CMAKE_GENERATOR MATCHES "^Visual Studio.*"))


### PR DESCRIPTION
To fix the OpenXR loader on Windows 7, I am making the filesystem canonicalization function a no-op. Canonicalization was added for Linux support to follow a symlink, but symlinks are not used on Windows and there is no canonicalization function that can be used everywhere.