### PR TITLE
[loader]doc: Use nativeLibraryDir to replace getNativeLibraryDir()

### DIFF
--- a/specification/loader/runtime.adoc
+++ b/specification/loader/runtime.adoc
@@ -440,7 +440,7 @@ If more than one is found, user preferences are used to identify the
 "active" runtime.
 
 The path containing the dynamic library is computed from
-`ApplicationInfo.getNativeLibraryDir()` and the specified ABI, and the
+`ApplicationInfo.nativeLibraryDir` and the specified ABI, and the
 filename is returned using the filename found in the OpenXR metadata value.
 The "hasFunctions" column is dynamically generated based on the presence of
 any function metadata entries.


### PR DESCRIPTION
`ApplicationInfo` doesn't have method called `getNativeLibraryDir()`, and it
only has `nativeLibraryDir` field, used by OpenXR loader source code.
See https://developer.android.com/reference/android/content/pm/ApplicationInfo#nativeLibraryDir and https://gitlab.freedesktop.org/monado/utilities/openxr-android-broker/-/blob/main/utils/src/main/java/org/khronos/openxr/runtime_broker/utils/RuntimeData.java#L257-261.