### PR TITLE
disable OPENGL on macOS

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,6 +50,8 @@ elseif(ANDROID)
         set(VULKAN_INCOMPATIBLE TRUE)
         message(STATUS "Vulkan disabled due to incompatibility: need to target at least API 24")
     endif()
+elseif(APPLE)
+    set(OPENGL_INCOMPATIBLE TRUE)
 endif()
 
 if(NOT OPENGL_INCOMPATIBLE)


### PR DESCRIPTION
OpenGL is causing lots of compilation errors on macOS, and it is deprecated anyways, so it seems most pragmatic to me to just disable it.

My original PR built successfully with `release-1.0.22`, but once rebased on top of main, required this fix to compile successfully.

Let me know if this is desirable and I can tack on a change fragment as well. Thanks!