### PR TITLE
xr_dependencies: Include unknwn.h on Windows even without d3d.

### DIFF
--- a/changes/sdk/pr.250.gh.OpenXR-SDK-Source.md
+++ b/changes/sdk/pr.250.gh.OpenXR-SDK-Source.md
@@ -1,0 +1,4 @@
+---
+- issue.237.gh.OpenXR-SDK-Source
+---
+xr_dependencies (shared utility): Include `unknwn.h` on Windows, even without D3D enabled.

--- a/src/common/xr_dependencies.h
+++ b/src/common/xr_dependencies.h
@@ -31,6 +31,7 @@
 #endif  // !WIN32_LEAN_AND_MEAN
 
 #include <windows.h>
+#include <unknwn.h>
 
 #endif  // XR_USE_PLATFORM_WIN32
 


### PR DESCRIPTION
Fixes #237