### PR TITLE
Fix some missing field initializer warnings

### DIFF
--- a/changes/sdk/pr.410.gh.OpenXR-SDK-Source.md
+++ b/changes/sdk/pr.410.gh.OpenXR-SDK-Source.md
@@ -1,0 +1,1 @@
+loader: Fix some warnings.

--- a/src/loader/loader_logger_recorders.cpp
+++ b/src/loader/loader_logger_recorders.cpp
@@ -160,13 +160,15 @@ bool DebugUtilsLogRecorder::LogMessage(XrLoaderLogMessageSeverityFlagBits messag
         XrDebugUtilsMessageTypeFlagsEXT utils_type = LoaderLogMessageTypesToDebugUtilsMessageTypes(message_type);
 
         // Convert the loader log message into the debug utils log message information
-        XrDebugUtilsMessengerCallbackDataEXT utils_callback_data = {XR_TYPE_DEBUG_UTILS_MESSENGER_CALLBACK_DATA_EXT};
+        XrDebugUtilsMessengerCallbackDataEXT utils_callback_data;
+        utils_callback_data.type = XR_TYPE_DEBUG_UTILS_MESSENGER_CALLBACK_DATA_EXT;
         utils_callback_data.messageId = callback_data->message_id;
         utils_callback_data.functionName = callback_data->command_name;
         utils_callback_data.message = callback_data->message;
-        std::vector<XrDebugUtilsObjectNameInfoEXT> utils_objects(callback_data->object_count,
-                                                                 {XR_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT});
+        std::vector<XrDebugUtilsObjectNameInfoEXT> utils_objects(callback_data->object_count);
         for (uint8_t object = 0; object < callback_data->object_count; ++object) {
+            utils_objects[object].type = XR_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
+            utils_objects[object].next = nullptr;
             utils_objects[object].objectHandle = callback_data->objects[object].handle;
             utils_objects[object].objectType = callback_data->objects[object].type;
             utils_objects[object].objectName = callback_data->objects[object].name.c_str();


### PR DESCRIPTION
The code was actually initializing the fields after the struct initialization but the compiler is not smart enough to acknowledge that. Explicitly initialize the fields one by one to remove the warnings.