### PR TITLE
Add header include

### DIFF
--- a/changes/sdk/pr.247.gh.OpenXR-SDK-Source.md
+++ b/changes/sdk/pr.247.gh.OpenXR-SDK-Source.md
@@ -1,0 +1,1 @@
+hello_xr: Make sure `common.h` includes the reflection header that it uses.

--- a/src/tests/hello_xr/common.h
+++ b/src/tests/hello_xr/common.h
@@ -10,6 +10,8 @@
 #include <stdarg.h>
 #include <stddef.h>
 
+#include "openxr_reflection.h"
+
 // Macro to generate stringify functions for OpenXR enumerations based data provided in openxr_reflection.h
 // clang-format off
 #define ENUM_CASE_STR(name, val) case name: return #name;

--- a/src/tests/hello_xr/common.h
+++ b/src/tests/hello_xr/common.h
@@ -10,7 +10,7 @@
 #include <stdarg.h>
 #include <stddef.h>
 
-#include "openxr_reflection.h"
+#include <openxr/openxr_reflection.h>
 
 // Macro to generate stringify functions for OpenXR enumerations based data provided in openxr_reflection.h
 // clang-format off


### PR DESCRIPTION
This project compiles by chance because the header "openxr_reflection.h" was included before the #include "common.h".
It would be better to explicitly include this file here, especially because it is needed to get the macro "to_string" working.