### PR TITLE
Fix warning: directive in .EXP differs from output filename

### DIFF
--- a/changes/sdk/pr.246.gh.OpenXR-SDK-Source.md
+++ b/changes/sdk/pr.246.gh.OpenXR-SDK-Source.md
@@ -1,0 +1,1 @@
+Loader: Fix conflicting filename in openxr_loader.def causing a linker warning when building debug for Windows.

--- a/src/loader/openxr-loader.def
+++ b/src/loader/openxr-loader.def
@@ -7,7 +7,7 @@
 ;
 ;;;;  End Copyright Notice ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-LIBRARY openxr_loader.dll
+LIBRARY
 EXPORTS
     xrCreateInstance
     xrDestroyInstance


### PR DESCRIPTION
From what I know, the filename specified after LIBRARY in a .def file is optional and can be removed. The name conflicts with the debug build since the "d" suffix is included with the filename and results in the following warning:

openxr_loaderd.exp : warning LNK4070: /OUT:openxr_loader.dll directive in .EXP differs from output filename '(...)\OpenXR-SDK-Source\build\src\loader\Debug\openxr_loaderd.dll'; ignoring directive