### PR TITLE
tests: Fix typo in declspec keyword

### DIFF
--- a/changes/sdk/pr.302.gh.OpenXR-SDK-Source.md
+++ b/changes/sdk/pr.302.gh.OpenXR-SDK-Source.md
@@ -1,0 +1,4 @@
+---
+- issue.1691.gl
+---
+hello_xr: Fix typo in declspec keyword

--- a/changes/sdk/pr.307.gh.OpenXR-SDK-Source.md
+++ b/changes/sdk/pr.307.gh.OpenXR-SDK-Source.md
@@ -1,0 +1,4 @@
+---
+- issue.1712.gl
+---
+Loader: Adjust Android loader build to use the static C++ runtime, since we do not expose any C++ interfaces.

--- a/src/tests/hello_xr/main.cpp
+++ b/src/tests/hello_xr/main.cpp
@@ -14,9 +14,9 @@
 // Favor the high performance NVIDIA or AMD GPUs
 extern "C" {
 // http://developer.download.nvidia.com/devzone/devcenter/gamegraphics/files/OptimusRenderingPolicies.pdf
-_declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
+__declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
 // https://gpuopen.com/learn/amdpowerxpressrequesthighperformance/
-_declspec(dllexport) DWORD AmdPowerXpressRequestHighPerformance = 0x00000001;
+__declspec(dllexport) DWORD AmdPowerXpressRequestHighPerformance = 0x00000001;
 }
 #endif  // defined(_WIN32)
 


### PR DESCRIPTION
This fixes the following errors with mingw toolchain.

```
OpenXR-SDK-Source/src/tests/hello_xr/main.cpp:17:10: error: expected constructor, destructor, or type conversion before '(' token
   17 | _declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
      |          ^
OpenXR-SDK-Source/src/tests/hello_xr/main.cpp:19:10: error: expected constructor, destructor, or type conversion before '(' token
   19 | _declspec(dllexport) DWORD AmdPowerXpressRequestHighPerformance = 0x00000001;
      |          ^
```
