### PR TITLE
Update jni wrappers, jnipp

### DIFF
--- a/changes/sdk/pr.280.gh.OpenXR-SDK-Source.1..md
+++ b/changes/sdk/pr.280.gh.OpenXR-SDK-Source.1..md
@@ -1,0 +1,1 @@
+- Update jnipp to fix crash on Android if app detatches thread from JVM (e.g. on shutdown).

--- a/changes/sdk/pr.280.gh.OpenXR-SDK-Source.md
+++ b/changes/sdk/pr.280.gh.OpenXR-SDK-Source.md
@@ -1,0 +1,5 @@
+---
+- issue.275.gh.OpenXR-SDK-Source
+- issue.1616.gl
+---
+- Update android-jni-wrappers to fix missing include.

--- a/src/external/android-jni-wrappers/wrap/ObjectWrapperBase.h
+++ b/src/external/android-jni-wrappers/wrap/ObjectWrapperBase.h
@@ -1,8 +1,9 @@
-// Copyright 2020, Collabora, Ltd.
+// Copyright 2020-2021, Collabora, Ltd.
 // SPDX-License-Identifier: BSL-1.0
 // Author: Ryan Pavlik <ryan.pavlik@collabora.com>
 
 #pragma once
+#include <assert.h>
 #include <jni.h>
 #include <jnipp.h>
 

--- a/src/external/jnipp/jnipp.h
+++ b/src/external/jnipp/jnipp.h
@@ -175,6 +175,20 @@ namespace jni
             value_t values[sizeof...(TArgs)];
         };
 
+        /* specialization for empty array - no args. Avoids "empty array" warning. */
+        template <>
+        class ArgArray<>
+        {
+        public:
+            ArgArray() {
+                std::memset(this, 0, sizeof(ArgArray<>));
+            }
+
+            ~ArgArray() {
+            }
+
+            value_t values[1];
+        };
         long getArrayLength(jarray array);
     }
 

--- a/src/external/jnipp/makefile
+++ b/src/external/jnipp/makefile
@@ -15,7 +15,7 @@ endif
 
 JAVA_HOME ?= /usr/lib/jvm/default-java
 
-CXXFLAGS=-I. -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/$(OS_NAME) -ldl -std=c++11
+CXXFLAGS=-I. -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/$(OS_NAME) -ldl -std=c++11 -Wall -g
 
 SRC=jnipp.o main.o
 VPATH=tests

--- a/src/external/jnipp/tests/main.cpp
+++ b/src/external/jnipp/tests/main.cpp
@@ -249,6 +249,15 @@ TEST(Object_moveAssignmentOperator)
     ASSERT(b.isNull());
 }
 
+TEST(Object_nullary_construct_from_signature)
+{
+    jni::Class String("java/lang/String");
+    jni::method_t init = String.getMethod("<init>", "()V");
+    jni::Object i = String.newInstance(init);
+    ASSERT(!i.isNull());
+    jni::internal::ArgArray<> a;
+}
+
 TEST(Object_call)
 {
     jni::Class Integer("java/lang/Integer");
@@ -575,6 +584,7 @@ int main()
 
         // jni::Object Tests
         RUN_TEST(Object_defaultConstructor_isNull);
+        RUN_TEST(Object_nullary_construct_from_signature);
         RUN_TEST(Object_copyConstructorIsSameObject);
         RUN_TEST(Object_moveConstructor);
         RUN_TEST(Object_copyAssignmentOperator);


### PR DESCRIPTION
Fixes #275 . Also fixes an issue where an app could cause a crash by detaching from the thread before shutting down OpenXR.