### PR TITLE
Remove draft state for loader spec

### DIFF
--- a/specification/loader/loader.adoc
+++ b/specification/loader/loader.adoc
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: CC-BY-4.0
 
-= OpenXR^(R)^  Loader - Design and Operation [DRAFT] {apititle}
+= OpenXR^(R)^  Loader - Design and Operation {apititle}
 Copyright (c) 2017-2022, The Khronos Group Inc.
 :data-uri:
 :icons: font


### PR DESCRIPTION
The OpenXR-SDK-Source has implemented and used new loader based on this spec for OpenXR apps. The loader implementation based on this spec has been released to normal users multiple version. IMO, it's time to remove draft state from spec title.

cc @rpavlik .