### PR TITLE
Defer Vulkan CPU sync until the next frame begins

### DIFF
--- a/changes/sdk/pr.277.gh.OpenXR-SDK-Source.md
+++ b/changes/sdk/pr.277.gh.OpenXR-SDK-Source.md
@@ -1,0 +1,1 @@
+hello_xr: Defer Vulkan CPU sync until the next frame begins.

--- a/src/tests/hello_xr/graphicsplugin_vulkan.cpp
+++ b/src/tests/hello_xr/graphicsplugin_vulkan.cpp
@@ -1545,6 +1545,8 @@ struct VulkanGraphicsPlugin : public IGraphicsPlugin {
         auto swapchainContext = m_swapchainImageContextMap[swapchainImage];
         uint32_t imageIndex = swapchainContext->ImageIndex(swapchainImage);
 
+        // XXX Should double-buffer the command buffers, for now just flush
+        m_cmdBuffer.Wait();
         m_cmdBuffer.Reset();
         m_cmdBuffer.Begin();
 
@@ -1605,8 +1607,6 @@ struct VulkanGraphicsPlugin : public IGraphicsPlugin {
 
         m_cmdBuffer.End();
         m_cmdBuffer.Exec(m_vkQueue);
-        // XXX Should double-buffer the command buffers, for now just flush
-        m_cmdBuffer.Wait();
 
 #if defined(USE_MIRROR_WINDOW)
         // Cycle the window's swapchain on the last view rendered


### PR DESCRIPTION
Reduces the impact of the pipeline stall by moving it after presentation, and provides a simple test for whether a runtime properly synchronizes presentation with application work.