### PR TITLE
loader: Use the static C++ runtime on android.

### DIFF
--- a/.azure-pipelines/openxr-sdk-source.yml
+++ b/.azure-pipelines/openxr-sdk-source.yml
@@ -108,5 +108,5 @@ stages:
             parameters:
               sourceDir: $(Pipeline.Workspace)/pregen
               buildType: RelWithDebInfo
-              generator: "Visual Studio 16 2019"
+              generator: "Visual Studio 17 2022"
               useVulkan: "false"

--- a/.azure-pipelines/shared/build_msvc.yml
+++ b/.azure-pipelines/shared/build_msvc.yml
@@ -7,7 +7,7 @@ parameters:
     default: "Debug"
   - name: generator
     type: string
-    default: "Visual Studio 16 2019"
+    default: "Visual Studio 17 2022"
   - name: cmakeArgs
     type: string
     default: ""

--- a/.azure-pipelines/shared/shared.py
+++ b/.azure-pipelines/shared/shared.py
@@ -4,7 +4,7 @@
 import json
 import sys
 
-VS_VERSION = 'Visual Studio 16 2019'
+VS_VERSION = 'Visual Studio 17 2022'
 
 PLATFORMS = ('Win32', 'x64', 'ARM', 'ARM64')
 

--- a/src/loader/build.gradle
+++ b/src/loader/build.gradle
@@ -107,7 +107,7 @@ android {
         versionCode = project.versionOpenXR.getVersionCode()
         externalNativeBuild {
             cmake {
-                arguments "-DANDROID_STL=c++_shared",
+                arguments "-DANDROID_STL=c++_static",
                         "-DBUILD_API_LAYERS=OFF",
                         "-DBUILD_TESTS=OFF",
                         "-DBUILD_LOADER=ON",


### PR DESCRIPTION
Already approved in concept internally.