### PR TITLE
Debug message when secure environment variables are ignored

### DIFF
--- a/changes/sdk/pr.336.gh.OpenXR-SDK-Source.md
+++ b/changes/sdk/pr.336.gh.OpenXR-SDK-Source.md
@@ -1,0 +1,1 @@
+Loader and layers: In debug builds, log when non-empty environment variables are being ignored due to executing with elevated privilege.

--- a/src/api_layers/api_dump.cpp
+++ b/src/api_layers/api_dump.cpp
@@ -69,6 +69,20 @@ struct ApiDumpRecordInfo {
 static ApiDumpRecordInfo g_record_info = {};
 static std::mutex g_record_mutex = {};
 
+// For routing platform_utils.hpp messages.
+void LogPlatformUtilsError(const std::string &message) {
+    std::cerr << message << std::endl;
+#if defined(XR_OS_WINDOWS)
+    OutputDebugStringA((message + "\n").c_str());
+#endif
+}
+void LogPlatformUtilsWarning(const std::string &message) {
+    std::cout << message << std::endl;
+#if defined(XR_OS_WINDOWS)
+    OutputDebugStringA((message + "\n").c_str());
+#endif
+}
+
 // HTML utilities
 bool ApiDumpLayerWriteHtmlHeader() {
     try {

--- a/src/api_layers/api_dump.cpp
+++ b/src/api_layers/api_dump.cpp
@@ -76,6 +76,9 @@ void LogPlatformUtilsError(const std::string &message) {
 #if defined(XR_OS_WINDOWS)
     OutputDebugStringA((message + "\n").c_str());
 #endif
+#else
+    // Unused
+    (void)message;
 #endif
 }
 

--- a/src/api_layers/api_dump.cpp
+++ b/src/api_layers/api_dump.cpp
@@ -71,9 +71,11 @@ static std::mutex g_record_mutex = {};
 
 // For routing platform_utils.hpp messages.
 void LogPlatformUtilsError(const std::string &message) {
+#if !defined(NDEBUG)
     std::cerr << message << std::endl;
 #if defined(XR_OS_WINDOWS)
     OutputDebugStringA((message + "\n").c_str());
+#endif
 #endif
 }
 

--- a/src/api_layers/api_dump.cpp
+++ b/src/api_layers/api_dump.cpp
@@ -76,12 +76,6 @@ void LogPlatformUtilsError(const std::string &message) {
     OutputDebugStringA((message + "\n").c_str());
 #endif
 }
-void LogPlatformUtilsWarning(const std::string &message) {
-    std::cout << message << std::endl;
-#if defined(XR_OS_WINDOWS)
-    OutputDebugStringA((message + "\n").c_str());
-#endif
-}
 
 // HTML utilities
 bool ApiDumpLayerWriteHtmlHeader() {

--- a/src/api_layers/core_validation.cpp
+++ b/src/api_layers/core_validation.cpp
@@ -211,6 +211,20 @@ bool CoreValidationWriteHtmlFooter() {
     }
 }
 
+// For routing platform_utils.hpp messages.
+void LogPlatformUtilsError(const std::string &message) {
+    std::cerr << message << std::endl;
+#if defined(XR_OS_WINDOWS)
+    OutputDebugStringA((message + "\n").c_str());
+#endif
+}
+void LogPlatformUtilsWarning(const std::string &message) {
+    std::cout << message << std::endl;
+#if defined(XR_OS_WINDOWS)
+    OutputDebugStringA((message + "\n").c_str());
+#endif
+}
+
 // Function to record all the core validation information
 void CoreValidLogMessage(GenValidUsageXrInstanceInfo *instance_info, const std::string &message_id,
                          GenValidUsageDebugSeverity message_severity, const std::string &command_name,

--- a/src/api_layers/core_validation.cpp
+++ b/src/api_layers/core_validation.cpp
@@ -218,12 +218,6 @@ void LogPlatformUtilsError(const std::string &message) {
     OutputDebugStringA((message + "\n").c_str());
 #endif
 }
-void LogPlatformUtilsWarning(const std::string &message) {
-    std::cout << message << std::endl;
-#if defined(XR_OS_WINDOWS)
-    OutputDebugStringA((message + "\n").c_str());
-#endif
-}
 
 // Function to record all the core validation information
 void CoreValidLogMessage(GenValidUsageXrInstanceInfo *instance_info, const std::string &message_id,

--- a/src/api_layers/core_validation.cpp
+++ b/src/api_layers/core_validation.cpp
@@ -213,9 +213,11 @@ bool CoreValidationWriteHtmlFooter() {
 
 // For routing platform_utils.hpp messages.
 void LogPlatformUtilsError(const std::string &message) {
+#if !defined(NDEBUG)
     std::cerr << message << std::endl;
 #if defined(XR_OS_WINDOWS)
     OutputDebugStringA((message + "\n").c_str());
+#endif
 #endif
 }
 

--- a/src/common/platform_utils.hpp
+++ b/src/common/platform_utils.hpp
@@ -36,6 +36,11 @@
 #include "common_config.h"
 #endif  // OPENXR_HAVE_COMMON_CONFIG
 
+// Consumers of this file must ensure these two functions are implemented. For example, the loader will implement these functions so
+// that it can route messages through the loader's logging system.
+void LogPlatformUtilsError(const std::string& message);
+void LogPlatformUtilsWarning(const std::string& message);
+
 // Environment variables
 #if defined(XR_OS_LINUX) || defined(XR_OS_APPLE)
 
@@ -78,6 +83,12 @@ static inline std::string PlatformUtilsGetEnv(const char* name) {
 static inline std::string PlatformUtilsGetSecureEnv(const char* name) {
     auto str = detail::ImplGetSecureEnv(name);
     if (str == nullptr) {
+        str = detail::ImplGetEnv(name);
+        if (!str.empty()) {
+            LogPlatformUtilsWarning(std::string("!!! WARNING !!! Environment variable ") + name +
+                                    " is being ignored due to running with secure execution. The value '" + str +
+                                    "' will NOT be used.");
+        }
         return {};
     }
     return str;
@@ -130,12 +141,6 @@ static inline bool PlatformGetGlobalRuntimeFileName(uint16_t major_version, std:
 
 #elif defined(XR_OS_WINDOWS)
 
-#if !defined(NDEBUG)
-inline void LogError(const std::string& error) { OutputDebugStringA(error.c_str()); }
-#else
-#define LogError(x)
-#endif
-
 inline std::wstring utf8_to_wide(const std::string& utf8Text) {
     if (utf8Text.empty()) {
         return {};
@@ -144,7 +149,7 @@ inline std::wstring utf8_to_wide(const std::string& utf8Text) {
     std::wstring wideText;
     const int wideLength = ::MultiByteToWideChar(CP_UTF8, 0, utf8Text.data(), (int)utf8Text.size(), nullptr, 0);
     if (wideLength == 0) {
-        LogError("utf8_to_wide get size error: " + std::to_string(::GetLastError()));
+        LogPlatformUtilsError("utf8_to_wide get size error: " + std::to_string(::GetLastError()));
         return {};
     }
 
@@ -153,7 +158,7 @@ inline std::wstring utf8_to_wide(const std::string& utf8Text) {
     wchar_t* wideString = const_cast<wchar_t*>(wideText.data());  // mutable data() only exists in c++17
     const int length = ::MultiByteToWideChar(CP_UTF8, 0, utf8Text.data(), (int)utf8Text.size(), wideString, wideLength);
     if (length != wideLength) {
-        LogError("utf8_to_wide convert string error: " + std::to_string(::GetLastError()));
+        LogPlatformUtilsError("utf8_to_wide convert string error: " + std::to_string(::GetLastError()));
         return {};
     }
 
@@ -168,7 +173,7 @@ inline std::string wide_to_utf8(const std::wstring& wideText) {
     std::string narrowText;
     int narrowLength = ::WideCharToMultiByte(CP_UTF8, 0, wideText.data(), (int)wideText.size(), nullptr, 0, nullptr, nullptr);
     if (narrowLength == 0) {
-        LogError("wide_to_utf8 get size error: " + std::to_string(::GetLastError()));
+        LogPlatformUtilsError("wide_to_utf8 get size error: " + std::to_string(::GetLastError()));
         return {};
     }
 
@@ -178,7 +183,7 @@ inline std::string wide_to_utf8(const std::wstring& wideText) {
     const int length =
         ::WideCharToMultiByte(CP_UTF8, 0, wideText.data(), (int)wideText.size(), narrowString, narrowLength, nullptr, nullptr);
     if (length != narrowLength) {
-        LogError("wide_to_utf8 convert string error: " + std::to_string(::GetLastError()));
+        LogPlatformUtilsError("wide_to_utf8 convert string error: " + std::to_string(::GetLastError()));
         return {};
     }
 
@@ -244,7 +249,7 @@ static inline std::string PlatformUtilsGetEnv(const char* name) {
     // call if there was enough capacity. Else it returns the required capacity (including null terminator).
     const DWORD length = ::GetEnvironmentVariableW(wname.c_str(), wValueData, (DWORD)wValue.size());
     if ((length == 0) || (length >= wValue.size())) {  // If error or the variable increased length between calls...
-        LogError("GetEnvironmentVariable get value error: " + std::to_string(::GetLastError()));
+        LogPlatformUtilsError("GetEnvironmentVariable get value error: " + std::to_string(::GetLastError()));
         return {};
     }
 
@@ -255,13 +260,20 @@ static inline std::string PlatformUtilsGetEnv(const char* name) {
 
 // Acts the same as PlatformUtilsGetEnv except returns an empty string if IsHighIntegrityLevel.
 static inline std::string PlatformUtilsGetSecureEnv(const char* name) {
+    // No secure version for Windows so the below integrity check is needed.
+    const std::string envValue = PlatformUtilsGetEnv(name);
+
     // Do not allow high integrity processes to act on data that can be controlled by medium integrity processes.
     if (IsHighIntegrityLevel()) {
+        if (!envValue.empty()) {
+            LogPlatformUtilsWarning(std::string("!!! WARNING !!! Environment variable ") + name +
+                                    " is being ignored due to running from an elevated context. The value '" + envValue +
+                                    "' will NOT be used.");
+        }
         return {};
     }
 
-    // No secure version for Windows so the above integrity check is needed.
-    return PlatformUtilsGetEnv(name);
+    return envValue;
 }
 
 // Sets an environment variable via UTF8 strings.

--- a/src/common/platform_utils.hpp
+++ b/src/common/platform_utils.hpp
@@ -36,10 +36,9 @@
 #include "common_config.h"
 #endif  // OPENXR_HAVE_COMMON_CONFIG
 
-// Consumers of this file must ensure these two functions are implemented. For example, the loader will implement these functions so
-// that it can route messages through the loader's logging system.
+// Consumers of this file must ensure this function is implemented. For example, the loader will implement this function so that it
+// can route messages through the loader's logging system.
 void LogPlatformUtilsError(const std::string& message);
-void LogPlatformUtilsWarning(const std::string& message);
 
 // Environment variables
 #if defined(XR_OS_LINUX) || defined(XR_OS_APPLE)
@@ -85,9 +84,9 @@ static inline std::string PlatformUtilsGetSecureEnv(const char* name) {
     if (str == nullptr) {
         str = detail::ImplGetEnv(name);
         if (!str.empty()) {
-            LogPlatformUtilsWarning(std::string("!!! WARNING !!! Environment variable ") + name +
-                                    " is being ignored due to running with secure execution. The value '" + str +
-                                    "' will NOT be used.");
+            LogPlatformUtilsError(std::string("!!! WARNING !!! Environment variable ") + name +
+                                  " is being ignored due to running with secure execution. The value '" + str +
+                                  "' will NOT be used.");
         }
         return {};
     }
@@ -266,9 +265,9 @@ static inline std::string PlatformUtilsGetSecureEnv(const char* name) {
     // Do not allow high integrity processes to act on data that can be controlled by medium integrity processes.
     if (IsHighIntegrityLevel()) {
         if (!envValue.empty()) {
-            LogPlatformUtilsWarning(std::string("!!! WARNING !!! Environment variable ") + name +
-                                    " is being ignored due to running from an elevated context. The value '" + envValue +
-                                    "' will NOT be used.");
+            LogPlatformUtilsError(std::string("!!! WARNING !!! Environment variable ") + name +
+                                  " is being ignored due to running from an elevated context. The value '" + envValue +
+                                  "' will NOT be used.");
         }
         return {};
     }

--- a/src/common/platform_utils.hpp
+++ b/src/common/platform_utils.hpp
@@ -83,7 +83,7 @@ static inline std::string PlatformUtilsGetSecureEnv(const char* name) {
     auto str = detail::ImplGetSecureEnv(name);
     if (str == nullptr) {
         str = detail::ImplGetEnv(name);
-        if (!str.empty()) {
+        if (str != nullptr && !std::string(str).empty()) {
             LogPlatformUtilsError(std::string("!!! WARNING !!! Environment variable ") + name +
                                   " is being ignored due to running with secure execution. The value '" + str +
                                   "' will NOT be used.");

--- a/src/loader/loader_logger.cpp
+++ b/src/loader/loader_logger.cpp
@@ -28,7 +28,6 @@
 
 // For routing platform_utils.hpp messages into the LoaderLogger.
 void LogPlatformUtilsError(const std::string& message) { LoaderLogger::LogErrorMessage("platform_utils", message); }
-void LogPlatformUtilsWarning(const std::string& message) { LoaderLogger::LogWarningMessage("platform_utils", message); }
 
 bool LoaderLogRecorder::LogDebugUtilsMessage(XrDebugUtilsMessageSeverityFlagsEXT /*message_severity*/,
                                              XrDebugUtilsMessageTypeFlagsEXT /*message_type*/,

--- a/src/loader/loader_logger.cpp
+++ b/src/loader/loader_logger.cpp
@@ -26,6 +26,10 @@
 #include <utility>
 #include <vector>
 
+// For routing platform_utils.hpp messages into the LoaderLogger.
+void LogPlatformUtilsError(const std::string& message) { LoaderLogger::LogErrorMessage("platform_utils", message); }
+void LogPlatformUtilsWarning(const std::string& message) { LoaderLogger::LogWarningMessage("platform_utils", message); }
+
 bool LoaderLogRecorder::LogDebugUtilsMessage(XrDebugUtilsMessageSeverityFlagsEXT /*message_severity*/,
                                              XrDebugUtilsMessageTypeFlagsEXT /*message_type*/,
                                              const XrDebugUtilsMessengerCallbackDataEXT* /*callback_data*/) {


### PR DESCRIPTION
The loader will ignore environment variables that determine which code to load when running from an elevated context (Windows) or secure execution is required (Linux). This has caught many people off guard and so this is the first step to try and make this behavior more visible. When this happens a message will be written into the debugger and to stderr like so (see first line):

![image](https://user-images.githubusercontent.com/5100250/193155736-06b1fbb3-3678-4539-8328-aa2192d66b03.png)


