### PR TITLE
Additional changes to fix CI.

### DIFF
--- a/.azure-pipelines/nuget/NugetTemplate/OpenXR.Loader.nuspec
+++ b/.azure-pipelines/nuget/NugetTemplate/OpenXR.Loader.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <!--
-  Copyright (c) 2020 The Khronos Group Inc.
+  Copyright (c) 2020-2021 The Khronos Group Inc.
   SPDX-License-Identifier: CC-BY-4.0
   -->
   <metadata>
@@ -11,7 +11,6 @@
     <owners>Khronos Group</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">Apache-2.0 OR MIT</license>
-    <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
     <projectUrl>https://github.com/KhronosGroup/OpenXR-SDK</projectUrl>
     <description>Khronos OpenXR loader and headers required to build a Win32 or UWP OpenXR application</description>
     <tags>native khronos openxr loader</tags>

--- a/maintainer-scripts/archive-sdk.sh
+++ b/maintainer-scripts/archive-sdk.sh
@@ -38,10 +38,17 @@ TARNAME=OpenXR-SDK
 # shellcheck disable=SC2046
 makeSubset "$TARNAME" $(getSDKFilenames)
 (
+    if [ -f COPYING.adoc ]; then
+        # Add the shared COPYING.adoc used in all GitHub projects derived from the internal openxr repo
+        add_to_tar "$TARNAME" COPYING.adoc
+    fi
+
     cd github
 
-    # Add the shared COPYING.adoc used in all GitHub projects derived from the internal openxr repo
-    add_to_tar "$TARNAME" COPYING.adoc
+    if [ -f COPYING.adoc ] && ! [ -f ../COPYING.adoc ]; then
+        # If we didn't get it before, maybe we got it now.
+        add_to_tar "$TARNAME" COPYING.adoc
+    fi
 
     cd sdk
     # Add the SDK-specific README


### PR DESCRIPTION
Apparently you can't have an actual license expression and a URL in a nuspec, and I apparently don't test generating the -sdk from the -sdk-source on Khronos CI.