### PR TITLE
layers/core_validation: Default to stdout logging

### DIFF
--- a/changes/sdk/pr.262.gh.OpenXR-SDK-Source.md
+++ b/changes/sdk/pr.262.gh.OpenXR-SDK-Source.md
@@ -1,0 +1,1 @@
+validation layer: Set default logging mode to stdout ("text") instead of none.

--- a/src/api_layers/README_core_validation.md
+++ b/src/api_layers/README_core_validation.md
@@ -31,17 +31,13 @@ There are three modes currently supported:
 3. Output HTML content to a file
 4. Output to the application using the `XR_EXT_debug_utils` extension
 
-Core Validation API layer does not output content by default.  In order to output
-to either stdout or a file, you must use the following environmental variables:
+Core Validation API layer outputs content to stdout by default.
 
-* `XR_CORE_VALIDATION_EXPORT_TYPE`
-* `XR_CORE_VALIDATION_FILE_NAME`
-
-`XR_CORE_VALIDATION_EXPORT_TYPE` is used to define the type of output from
+`XR_CORE_VALIDATION_EXPORT_TYPE` is used to change the type of output from
 the API layer.  Currently, this can be set to the following:
 
-* `text`  : This will generate standard text output.
 * `html`  : This will generate HTML formatted content.
+* `none`  : This will disable output.
 
 `XR_CORE_VALIDATION_FILE_NAME` is used to define the file name that is
 written to.  If not defined, the information goes to stdout.  If defined,

--- a/src/api_layers/core_validation.cpp
+++ b/src/api_layers/core_validation.cpp
@@ -481,13 +481,15 @@ XRAPI_ATTR XrResult XRAPI_CALL CoreValidationXrCreateApiLayerInstance(const XrIn
 
         if (!g_record_info.initialized) {
             g_record_info.initialized = true;
-            g_record_info.type = RECORD_NONE;
+            g_record_info.type = RECORD_TEXT_COUT;
         }
 
         std::string export_type = PlatformUtilsGetEnv("XR_CORE_VALIDATION_EXPORT_TYPE");
         std::string file_name = PlatformUtilsGetEnv("XR_CORE_VALIDATION_FILE_NAME");
         if (!file_name.empty()) {
             g_record_info.file_name = file_name;
+            g_record_info.type = RECORD_TEXT_FILE;
+            user_defined_output = true;
         }
 
         if (!export_type.empty()) {
@@ -495,22 +497,17 @@ XRAPI_ATTR XrResult XRAPI_CALL CoreValidationXrCreateApiLayerInstance(const XrIn
             std::transform(export_type.begin(), export_type.end(), export_type_lower.begin(),
                            [](unsigned char c) { return std::tolower(c); });
 
-            std::cerr << "Core Validation output type: " << export_type_lower
-                      << ", first time = " << (first_time ? "true" : "false") << std::endl;
-            if (export_type_lower == "text") {
-                if (!g_record_info.file_name.empty()) {
-                    g_record_info.type = RECORD_TEXT_FILE;
-                } else {
-                    g_record_info.type = RECORD_TEXT_COUT;
-                }
-                user_defined_output = true;
-            } else if (export_type_lower == "html" && first_time) {
+            if (export_type_lower == "html" && first_time) {
                 g_record_info.type = RECORD_HTML_FILE;
                 if (!CoreValidationWriteHtmlHeader()) {
                     return XR_ERROR_INITIALIZATION_FAILED;
                 }
+            } else if (export_type_lower == "none") {
+                g_record_info.type = RECORD_NONE;
             }
         }
+        std::cerr << "Core Validation output type: " << (export_type.empty() ? "text" : export_type)
+                  << ", first time = " << (first_time ? "true" : "false") << std::endl;
 
         // Call the generated pre valid usage check.
         validation_result = GenValidUsageInputsXrCreateInstance(info, instance);


### PR DESCRIPTION
Vulkan validation defaults to stdout logging too.

