### PR TITLE
hello_xr: Bump AGP to 7.0.4

### DIFF
--- a/changes/sdk/pr.334.gh.OpenXR-SDK-Source.md
+++ b/changes/sdk/pr.334.gh.OpenXR-SDK-Source.md
@@ -1,0 +1,1 @@
+hello_xr: Bump hello_xr AGP to 7.0.4 to fix building of hello_xr on M1 device

--- a/src/tests/hello_xr/build.gradle
+++ b/src/tests/hello_xr/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:7.0.4'
     }
 }
 

--- a/src/tests/hello_xr/gradle/wrapper/gradle-wrapper.properties
+++ b/src/tests/hello_xr/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Fixes: https://github.com/KhronosGroup/OpenXR-SDK-Source/issues/327.

It will help to fix building of hello_xr on macOS M1.