### PR TITLE
Fix not finding 'wayland-client.h' with builds on Linux by default

### DIFF
--- a/changes/sdk/pr.346.gh.OpenXR-SDK-Source.md
+++ b/changes/sdk/pr.346.gh.OpenXR-SDK-Source.md
@@ -1,0 +1,1 @@
+loader,api_layers: Fix finding wayland-client.h on linux

--- a/src/api_layers/CMakeLists.txt
+++ b/src/api_layers/CMakeLists.txt
@@ -104,6 +104,10 @@ if(Vulkan_FOUND)
         PRIVATE ${Vulkan_INCLUDE_DIRS}
     )
 endif()
+if(BUILD_WITH_WAYLAND_HEADERS)
+    target_include_directories(XrApiLayer_api_dump
+        PRIVATE ${WAYLAND_CLIENT_INCLUDE_DIRS})
+endif()
 
 # Basics for core_validation API Layer
 
@@ -167,6 +171,10 @@ if(Vulkan_FOUND)
     target_include_directories(XrApiLayer_core_validation
         PRIVATE ${Vulkan_INCLUDE_DIRS}
     )
+endif()
+if(BUILD_WITH_WAYLAND_HEADERS)
+    target_include_directories(XrApiLayer_core_validation
+        PRIVATE ${WAYLAND_CLIENT_INCLUDE_DIRS})
 endif()
 
 if(WIN32)

--- a/src/cmake/presentation.cmake
+++ b/src/cmake/presentation.cmake
@@ -132,7 +132,7 @@ elseif(PRESENTATION_BACKEND MATCHES "wayland")
             ${WAYLAND_PROTOCOLS_DIR}/${PROTOCOL}.h
         )
 
-        target_include_directories(openxr-gfxwrapper PUBLIC ${WAYLAND_PROTOCOLS_DIR})
+        target_include_directories(openxr-gfxwrapper PUBLIC ${WAYLAND_PROTOCOLS_DIR} ${WAYLAND_CLIENT_INCLUDE_DIRS})
         target_link_libraries(
             openxr-gfxwrapper PRIVATE ${EGL_LIBRARIES} ${WAYLAND_CLIENT_LIBRARIES} ${WAYLAND_EGL_LIBRARIES}
         )

--- a/src/loader/CMakeLists.txt
+++ b/src/loader/CMakeLists.txt
@@ -90,6 +90,10 @@ else()
         target_compile_options(openxr_loader PRIVATE -Wno-unused-parameter)
     endif()
 endif()
+if(BUILD_WITH_WAYLAND_HEADERS)
+    target_include_directories(openxr_loader PRIVATE ${WAYLAND_CLIENT_INCLUDE_DIRS})
+endif()
+
 set_target_properties(openxr_loader PROPERTIES FOLDER ${LOADER_FOLDER})
 
 if(LOADER_EXTERNAL_GEN_DEPENDS)


### PR DESCRIPTION
Building openxr, for example, when it is included as a submodule in another project and no special compiler flags are used, fails because the mentioned header file was not found.

Fixes #349 