### PR TITLE
Android file ifdef guard in loader

### DIFF
--- a/changes/sdk/pr.274.gh.OpenXR-SDK-Source.md
+++ b/changes/sdk/pr.274.gh.OpenXR-SDK-Source.md
@@ -1,0 +1,1 @@
+- Loader: Add `ifdef` guards around contents of Android-specific files so all platforms may still glob all source files in OpenXR-SDK to build the loader with a custom build system.

--- a/src/loader/CMakeLists.txt
+++ b/src/loader/CMakeLists.txt
@@ -46,6 +46,8 @@ else() # build static lib
 endif()
 
 add_library(openxr_loader ${LIBRARY_TYPE}
+    android_utilities.cpp
+    android_utilities.h
     api_layer_interface.cpp
     api_layer_interface.hpp
     loader_core.cpp
@@ -231,8 +233,6 @@ elseif(ANDROID)
         CXX_STANDARD_REQUIRED TRUE)
     target_sources(openxr_loader
         PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/android_utilities.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/android_utilities.h
         ${ANDROID_WRAP_SOURCES}
         ${JNIPP_ROOT}/jnipp.cpp
     )

--- a/src/loader/android_utilities.cpp
+++ b/src/loader/android_utilities.cpp
@@ -7,6 +7,7 @@
 
 #include "android_utilities.h"
 
+#ifdef __ANDROID__
 #include <wrap/android.net.h>
 #include <wrap/android.content.h>
 #include <wrap/android.database.h>
@@ -314,3 +315,5 @@ int getActiveRuntimeVirtualManifest(wrap::android::content::Context const &conte
     return 0;
 }
 }  // namespace openxr_android
+
+#endif  // __ANDROID__

--- a/src/loader/android_utilities.h
+++ b/src/loader/android_utilities.h
@@ -6,6 +6,7 @@
 // Initial Author: Ryan Pavlik <ryan.pavlik@collabora.com>
 
 #pragma once
+#ifdef __ANDROID__
 
 #include "wrap/android.content.h"
 
@@ -27,3 +28,5 @@ using wrap::android::content::Context;
  */
 int getActiveRuntimeVirtualManifest(wrap::android::content::Context const &context, Json::Value &virtualManifest);
 }  // namespace openxr_android
+
+#endif  // __ANDROID__


### PR DESCRIPTION
Adding this makes it possible to continue just globbing all the files in OpenXR-SDK to build, even on non-Android.
