### PR TITLE
add macOS define

### DIFF
--- a/changes/sdk/pr.323.gh.OpenXR-SDK-Source.md
+++ b/changes/sdk/pr.323.gh.OpenXR-SDK-Source.md
@@ -1,0 +1,1 @@
+Loader: add -DXR_OS_APPLE define on macOS (fixes compilation on macOS)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -139,6 +139,8 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     add_definitions(-DXR_OS_LINUX)
 elseif(ANDROID)
     add_definitions(-DXR_OS_ANDROID)
+elseif(APPLE)
+    add_definitions(-DXR_OS_APPLE)
 endif()
 
 # /EHsc (support for C++ exceptions) is default in most configurations but seems missing when building arm/arm64.


### PR DESCRIPTION
This fixes building the loader on macOS.

With this commit I am able to build the loader on macOS as part of the [openxr rust crate](https://github.com/Ralith/openxrs). I also have a fork of [hotham-simulator](https://github.com/leetvr/hotham/wiki/Adding-the-Hotham-Simulator-to-your-development-environment) working locally, allowing complete (albeit basic) openXR development locally on my macbook.