### PR TITLE
Fix finding wayland-client.h on Linux

### DIFF
--- a/src/cmake/presentation.cmake
+++ b/src/cmake/presentation.cmake
@@ -132,7 +132,7 @@ elseif(PRESENTATION_BACKEND MATCHES "wayland")
             ${WAYLAND_PROTOCOLS_DIR}/${PROTOCOL}.h
         )
 
-        target_include_directories(openxr-gfxwrapper PUBLIC ${WAYLAND_PROTOCOLS_DIR})
+        target_include_directories(openxr-gfxwrapper PUBLIC ${WAYLAND_PROTOCOLS_DIR} ${WAYLAND_CLIENT_INCLUDE_DIRS})
         target_link_libraries(
             openxr-gfxwrapper PRIVATE ${EGL_LIBRARIES} ${WAYLAND_CLIENT_LIBRARIES} ${WAYLAND_EGL_LIBRARIES}
         )

--- a/src/loader/CMakeLists.txt
+++ b/src/loader/CMakeLists.txt
@@ -81,6 +81,7 @@ else()
     target_include_directories(openxr_loader
         PRIVATE
         ${PROJECT_SOURCE_DIR}/src/external/jsoncpp/include
+        ${WAYLAND_CLIENT_INCLUDE_DIRS}
     )
     if(SUPPORTS_Werrorunusedparameter)
         # Don't error on this - triggered by jsoncpp


### PR DESCRIPTION
When compiling with the wayland-client package on Linux, the corresponding headers are installed in a subdirectory of /usr/include. This path is not added to the compiler search path by openxr, so the required file 'wayland-client.h' is not found.

```
In file included from /home/user/src/vsgFramework-build/components/vsgvr-src/deps/openxr/src/common/platform_utils.hpp:12:0,
                 from /home/user/src/vsgFramework-build/components/vsgvr-src/deps/openxr/src/common/filesystem_utils.cpp:13:
/home/user/src/vsgFramework-build/components/vsgvr-src/deps/openxr/src/common/xr_dependencies.h:88:10: fatal error: wayland-client.h: file not found
 #include "wayland-client.h"
          ^~~~~~~~~~~~~~~~~~

```
To fix the problem, the include directories provided by the pkgconfig module for wayland-client are added to the corresponding cmake targets.