### PR TITLE
Fix loader building with Gradle

### DIFF
--- a/.github/workflows/android-OpenXR-loader.yml
+++ b/.github/workflows/android-OpenXR-loader.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install ninja-build tool
         uses: seanmiddleditch/gha-setup-ninja@v3
-      - name: set up JDK 11
+      - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
           java-version: "11"

--- a/.github/workflows/android-OpenXR-loader.yml
+++ b/.github/workflows/android-OpenXR-loader.yml
@@ -1,0 +1,30 @@
+# Copyright 2022, Collabora, Ltd.
+# SPDX-License-Identifier: CC0-1.0
+
+name: OpenXR Loader for Android - Check
+on:
+  pull_request:
+
+jobs:
+  build-loader:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install ninja-build tool
+        uses: seanmiddleditch/gha-setup-ninja@v3
+      - name: set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: "11"
+          distribution: "adopt"
+          cache: gradle
+
+      - name: Build OpenXR Loader with Gradle for Android
+        run: |
+          cd src/loader
+          ./gradlew build
+      - name: Upload OpenXR Loader for Android
+        uses: actions/upload-artifact@v2
+        with:
+          name: OpenXR Loader for Android
+          path: src/loader/build/outputs/aar/

--- a/.github/workflows/android-helloxr-ci.yml
+++ b/.github/workflows/android-helloxr-ci.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install ninja-build tool
         uses: seanmiddleditch/gha-setup-ninja@v3
-      - name: set up JDK 11
+      - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
           java-version: "11"

--- a/changes/sdk/pr.312.gh.OpenXR-SDK-Source.md
+++ b/changes/sdk/pr.312.gh.OpenXR-SDK-Source.md
@@ -1,0 +1,1 @@
+Loader: Fix loader building with Gradle and add CI checking for loader building with Gradle

--- a/src/loader/build.gradle
+++ b/src/loader/build.gradle
@@ -40,6 +40,7 @@ def registry = "${project.repoRoot}/specification/registry/xr.xml"
 // Python is used to generate header files
 python {
     pip "jinja2:2.10.3"
+    pip "MarkupSafe:2.0.1"
     minPythonVersion = "3.4"
 
     environment = ["PYTHONPATH": scriptDir]


### PR DESCRIPTION
The ru.vyarus.use-python will download MarkupSafe 2.1.1 on my laptopn
with Python 3.8. But MarkupSafe removed soft_unicode from 2.1.0, used by
jinja2:2.10.3, and it will cause importing error when running `./gradlew
build` under src/loader directory. Instead of updating jinja2, this PR
try to fix MarkupSafe version for loader to fix building problem.

The release note of MarkupSafe is here:
https://markupsafe.palletsprojects.com/en/2.1.x/changes/#version-2-1-0.

This PR also a GitHub workflow to check OpenXR Loader building with Gradle.