### PR TITLE
Layers: Correctly update iterator when erasing vector element

### DIFF
--- a/changes/sdk/pr.256.gh.OpenXR-SDK-Source.md
+++ b/changes/sdk/pr.256.gh.OpenXR-SDK-Source.md
@@ -1,0 +1,1 @@
+Loader: Fix iteration over explicit layer manifests.

--- a/src/loader/api_layer_interface.cpp
+++ b/src/loader/api_layer_interface.cpp
@@ -232,7 +232,9 @@ XrResult ApiLayerInterface::LoadApiLayers(const std::string& openxr_command, uin
         for (const auto& layer_name : enabled_explicit_api_layer_names) {
             bool found_this_layer = false;
 
-            for (auto it = explicit_layer_manifest_files.begin(); it < explicit_layer_manifest_files.end(); it++) {
+            for (auto it = explicit_layer_manifest_files.begin(); it != explicit_layer_manifest_files.end();) {
+                bool erased_layer_manifest_file = false;
+
                 if (layers_already_found.count(layer_name) > 0) {
                     found_this_layer = true;
                 } else if (layer_name == (*it)->LayerName()) {
@@ -240,6 +242,11 @@ XrResult ApiLayerInterface::LoadApiLayers(const std::string& openxr_command, uin
                     layers_already_found.insert(layer_name);
                     enabled_layer_manifest_files_in_init_order.push_back(std::move(*it));
                     it = explicit_layer_manifest_files.erase(it);
+                    erased_layer_manifest_file = true;
+                }
+
+                if (!erased_layer_manifest_file) {
+                    it++;
                 }
             }
 


### PR DESCRIPTION
ApiLayerInterface::LoadApiLayers would load the manifest files for explicit layers in order to match them against requested layers. As the layers are matched, they would be erased from the manifest vector in order to prevent double-matching. However, in the erase case, the iterator wasn't being updated correctly.