### PR TITLE
Disable the "close and release" step in the automatic Gradle publication to Maven Central.

### DIFF
--- a/maintainer-scripts/build-and-publish-aar-mavencentral.sh
+++ b/maintainer-scripts/build-and-publish-aar-mavencentral.sh
@@ -17,4 +17,5 @@ cd "${MAINT_SCRIPTS}/publish-aar"
 ./gradlew publishMavenPublicationToBuildDirRepository publishMavenPublicationToOSSRHRepository
 
 # Need to explicitly "close and release" it then
-./gradlew closeAndReleaseRepository
+# TODO disabled because it errors out
+# ./gradlew closeAndReleaseRepository


### PR DESCRIPTION
It errors out, and having failing release CI isn't a great look.