### PR TITLE
loader: Prefer cstdio and cstdlib for c++ files

### DIFF
--- a/changes/sdk/pr.357.gh.OpenXR-SDK-Source.md
+++ b/changes/sdk/pr.357.gh.OpenXR-SDK-Source.md
@@ -1,0 +1,1 @@
+loader: Prefer cstdio and cstdlib for c++ files

--- a/src/loader/manifest_file.cpp
+++ b/src/loader/manifest_file.cpp
@@ -27,13 +27,13 @@
 #include <openxr/openxr.h>
 
 #include <algorithm>
+#include <cstdlib>
+#include <cstdio>
 #include <cstring>
 #include <fstream>
 #include <memory>
 #include <sstream>
 #include <stdexcept>
-#include <stdio.h>
-#include <stdlib.h>
 #include <string>
 #include <unordered_map>
 #include <utility>

--- a/src/tests/list/list.cpp
+++ b/src/tests/list/list.cpp
@@ -26,9 +26,9 @@
 #include "xr_dependencies.h"
 #include <openxr/openxr.h>
 
-#include <stdio.h>
+#include <cstdlib>
+#include <cstdio>
 #include <string.h>
-#include <stdlib.h>
 #include <inttypes.h>
 #include <vector>
 

--- a/src/tests/loader_test/loader_test_utils.cpp
+++ b/src/tests/loader_test/loader_test_utils.cpp
@@ -28,8 +28,8 @@
 #include "xr_dependencies.h"
 #include <openxr/openxr.h>
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 
 #if defined(XR_OS_WINDOWS)
 


### PR DESCRIPTION
See https://clang.llvm.org/extra/clang-tidy/checks/modernize/deprecated-headers.html.