### PR TITLE
Add vendor ID

### DIFF
--- a/changes/registry/pr319.gh.OpenXR-SDK-Source.md
+++ b/changes/registry/pr319.gh.OpenXR-SDK-Source.md
@@ -1,0 +1,1 @@
+Register author ID for Fred Emmott.

--- a/specification/registry/xr.xml
+++ b/specification/registry/xr.xml
@@ -34,6 +34,7 @@ maintained in the default branch of the Khronos OpenXR GitHub project.
         <tag name="EXT"        author="Multivendor"                 contact="Ryan Pavlik @rpavlik"/>
         <tag name="EXTX"       author="Multivendor experimental"    contact="Brad Grantham @bradgrantham-lunarg"/>
         <tag name="FB"         author="Facebook"                    contact="Cass Everitt @casseveritt, Jonathan Wright @Nelno"/>
+        <tag name="FREDEMMOTT" author="Frederick Emmott"            contact="Frederick Emmott @fredemmott"/>
         <tag name="GOOGLE"     author="Google"                      contact="Kaye Mason @chaleur"/>
         <tag name="HTC"        author="HTC"                         contact="Chris Kuo @ggkuo, Kyle Chen @kylechen76"/>
         <tag name="HTCX"       author="HTC"                         contact="Chris Kuo @ggkuo, Kyle Chen @kylechen76"/>


### PR DESCRIPTION
Software that will use this vendor id: https://github.com/fredemmott/OpenKneeboard/ - currently uses XR_APILAYER_NOVENDOR_OpenKneeboard.

Spec notes that vendor IDs should be reserved, and can be used for API layers - and, if you have a vendor ID, it *should* be used for all your API layers. However, it's unclear if it's fine to publish an API layer without an assigned vendor ID:

> This usually takes the form of:
>
> An OpenXR API layer prefix string: "XR_APILAYER_"
>
> The name of the vendor developing the API layer: e.g. "LUNARG_"
>
> A short descriptive name of the API layer: e.g. "test"

If it is intended that api layers 'should' or 'must' register vendors, please approve this pull request, so I can use it in my software.

If this is not intended, perhaps the documentation should encourage the use of `NOVENDOR` or similar? This is used by several other projects, e.g. OpenXR toolkit