### PR TITLE
sdk: Common: Add `stdint.h` include to `platform_utils.hpp` for GCC 13+

### DIFF
--- a/changes/sdk/pr.406.gh.OpenXR-SDK-Source.md
+++ b/changes/sdk/pr.406.gh.OpenXR-SDK-Source.md
@@ -1,0 +1,1 @@
+Common: Add `stdint.h` include to `platform_utils.hpp` for GCC 13+

--- a/src/common/platform_utils.hpp
+++ b/src/common/platform_utils.hpp
@@ -11,6 +11,7 @@
 
 #include "xr_dependencies.h"
 #include <string>
+#include <stdint.h>
 #include <stdlib.h>
 
 // OpenXR paths and registry key locations


### PR DESCRIPTION
GCC 13 seems to have changed some implicit includes in standard headers, and now `stdint.h` needs to be included explicitly to use `uint16_t` in this file.