### PR TITLE
OpenXR loader: partial fix for XRLOADER_DISABLE_EXCEPTION_HANDLING 

### DIFF
--- a/changes/sdk/pr.405.gh.OpenXR-SDK-Source.md
+++ b/changes/sdk/pr.405.gh.OpenXR-SDK-Source.md
@@ -1,0 +1,1 @@
+Loader: Partial fix for the loader not honoring BUILD_LOADER_WITH_EXCEPTION_HANDLING on Android.

--- a/src/loader/CMakeLists.txt
+++ b/src/loader/CMakeLists.txt
@@ -75,6 +75,10 @@ add_library(openxr_loader ${LIBRARY_TYPE}
 if(BUILD_WITH_SYSTEM_JSONCPP)
     target_link_libraries(openxr_loader PRIVATE JsonCpp::JsonCpp)
 else()
+    if(NOT BUILD_LOADER_WITH_EXCEPTION_HANDLING)
+        target_compile_definitions(openxr_loader PRIVATE JSON_USE_EXCEPTION=0)
+    endif()
+
     target_sources(openxr_loader
         PRIVATE
         ${PROJECT_SOURCE_DIR}/src/external/jsoncpp/src/lib_json/json_reader.cpp
@@ -123,6 +127,16 @@ if(Vulkan_FOUND)
 endif()
 if(NOT BUILD_LOADER_WITH_EXCEPTION_HANDLING)
     target_compile_definitions(openxr_loader PRIVATE XRLOADER_DISABLE_EXCEPTION_HANDLING)
+
+# TODO: uncomment this once jnipp starts supporting -fno-exceptions
+#
+#    if(ANDROID AND (CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang"))
+#        target_compile_options(openxr_loader
+#            PRIVATE
+#                -fno-exceptions
+#        )
+#    endif()
+
 endif()
 
 target_link_libraries(

--- a/src/loader/android_utilities.cpp
+++ b/src/loader/android_utilities.cpp
@@ -245,18 +245,39 @@ static int populateFunctions(wrap::android::content::Context const &context, boo
     return 0;
 }
 
+// The current file relies on android-jni-wrappers and jnipp, which may throw on failure.
+// This is problematic when the loader is compiled with exception handling disabled - the consumers can reasonably
+// expect that the compilation with -fno-exceptions will succeed, but the compiler will not accept the code that
+// uses `try` & `catch` keywords. We cannot use the `exception_handling.hpp` here since we're not at an ABI boundary,
+// so we define helper macros here. This is fine for now since the only ocurrence of exception-handling code is in this file.
+#ifdef XRLOADER_DISABLE_EXCEPTION_HANDLING
+
+#define ANDROID_UTILITIESS_TRY
+#define ANDROID_UTILITIES_CATCH_FALLBACK(...)
+
+#else
+
+#define ANDROID_UTILITIESS_TRY try
+#define ANDROID_UTILITIES_CATCH_FALLBACK(...) \
+    catch(const std::exception& e) {          \
+        __VA_ARGS__                           \
+    }
+
+#endif // XRLOADER_DISABLE_EXCEPTION_HANDLING
+
 /// Get cursor for active runtime, parameterized by whether or not we use the system broker
 static bool getActiveRuntimeCursor(wrap::android::content::Context const &context, jni::Array<std::string> const &projection,
                                    bool systemBroker, Cursor &cursor) {
     auto uri = active_runtime::makeContentUri(systemBroker, XR_VERSION_MAJOR(XR_CURRENT_API_VERSION), ABI);
     ALOGI("getActiveRuntimeCursor: Querying URI: %s", uri.toString().c_str());
-    try {
+
+    ANDROID_UTILITIESS_TRY {
         cursor = context.getContentResolver().query(uri, projection);
-    } catch (const std::exception &e) {
+    } ANDROID_UTILITIES_CATCH_FALLBACK(
         ALOGW("Exception when querying %s content resolver: %s", getBrokerTypeName(systemBroker), e.what());
         cursor = {};
         return false;
-    }
+    )
 
     if (cursor.isNull()) {
         ALOGW("Null cursor when querying %s content resolver.", getBrokerTypeName(systemBroker));

--- a/src/loader/android_utilities.cpp
+++ b/src/loader/android_utilities.cpp
@@ -259,11 +259,11 @@ static int populateFunctions(wrap::android::content::Context const &context, boo
 
 #define ANDROID_UTILITIES_TRY try
 #define ANDROID_UTILITIES_CATCH_FALLBACK(...) \
-    catch(const std::exception& e) {          \
+    catch (const std::exception &e) {         \
         __VA_ARGS__                           \
     }
 
-#endif // XRLOADER_DISABLE_EXCEPTION_HANDLING
+#endif  // XRLOADER_DISABLE_EXCEPTION_HANDLING
 
 /// Get cursor for active runtime, parameterized by whether or not we use the system broker
 static bool getActiveRuntimeCursor(wrap::android::content::Context const &context, jni::Array<std::string> const &projection,
@@ -271,13 +271,10 @@ static bool getActiveRuntimeCursor(wrap::android::content::Context const &contex
     auto uri = active_runtime::makeContentUri(systemBroker, XR_VERSION_MAJOR(XR_CURRENT_API_VERSION), ABI);
     ALOGI("getActiveRuntimeCursor: Querying URI: %s", uri.toString().c_str());
 
-    ANDROID_UTILITIES_TRY {
-        cursor = context.getContentResolver().query(uri, projection);
-    } ANDROID_UTILITIES_CATCH_FALLBACK(
-        ALOGW("Exception when querying %s content resolver: %s", getBrokerTypeName(systemBroker), e.what());
-        cursor = {};
-        return false;
-    )
+    ANDROID_UTILITIES_TRY { cursor = context.getContentResolver().query(uri, projection); }
+    ANDROID_UTILITIES_CATCH_FALLBACK(
+        ALOGW("Exception when querying %s content resolver: %s", getBrokerTypeName(systemBroker), e.what()); cursor = {};
+        return false;)
 
     if (cursor.isNull()) {
         ALOGW("Null cursor when querying %s content resolver.", getBrokerTypeName(systemBroker));

--- a/src/loader/android_utilities.cpp
+++ b/src/loader/android_utilities.cpp
@@ -252,12 +252,12 @@ static int populateFunctions(wrap::android::content::Context const &context, boo
 // so we define helper macros here. This is fine for now since the only ocurrence of exception-handling code is in this file.
 #ifdef XRLOADER_DISABLE_EXCEPTION_HANDLING
 
-#define ANDROID_UTILITIESS_TRY
+#define ANDROID_UTILITIES_TRY
 #define ANDROID_UTILITIES_CATCH_FALLBACK(...)
 
 #else
 
-#define ANDROID_UTILITIESS_TRY try
+#define ANDROID_UTILITIES_TRY try
 #define ANDROID_UTILITIES_CATCH_FALLBACK(...) \
     catch(const std::exception& e) {          \
         __VA_ARGS__                           \
@@ -271,7 +271,7 @@ static bool getActiveRuntimeCursor(wrap::android::content::Context const &contex
     auto uri = active_runtime::makeContentUri(systemBroker, XR_VERSION_MAJOR(XR_CURRENT_API_VERSION), ABI);
     ALOGI("getActiveRuntimeCursor: Querying URI: %s", uri.toString().c_str());
 
-    ANDROID_UTILITIESS_TRY {
+    ANDROID_UTILITIES_TRY {
         cursor = context.getContentResolver().query(uri, projection);
     } ANDROID_UTILITIES_CATCH_FALLBACK(
         ALOGW("Exception when querying %s content resolver: %s", getBrokerTypeName(systemBroker), e.what());


### PR DESCRIPTION
Work left: adjust JNIPP to support no-exceptions mode.

Tested by building the following two configurations (based on the parameters that maintainer-scripts/build-aar.sh script is passing to cmake):
`cmake -S . -B out/exceptions -G Ninja -DCMAKE_TOOLCHAIN_FILE=/usr/local/google/code/clankium/src/third_party/android_ndk/build/cmake/android.toolchain.cmake -DCMAKE_ANDROID_NDK=/usr/local/google/code/clankium/src/third_party/android_ndk/ -DANDROID_ABI=arm64-v8a -DANDROID_PLATFORM=24 -DANDROID_STL=c++_static -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=OFF -DBUILD_CONFORMANCE_TESTS=OFF -DBUILD_LOADER=ON -DBUILD_API_LAYERS=OFF`

`cmake -S . -B out/no-exceptions -G Ninja -DCMAKE_TOOLCHAIN_FILE=/usr/local/google/code/clankium/src/third_party/android_ndk/build/cmake/android.toolchain.cmake -DCMAKE_ANDROID_NDK=/usr/local/google/code/clankium/src/third_party/android_ndk/ -DANDROID_ABI=arm64-v8a -DANDROID_PLATFORM=24 -DANDROID_STL=c++_static -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=OFF -DBUILD_CONFORMANCE_TESTS=OFF -DBUILD_LOADER=ON -DBUILD_API_LAYERS=OFF -DBUILD_LOADER_WITH_EXCEPTION_HANDLING=OFF`