### PR TITLE
Add locking to protect against multithreaded conformance test usage.

### DIFF
--- a/changes/sdk/pr.252.gh.OpenXR-SDK-Source.md
+++ b/changes/sdk/pr.252.gh.OpenXR-SDK-Source.md
@@ -1,0 +1,1 @@
+Loader: Improved locking around a few areas of the loader that aren't robust against usual concurrent calls.

--- a/src/loader/loader_logger.hpp
+++ b/src/loader/loader_logger.hpp
@@ -17,6 +17,7 @@
 #include <vector>
 #include <set>
 #include <map>
+#include <shared_mutex>
 
 #include <openxr/openxr.h>
 
@@ -172,6 +173,8 @@ class LoaderLogger {
 
    private:
     LoaderLogger();
+
+    std::shared_timed_mutex _mutex;
 
     // List of *all* available recorder objects (including created specifically for an Instance)
     std::vector<std::unique_ptr<LoaderLogRecorder>> _recorders;


### PR DESCRIPTION
The "multithreaded" conformance test is intended to test the runtime but it has exposed two race conditions in the loader:
1. If debug utils extension is enabled, and instance-specific logger will be added and removed when an XrInstance is created. However, if another thread is trying to log while the list of loggers changes then it may crash. So I added a read/write lock in the logger class to protect this.
2. If an XrInstance is being destroyed while xrEnumerateInstanceProperties is called, xrDestroyInstance may unload the runtime while xrEnumerateInstanceProperties is calling into the runtime to get instance properties. I consolidated the two existing locks into a "global loader lock" and expanded its use to a few more areas to solve this. I didn't want to introduce a third lock because then you can easily get into accidental dead lock issues if the locks are acquired in the wrong order, so a single lock is safer and the functions that use the lock don't require special concerns around concurrency anyway.