### PR TITLE
hello_xr: add debug output for Vulkan extensions from runtime vs. app

### DIFF
--- a/changes/sdk/pr.403.gh.OpenXR-SDK-Source.md
+++ b/changes/sdk/pr.403.gh.OpenXR-SDK-Source.md
@@ -1,0 +1,1 @@
+- Addition: hello_xr: Log Vulkan extensions requested by runtime and by app, visible when running with `--verbose`.

--- a/src/tests/hello_xr/graphicsplugin_vulkan.cpp
+++ b/src/tests/hello_xr/graphicsplugin_vulkan.cpp
@@ -1854,6 +1854,19 @@ struct VulkanGraphicsPluginLegacy : public VulkanGraphicsPlugin {
     virtual XrStructureType GetGraphicsBindingType() const override { return XR_TYPE_GRAPHICS_BINDING_VULKAN_KHR; }
     virtual XrStructureType GetSwapchainImageType() const override { return XR_TYPE_SWAPCHAIN_IMAGE_VULKAN_KHR; }
 
+    static void LogVulkanExtensions(const std::string title, const std::vector<const char*>& extensions, unsigned int start = 0) {
+        const std::string indentStr(1, ' ');
+
+        Log::Write(Log::Level::Verbose, Fmt("%s: (%d)", title.c_str(), extensions.size() - start));
+        for (auto ext : extensions) {
+            if (start) {
+                start--;
+                continue;
+            }
+            Log::Write(Log::Level::Verbose, Fmt("%s  Name=%s", indentStr.c_str(), ext));
+        }
+    }
+
     virtual XrResult CreateVulkanInstanceKHR(XrInstance instance, const XrVulkanInstanceCreateInfoKHR* createInfo,
                                              VkInstance* vulkanInstance, VkResult* vulkanResult) override {
         PFN_xrGetVulkanInstanceExtensionsKHR pfnGetVulkanInstanceExtensionsKHR = nullptr;
@@ -1869,11 +1882,14 @@ struct VulkanGraphicsPluginLegacy : public VulkanGraphicsPlugin {
         {
             // Note: This cannot outlive the extensionNames above, since it's just a collection of views into that string!
             std::vector<const char*> extensions = ParseExtensionString(&extensionNames[0]);
+            LogVulkanExtensions("Vulkan Instance Extensions, requested by runtime", extensions);
 
             // Merge the runtime's request with the applications requests
             for (uint32_t i = 0; i < createInfo->vulkanCreateInfo->enabledExtensionCount; ++i) {
                 extensions.push_back(createInfo->vulkanCreateInfo->ppEnabledExtensionNames[i]);
             }
+            LogVulkanExtensions("Vulkan Instance Extensions, requested by application", extensions,
+                                extensions.size() - createInfo->vulkanCreateInfo->enabledExtensionCount);
 
             VkInstanceCreateInfo instInfo{VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO};
             memcpy(&instInfo, createInfo->vulkanCreateInfo, sizeof(instInfo));
@@ -1907,11 +1923,14 @@ struct VulkanGraphicsPluginLegacy : public VulkanGraphicsPlugin {
             if (deviceExtensionNamesSize > 0) {
                 extensions = ParseExtensionString(&deviceExtensionNames[0]);
             }
+            LogVulkanExtensions("Vulkan Device Extensions, requested by runtime", extensions);
 
             // Merge the runtime's request with the applications requests
             for (uint32_t i = 0; i < createInfo->vulkanCreateInfo->enabledExtensionCount; ++i) {
                 extensions.push_back(createInfo->vulkanCreateInfo->ppEnabledExtensionNames[i]);
             }
+            LogVulkanExtensions("Vulkan Device Extensions, requested by application", extensions,
+                                extensions.size() - createInfo->vulkanCreateInfo->enabledExtensionCount);
 
             VkPhysicalDeviceFeatures features{};
             memcpy(&features, createInfo->vulkanCreateInfo->pEnabledFeatures, sizeof(features));


### PR DESCRIPTION
Adding some extra debug output when "--verbose --graphics Vulkan(2)" is specified, to list which Vulkan instance and Vulkan device extensions were requested by the XR runtime and which were requested by the application.

I found this quite useful to have to get the current wineopenxr implementation running without Steam. Steam uses Windows registry keys at the moment to relay Vulkan extensions needed by the XR runtime to DXVK. Without Steam I need to populate the registry keys manually at the moment.