### PR TITLE
hello_xr: Export built-in NativeActivity

### DIFF
--- a/changes/sdk/pr.358.gh.OpenXR-SDK-Source.md
+++ b/changes/sdk/pr.358.gh.OpenXR-SDK-Source.md
@@ -1,0 +1,1 @@
+hello_xr: Export built-in NativeActivity

--- a/src/tests/hello_xr/AndroidManifest.xml
+++ b/src/tests/hello_xr/AndroidManifest.xml
@@ -46,6 +46,7 @@
       android:resizeableActivity="false"
       android:screenOrientation="landscape"
       android:theme="@android:style/Theme.Black.NoTitleBar.Fullscreen"
+      android:exported="true"
       tools:ignore="NonResizeableActivity">
       <!-- Tell NativeActivity the name of the .so -->
       <meta-data


### PR DESCRIPTION
If exported attribute is true, the app can be launched by other apps on latest Android platform.

See https://developer.android.com/guide/topics/manifest/activity-element.