### PR TITLE
hello_xr: Use correct lost event count

### DIFF
--- a/changes/sdk/pr.359.gh.OpenXR-SDK-Source.md
+++ b/changes/sdk/pr.359.gh.OpenXR-SDK-Source.md
@@ -1,0 +1,2 @@
+clang-format: Add clang-format-15 as acceptable clang formats 
+hello_xr: Use correct lost event count

--- a/runClangFormat.sh
+++ b/runClangFormat.sh
@@ -18,7 +18,7 @@
 set -e
 (
     PREFERRED_CLANG_FORMAT=clang-format-10
-    ACCEPTABLE_CLANG_FORMATS="${PREFERRED_CLANG_FORMAT} clang-format-11 clang-format-12 clang-format-13 clang-format-14 clang-format"
+    ACCEPTABLE_CLANG_FORMATS="${PREFERRED_CLANG_FORMAT} clang-format-11 clang-format-12 clang-format-13 clang-format-14 clang-format-15 clang-format"
     cd "$(dirname $0)"
     if [ ! "${CLANGFORMAT}" ]; then
         for tool in ${ACCEPTABLE_CLANG_FORMATS}; do

--- a/src/tests/hello_xr/openxr_program.cpp
+++ b/src/tests/hello_xr/openxr_program.cpp
@@ -680,7 +680,7 @@ struct OpenXrProgram : IOpenXrProgram {
         if (xr == XR_SUCCESS) {
             if (baseHeader->type == XR_TYPE_EVENT_DATA_EVENTS_LOST) {
                 const XrEventDataEventsLost* const eventsLost = reinterpret_cast<const XrEventDataEventsLost*>(baseHeader);
-                Log::Write(Log::Level::Warning, Fmt("%d events lost", eventsLost));
+                Log::Write(Log::Level::Warning, Fmt("%d events lost", eventsLost->lostEventCount));
             }
 
             return baseHeader;


### PR DESCRIPTION
1. Use correct `lostEventCount` field for log.
2. Add clang-format-15 as acceptable clang formats.

Fixes: https://github.com/KhronosGroup/OpenXR-SDK-Source/issues/298.