### PR TITLE
cmake: Fix exporting APIs from openxr-loader in mingw

### DIFF
--- a/src/loader/CMakeLists.txt
+++ b/src/loader/CMakeLists.txt
@@ -41,7 +41,7 @@ run_xr_xml_generate(loader_source_generator.py xr_generated_loader.cpp)
 if(DYNAMIC_LOADER)
     add_definitions(-DXRAPI_DLL_EXPORT)
     set(LIBRARY_TYPE SHARED)
-    if(MSVC)
+    if(WIN32)
         list(APPEND openxr_loader_RESOURCE_FILE ${CMAKE_CURRENT_SOURCE_DIR}/openxr-loader.def)
     endif()
 else() # build static lib


### PR DESCRIPTION

    cmake: Fix exporting APIs from openxr-loader in mingw

    This adds openxr-loader.def in source list of openxr-loader.dll for
    all toolchain in Windows platform and fixes linking with test programs.
    Otherwise, all required APIs are not exported from the shared library
    and compiling test programs shows following errors

    ld.exe: list_json.cpp.obj(.text+0x686): undefined reference to `xrDestroyInstance'
    ld.exe: list_json.cpp.obj(.text+0x96f): undefined reference to `xrCreateInstance'

