### PR TITLE
OpenXR loader: add API layer discovery support.

### DIFF
--- a/changes/sdk/mr.3475.gl.md
+++ b/changes/sdk/mr.3475.gl.md
@@ -1,0 +1,4 @@
+---
+- pr.413.gh.OpenXR-SDK-Source
+---
+Improvement: Loader: Code cleanup and robustness improvements.

--- a/src/common/platform_utils.hpp
+++ b/src/common/platform_utils.hpp
@@ -342,6 +342,16 @@ static inline std::string PlatformUtilsGetSecureEnv(const char* /* name */) {
     return {};
 }
 
+static inline bool PlatformUtilsGetBoolSysProp(const char* name, bool default_value) {
+    bool result = default_value;
+    char value[PROP_VALUE_MAX] = {};
+    if (__system_property_get(name, value) != 0) {
+        result = (value[0] == 't');
+    }
+
+    return result;
+}
+
 // Intended to be only used as a fallback on Android, with a more open, "native" technique used in most cases
 static inline bool PlatformGetGlobalRuntimeFileName(uint16_t major_version, std::string& file_name) {
     // Prefix for the runtime JSON file name

--- a/src/loader/android_utilities.cpp
+++ b/src/loader/android_utilities.cpp
@@ -16,7 +16,6 @@
 #include <openxr/openxr.h>
 
 #include <dlfcn.h>
-#include <sstream>
 #include <vector>
 #include <android/log.h>
 
@@ -26,8 +25,6 @@
 #define ALOGI(...) __android_log_print(ANDROID_LOG_INFO, "OpenXR-Loader", __VA_ARGS__)
 
 namespace openxr_android {
-using wrap::android::content::ContentUris;
-using wrap::android::content::Context;
 using wrap::android::database::Cursor;
 using wrap::android::net::Uri;
 using wrap::android::net::Uri_Builder;

--- a/src/loader/android_utilities.cpp
+++ b/src/loader/android_utilities.cpp
@@ -273,12 +273,14 @@ static bool getActiveRuntimeCursor(wrap::android::content::Context const &contex
     return getCursor(context, projection, uri, systemBroker, "active runtime", cursor);
 }
 
-int getActiveRuntimeVirtualManifest(wrap::android::content::Context const &context, Json::Value &virtualManifest) {
-    jni::Array<std::string> projection = makeArray({active_runtime::Columns::PACKAGE_NAME, active_runtime::Columns::NATIVE_LIB_DIR,
-                                                    active_runtime::Columns::SO_FILENAME, active_runtime::Columns::HAS_FUNCTIONS});
+int getActiveRuntimeVirtualManifest(wrap::android::content::Context const &context, Json::Value &virtualManifest,
+                                    bool &systemBroker) {
+    const jni::Array<std::string> projection =
+        makeArray({active_runtime::Columns::PACKAGE_NAME, active_runtime::Columns::NATIVE_LIB_DIR,
+                   active_runtime::Columns::SO_FILENAME, active_runtime::Columns::HAS_FUNCTIONS});
 
     // First, try getting the installable broker's provider
-    bool systemBroker = false;
+    systemBroker = false;
     Cursor cursor;
     if (!getActiveRuntimeCursor(context, projection, systemBroker, cursor)) {
         // OK, try the system broker as a fallback.

--- a/src/loader/android_utilities.cpp
+++ b/src/loader/android_utilities.cpp
@@ -36,8 +36,12 @@ constexpr auto SYSTEM_AUTHORITY = "org.khronos.openxr.system_runtime_broker";
 constexpr auto BASE_PATH = "openxr";
 constexpr auto ABI_PATH = "abi";
 constexpr auto RUNTIMES_PATH = "runtimes";
+constexpr auto API_LAYERS_PATH = "api_layers";
+constexpr auto IMP_LAYER = "implicit";
+constexpr auto EXP_LAYER = "explicit";
 
 constexpr const char *getBrokerAuthority(bool systemBroker) { return systemBroker ? SYSTEM_AUTHORITY : AUTHORITY; }
+constexpr const char *getLayerTypePath(bool implicitLayer) { return implicitLayer ? IMP_LAYER : EXP_LAYER; }
 
 struct BaseColumns {
     /**
@@ -148,6 +152,33 @@ static Uri makeRuntimeContentUri(bool systemBroker, int majorVersion, std::strin
     return builder.build();
 }
 
+/**
+ * Create a content URI for querying all rows of the API Layer function remapping data for a given
+ * runtime package, major version of OpenXR, and layer name,
+ *
+ * @param systemBroker If the system runtime broker (instead of the installable one) should be queried.
+ * @param majorVer    The major version of OpenXR.
+ * @param packageName The package name of the runtime.
+ * @param abi The Android ABI name in use.
+ * @param layerName The name of the API layer.
+ * @return A content URI for the entire table: the function remapping for that runtime and layer.
+ */
+static Uri makeLayerContentUri(bool systemBroker, int majorVersion, std::string const &packageName, const char *abi,
+                               std::string const &layerName) {
+    auto builder = Uri_Builder::construct();
+    builder.scheme("content")
+        .authority(getBrokerAuthority(systemBroker))
+        .appendPath(BASE_PATH)
+        .appendPath(std::to_string(majorVersion))
+        .appendPath(ABI_PATH)
+        .appendPath(abi)
+        .appendPath(API_LAYERS_PATH)
+        .appendPath(packageName)
+        .appendPath(layerName)
+        .appendPath(TABLE_PATH);
+    return builder.build();
+}
+
 struct Columns : BaseColumns {
     /**
      * Constant for the FUNCTION_NAME column name
@@ -160,6 +191,94 @@ struct Columns : BaseColumns {
     static constexpr auto SYMBOL_NAME = "symbol_name";
 };
 }  // namespace functions
+
+namespace instance_extensions {
+/**
+ * Final path component to this URI.
+ */
+static constexpr auto TABLE_PATH = "instance_extensions";
+
+/**
+ * Create a content URI for querying all rows of the instance extensions supported by a given
+ * API layer.
+ *
+ * @param systemBroker If the system runtime broker (instead of the installable one) should be queried.
+ * @param majorVer    The major version of OpenXR.
+ * @param packageName The package name of the runtime.
+ * @param abi The Android ABI name in use.
+ * @param layerName The API layer name.
+ * @return A content URI for the entire table: the function remapping for that runtime.
+ */
+static Uri makeContentUri(bool systemBroker, int majorVersion, std::string const &packageName, const char *abi,
+                          std::string const &layerName) {
+    auto builder = Uri_Builder::construct();
+    builder.scheme("content")
+        .authority(getBrokerAuthority(systemBroker))
+        .appendPath(BASE_PATH)
+        .appendPath(std::to_string(majorVersion))
+        .appendPath(ABI_PATH)
+        .appendPath(abi)
+        .appendPath(API_LAYERS_PATH)
+        .appendPath(packageName)
+        .appendPath(layerName)
+        .appendPath(TABLE_PATH);
+    return builder.build();
+}
+struct Columns : BaseColumns {
+    /**
+     * Constant for the INSTANCE_EXTENSION_NAMES column name
+     */
+    static constexpr auto INSTANCE_EXTENSION_NAMES = "instance_extension_names";
+
+    /**
+     * Constant for the INSTANCE_EXTENSION_VERSIONS column name
+     */
+    static constexpr auto INSTANCE_EXTENSION_VERSIONS = "instance_extension_versions";
+};
+}  // namespace instance_extensions
+
+namespace api_layer {
+
+/**
+ * Create a content URI for querying all rows of the implicit/explicit API layer data for a given
+ * runtime package and major version of OpenXR.
+ *
+ * @param systemBroker If the system runtime broker (instead of the installable one) should be queried.
+ * @param majorVer    The major version of OpenXR.
+ * @param layerType The layer type of the API layer.
+ * @param abi The Android ABI name in use.
+ * @return A content URI for the entire table: the API layers for that runtime.
+ */
+static Uri makeContentUri(bool systemBroker, int majorVersion, std::string const &layerType, const char *abi) {
+    auto builder = Uri_Builder::construct();
+    builder.scheme("content")
+        .authority(getBrokerAuthority(systemBroker))
+        .appendPath(BASE_PATH)
+        .appendPath(std::to_string(majorVersion))
+        .appendPath(ABI_PATH)
+        .appendPath(abi)
+        .appendPath(API_LAYERS_PATH)
+        .appendPath(getLayerTypePath(layerType == IMP_LAYER));
+    return builder.build();
+}
+struct Columns : BaseColumns {
+    // implicit or explicit
+    static constexpr auto PACKAGE_NAME = "package_name";
+    static constexpr auto FILE_FORMAT_VERSION = "file_format_version";
+    static constexpr auto NAME = "name";
+    static constexpr auto NATIVE_LIB_DIR = "native_lib_dir";
+    static constexpr auto SO_FILENAME = "so_filename";
+    static constexpr auto API_VERSION = "api_version";
+    static constexpr auto IMPLEMENTATION_VERSION = "implementation_version";
+    static constexpr auto DESCRIPTION = "description";
+    static constexpr auto DISABLE_ENVIRONMENT = "disable_environment";
+    static constexpr auto ENABLE_ENVIRONMENT = "enable_environment";
+    static constexpr auto DISABLE_SYS_PROP = "disable_sys_prop";
+    static constexpr auto ENABLE_SYS_PROP = "enable_sys_prop";
+    static constexpr auto HAS_FUNCTIONS = "has_functions";
+    static constexpr auto HAS_INSTANCE_EXTENSIONS = "has_instance_extensions";
+};
+}  // namespace api_layer
 
 }  // namespace
 
@@ -332,6 +451,157 @@ int getActiveRuntimeVirtualManifest(wrap::android::content::Context const &conte
     cursor.close();
     return -1;
 }
+
+static int populateApiLayerFunctions(wrap::android::content::Context const &context, bool systemBroker,
+                                     const std::string &packageName, std::string const &layerName, Json::Value &rootNode) {
+    const jni::Array<std::string> projection = makeArray({functions::Columns::FUNCTION_NAME, functions::Columns::SYMBOL_NAME});
+
+    auto uri = functions::makeLayerContentUri(systemBroker, XR_VERSION_MAJOR(XR_CURRENT_API_VERSION), packageName, ABI, layerName);
+    ALOGI("populateApiLayerFunctions: Querying URI: %s", uri.toString().c_str());
+
+    Cursor cursor;
+    if (!getCursor(context, projection, uri, systemBroker, "API layer functions", cursor)) {
+        return -1;
+    }
+
+    auto functionIndex = cursor.getColumnIndex(functions::Columns::FUNCTION_NAME);
+    auto symbolIndex = cursor.getColumnIndex(functions::Columns::SYMBOL_NAME);
+    while (cursor.moveToNext()) {
+        rootNode["api_layer"]["functions"][cursor.getString(functionIndex)] = cursor.getString(symbolIndex);
+    }
+
+    cursor.close();
+    return 0;
+}
+
+static int populateApiLayerInstanceExtensions(wrap::android::content::Context const &context, bool systemBroker,
+                                              const std::string &packageName, std::string const &layerName, Json::Value &rootNode) {
+    const jni::Array<std::string> projection = makeArray(
+        {instance_extensions::Columns::INSTANCE_EXTENSION_NAMES, instance_extensions::Columns::INSTANCE_EXTENSION_VERSIONS});
+
+    auto uri =
+        instance_extensions::makeContentUri(systemBroker, XR_VERSION_MAJOR(XR_CURRENT_API_VERSION), packageName, ABI, layerName);
+    ALOGI("populateApiLayerInstanceExtensions: Querying URI: %s", uri.toString().c_str());
+
+    Cursor cursor;
+    if (!getCursor(context, projection, uri, systemBroker, "API layer instance extensions", cursor)) {
+        return -1;
+    }
+
+    auto nameIndex = cursor.getColumnIndex(instance_extensions::Columns::INSTANCE_EXTENSION_NAMES);
+    auto versionIndex = cursor.getColumnIndex(instance_extensions::Columns::INSTANCE_EXTENSION_VERSIONS);
+    Json::Value extension(Json::objectValue);
+    while (cursor.moveToNext()) {
+        extension["name"] = cursor.getString(nameIndex);
+        extension["extension_version"] = cursor.getString(versionIndex);
+        rootNode["api_layer"]["instance_extensions"].append(extension);
+    }
+
+    cursor.close();
+    return 0;
+}
+
+/// Get cursor for API layers, parameterized by whether or not we use the system broker
+static bool getApiLayerCursor(wrap::android::content::Context const &context, jni::Array<std::string> const &projection,
+                              std::string const &targetType, bool systemBroker, Cursor &cursor) {
+    auto uri = api_layer::makeContentUri(systemBroker, XR_VERSION_MAJOR(XR_CURRENT_API_VERSION), targetType, ABI);
+    ALOGI("getApiLayerCursor: Querying URI: %s", uri.toString().c_str());
+    return getCursor(context, projection, uri, systemBroker, "API Layer", cursor);
+}
+
+static Json::Value makeApiLayerManifest(bool systemBroker, std::string layerType, wrap::android::content::Context const &context,
+                                        Cursor &cursor) {
+    auto packageName = cursor.getString(cursor.getColumnIndex(api_layer::Columns::PACKAGE_NAME));
+    auto fileFormatVersion = cursor.getString(cursor.getColumnIndex(api_layer::Columns::FILE_FORMAT_VERSION));
+    auto name = cursor.getString(cursor.getColumnIndex(api_layer::Columns::NAME));
+    auto libDir = cursor.getString(cursor.getColumnIndex(active_runtime::Columns::NATIVE_LIB_DIR));
+    auto fileName = cursor.getString(cursor.getColumnIndex(api_layer::Columns::SO_FILENAME));
+    auto apiVersion = cursor.getString(cursor.getColumnIndex(api_layer::Columns::API_VERSION));
+    auto implementationVersion = cursor.getString(cursor.getColumnIndex(api_layer::Columns::IMPLEMENTATION_VERSION));
+    auto description = cursor.getString(cursor.getColumnIndex(api_layer::Columns::DESCRIPTION));
+    auto disable_environment = cursor.getString(cursor.getColumnIndex(api_layer::Columns::DISABLE_ENVIRONMENT));
+    auto enable_environment = cursor.getString(cursor.getColumnIndex(api_layer::Columns::ENABLE_ENVIRONMENT));
+    auto disable_sys_prop = cursor.getString(cursor.getColumnIndex(api_layer::Columns::DISABLE_SYS_PROP));
+    auto enable_sys_prop = cursor.getString(cursor.getColumnIndex(api_layer::Columns::ENABLE_SYS_PROP));
+    auto has_instance_extensions = cursor.getString(cursor.getColumnIndex(api_layer::Columns::HAS_INSTANCE_EXTENSIONS));
+    auto has_functions = cursor.getString(cursor.getColumnIndex(api_layer::Columns::HAS_FUNCTIONS));
+
+    ALOGI("Got api layer: type: %s, name: %s, native lib dir: %s, fileName: %s", layerType.c_str(), name.c_str(), libDir.c_str(),
+          fileName.c_str());
+
+    Json::Value rootNode(Json::objectValue);
+    rootNode["file_format_version"] = fileFormatVersion;
+    rootNode["api_layer"] = Json::objectValue;
+    rootNode["api_layer"]["name"] = name;
+    rootNode["api_layer"]["library_path"] = libDir + "/" + fileName;
+    rootNode["api_layer"]["api_version"] = apiVersion;
+    rootNode["api_layer"]["implementation_version"] = implementationVersion;
+    rootNode["api_layer"]["description"] = description;
+    rootNode["api_layer"]["disable_environment"] = disable_environment;
+    rootNode["api_layer"]["enable_environment"] = enable_environment;
+    rootNode["api_layer"]["disable_sys_prop"] = disable_sys_prop;
+    rootNode["api_layer"]["enable_sys_prop"] = enable_sys_prop;
+    if (has_functions == "true") {
+        rootNode["api_layer"]["functions"] = Json::Value(Json::objectValue);
+        populateApiLayerFunctions(context, systemBroker, packageName, name, rootNode);
+    }
+    if (has_instance_extensions == "true") {
+        rootNode["api_layer"]["instance_extensions"] = Json::Value(Json::arrayValue);
+        populateApiLayerInstanceExtensions(context, systemBroker, packageName, name, rootNode);
+    }
+
+    return rootNode;
+}
+
+static int enumerateApiLayerManifests(std::string layerType, wrap::android::content::Context const &context,
+                                      const jni::Array<std::string> &projection, std::vector<Json::Value> &virtualManifests,
+                                      bool systemBroker) {
+    Cursor cursor;
+
+    if (!getApiLayerCursor(context, projection, layerType, systemBroker, cursor)) {
+        return -1;
+    }
+
+    cursor.moveToFirst();
+    const int32_t n = cursor.getCount();
+    virtualManifests.reserve(virtualManifests.size() + n);
+
+    for (int32_t i = 0; i < n; ++i) {
+        virtualManifests.emplace_back(makeApiLayerManifest(systemBroker, layerType, context, cursor));
+        cursor.moveToNext();
+    }
+
+    cursor.close();
+    return 0;
+}
+
+int getApiLayerVirtualManifests(std::string layerType, wrap::android::content::Context const &context,
+                                std::vector<Json::Value> &virtualManifests, bool systemBroker) {
+    ALOGI("Try to get %s API layer from broker", layerType.c_str());
+    const jni::Array<std::string> projection = makeArray(
+        {api_layer::Columns::PACKAGE_NAME, api_layer::Columns::FILE_FORMAT_VERSION, api_layer::Columns::NAME,
+         api_layer::Columns::NATIVE_LIB_DIR, api_layer::Columns::SO_FILENAME, api_layer::Columns::API_VERSION,
+         api_layer::Columns::IMPLEMENTATION_VERSION, api_layer::Columns::DESCRIPTION, api_layer::Columns::DISABLE_ENVIRONMENT,
+         api_layer::Columns::ENABLE_ENVIRONMENT, api_layer::Columns::DISABLE_SYS_PROP, api_layer::Columns::ENABLE_SYS_PROP,
+         api_layer::Columns::HAS_FUNCTIONS, api_layer::Columns::HAS_INSTANCE_EXTENSIONS});
+
+    if (layerType == IMP_LAYER) {
+        std::vector<Json::Value> implicitLayerManifest;
+        if (0 != enumerateApiLayerManifests(IMP_LAYER, context, projection, implicitLayerManifest, systemBroker)) {
+            return -1;
+        }
+        virtualManifests = std::move(implicitLayerManifest);
+    } else {
+        std::vector<Json::Value> explicitLayerManifest;
+        if (0 != enumerateApiLayerManifests(EXP_LAYER, context, projection, explicitLayerManifest, systemBroker)) {
+            return -1;
+        }
+        virtualManifests = std::move(explicitLayerManifest);
+    }
+
+    return 0;
+}
+
 }  // namespace openxr_android
 
 #endif  // __ANDROID__

--- a/src/loader/android_utilities.h
+++ b/src/loader/android_utilities.h
@@ -26,7 +26,8 @@ using wrap::android::content::Context;
  *
  * @return 0 on success, something else on failure.
  */
-int getActiveRuntimeVirtualManifest(wrap::android::content::Context const &context, Json::Value &virtualManifest);
+int getActiveRuntimeVirtualManifest(wrap::android::content::Context const &context, Json::Value &virtualManifest,
+                                    bool &systemBroker);
 }  // namespace openxr_android
 
 #endif  // __ANDROID__

--- a/src/loader/android_utilities.h
+++ b/src/loader/android_utilities.h
@@ -28,6 +28,18 @@ using wrap::android::content::Context;
  */
 int getActiveRuntimeVirtualManifest(wrap::android::content::Context const &context, Json::Value &virtualManifest,
                                     bool &systemBroker);
+
+/*!
+ * Find the implicit/explicit API layers on the system, and return a constructed JSON object representing it.
+ *
+ * @param type An String to indicate layer type of API layers, implicit or explicit.
+ * @param context An Android context, preferably an Activity Context.
+ * @param[out] virtualManifest The Json::Value to fill with the virtual manifest.
+ *
+ * @return 0 on success, something else on failure.
+ */
+int getApiLayerVirtualManifests(std::string layerType, wrap::android::content::Context const &context,
+                                std::vector<Json::Value> &virtualManifests, bool systemBroker);
 }  // namespace openxr_android
 
 #endif  // __ANDROID__

--- a/src/loader/api_layer_interface.cpp
+++ b/src/loader/api_layer_interface.cpp
@@ -422,9 +422,10 @@ XrResult ApiLayerInterface::LoadApiLayers(const std::string& openxr_command, uin
         }
 
         // Add this API layer to the vector
-        api_layer_interfaces.emplace_back(new ApiLayerInterface(manifest_file->LayerName(), layer_library, supported_extensions,
-                                                                api_layer_info.getInstanceProcAddr,
-                                                                api_layer_info.createApiLayerInstance));
+        std::unique_ptr<ApiLayerInterface> iface{new ApiLayerInterface(manifest_file->LayerName(), layer_library,
+                                                                       supported_extensions, api_layer_info.getInstanceProcAddr,
+                                                                       api_layer_info.createApiLayerInstance)};
+        api_layer_interfaces.emplace_back(std::move(iface));
 
         // If we load one, clear all errors.
         any_loaded = true;

--- a/src/loader/loader_init_data.hpp
+++ b/src/loader/loader_init_data.hpp
@@ -16,6 +16,7 @@
 #include <json/value.h>
 #include <android/asset_manager_jni.h>
 #include "android_utilities.h"
+#include "manifest_file.hpp"
 #endif  // XR_USE_PLATFORM_ANDROID
 
 #ifdef XR_KHR_LOADER_INIT_SUPPORT
@@ -84,7 +85,9 @@ class LoaderInitData {
 XrResult InitializeLoaderInitData(const XrLoaderInitInfoBaseHeaderKHR* loaderInitInfo);
 
 #ifdef XR_USE_PLATFORM_ANDROID
-XrResult GetPlatformRuntimeVirtualManifest(Json::Value& out_manifest);
+
+//! Modifies @p out_manifest and @p out_runtime_source only if returning successfully
+XrResult GetPlatformRuntimeVirtualManifest(Json::Value& out_manifest, ManifestFileSource& out_runtime_source);
 std::string GetAndroidNativeLibraryDir();
 void* Android_Get_Asset_Manager();
 #endif  // XR_USE_PLATFORM_ANDROID

--- a/src/loader/loader_init_data.hpp
+++ b/src/loader/loader_init_data.hpp
@@ -88,6 +88,10 @@ XrResult InitializeLoaderInitData(const XrLoaderInitInfoBaseHeaderKHR* loaderIni
 
 //! Modifies @p out_manifest and @p out_runtime_source only if returning successfully
 XrResult GetPlatformRuntimeVirtualManifest(Json::Value& out_manifest, ManifestFileSource& out_runtime_source);
+
+//! Modifies @p out_manifest only if returning successfully
+XrResult GetPlatformApiLayerVirtualManifests(bool is_implicit, bool system_broker, std::vector<Json::Value>& out_manifest);
+
 std::string GetAndroidNativeLibraryDir();
 void* Android_Get_Asset_Manager();
 #endif  // XR_USE_PLATFORM_ANDROID

--- a/src/loader/manifest_file.cpp
+++ b/src/loader/manifest_file.cpp
@@ -638,7 +638,8 @@ void RuntimeManifestFile::CreateIfValid(const Json::Value &root_node, const std:
     }
 
     // Add this runtime manifest file
-    manifest_files.emplace_back(new RuntimeManifestFile(filename, lib_path));
+    std::unique_ptr<RuntimeManifestFile> manifest{new RuntimeManifestFile(filename, lib_path)};
+    manifest_files.emplace_back(std::move(manifest));
 
     // Add any extensions to it after the fact, while handling any renamed functions
     manifest_files.back()->ParseCommon(runtime_root_node);
@@ -891,8 +892,9 @@ void ApiLayerManifestFile::CreateIfValid(ManifestFileType type, const std::strin
     }
 
     // Add this layer manifest file
-    manifest_files.emplace_back(
-        new ApiLayerManifestFile(type, filename, layer_name, description, api_version, implementation_version, library_path));
+    std::unique_ptr<ApiLayerManifestFile> manifest{
+        new ApiLayerManifestFile(type, filename, layer_name, description, api_version, implementation_version, library_path)};
+    manifest_files.emplace_back(std::move(manifest));
 
     // Add any extensions to it after the fact, while handling any renamed functions
     manifest_files.back()->ParseCommon(layer_root_node);

--- a/src/loader/manifest_file.cpp
+++ b/src/loader/manifest_file.cpp
@@ -682,7 +682,8 @@ XrResult RuntimeManifestFile::FindManifestFiles(const std::string &openxr_comman
 
 #if defined(XR_KHR_LOADER_INIT_SUPPORT) && defined(XR_USE_PLATFORM_ANDROID)
         Json::Value virtualManifest;
-        result = GetPlatformRuntimeVirtualManifest(virtualManifest);
+        ManifestFileSource runtimeSource = ManifestFileSource::FROM_JSON_MANIFEST;
+        result = GetPlatformRuntimeVirtualManifest(virtualManifest, runtimeSource);
         if (XR_SUCCESS == result) {
             RuntimeManifestFile::CreateIfValid(virtualManifest, "", manifest_files);
             return result;

--- a/src/loader/manifest_file.cpp
+++ b/src/loader/manifest_file.cpp
@@ -640,8 +640,7 @@ void RuntimeManifestFile::CreateIfValid(const Json::Value &root_node, const std:
     // Add this runtime manifest file
     manifest_files.emplace_back(new RuntimeManifestFile(filename, lib_path));
 
-    // Add any extensions to it after the fact.
-    // Handle any renamed functions
+    // Add any extensions to it after the fact, while handling any renamed functions
     manifest_files.back()->ParseCommon(runtime_root_node);
 }
 
@@ -895,7 +894,7 @@ void ApiLayerManifestFile::CreateIfValid(ManifestFileType type, const std::strin
     manifest_files.emplace_back(
         new ApiLayerManifestFile(type, filename, layer_name, description, api_version, implementation_version, library_path));
 
-    // Add any extensions to it after the fact.
+    // Add any extensions to it after the fact, while handling any renamed functions
     manifest_files.back()->ParseCommon(layer_root_node);
 }
 

--- a/src/loader/manifest_file.cpp
+++ b/src/loader/manifest_file.cpp
@@ -831,7 +831,15 @@ void ApiLayerManifestFile::CreateIfValid(ManifestFileType type, const std::strin
         }
 
 #if defined(XR_OS_ANDROID)
+
+        // Implicit layers require the disable system property on Android.
         auto &disable_prop_node = layer_root_node["disable_sys_prop"];
+        if (disable_prop_node.isNull() || !disable_prop_node.isString()) {
+            error_ss << "Implicit layer " << filename << " is missing \"disable_sys_prop\"";
+            LoaderLogger::LogErrorMessage("", error_ss.str());
+            return;
+        }
+
         // Check if there's an system property to enable this API layer
         auto &enable_prop_node = layer_root_node["enable_sys_prop"];
         if (!enable_prop_node.isNull() && enable_prop_node.isString()) {

--- a/src/loader/manifest_file.cpp
+++ b/src/loader/manifest_file.cpp
@@ -1083,8 +1083,24 @@ XrResult ApiLayerManifestFile::FindManifestFiles(const std::string &openxr_comma
         result = GetPlatformApiLayerVirtualManifests(type == ManifestFileType::MANIFEST_TYPE_IMPLICIT_API_LAYER, system_broker,
                                                      virtual_manifests);
         if (XR_SUCCESS == result) {
-            for (const auto &virtual_manifest : virtual_manifests) {
-                ApiLayerManifestFile::CreateIfValid(type, "virtual manifest", virtual_manifest,
+            std::string fnBase;
+            {
+                std::ostringstream oss{"_virtualManifest_"};
+                if (system_broker) {
+                    oss << "systemBroker_";
+                } else {
+                    oss << "installableBroker_";
+                }
+                if (type == ManifestFileType::MANIFEST_TYPE_IMPLICIT_API_LAYER) {
+                    oss << "implicit.json";
+                } else {
+                    oss << "explicit.json";
+                }
+                fnBase = oss.str();
+            }
+            const size_t n = virtual_manifests.size();
+            for (size_t i = 0; i < n; ++i) {
+                ApiLayerManifestFile::CreateIfValid(type, std::to_string(i) + fnBase, virtual_manifests[i],
                                                     &ApiLayerManifestFile::LocateLibraryInAssets, manifest_files);
             }
         } else {

--- a/src/loader/manifest_file.cpp
+++ b/src/loader/manifest_file.cpp
@@ -861,7 +861,16 @@ void ApiLayerManifestFile::CreateIfValid(ManifestFileType type, const std::strin
         return;
     }
 
-    uint32_t implementation_version = atoi(layer_root_node["implementation_version"].asString().c_str());
+    uint32_t implementation_version = 0;
+    {
+        char *end_ptr;
+        implementation_version = strtol(layer_root_node["implementation_version"].asString().c_str(), &end_ptr, 10);
+        if (*end_ptr != '\0') {
+            std::ostringstream oss(error_ss.str());
+            oss << "layer " << filename << " has invalid implementation version.";
+            LoaderLogger::LogWarningMessage("", oss.str());
+        }
+    }
     std::string library_path = layer_root_node["library_path"].asString();
 
     // If the library_path variable has no directory symbol, it's just a file name and should be accessible on the

--- a/src/loader/manifest_file.hpp
+++ b/src/loader/manifest_file.hpp
@@ -28,6 +28,16 @@ enum ManifestFileType {
     MANIFEST_TYPE_EXPLICIT_API_LAYER,
 };
 
+//! Where did the data for this manifest file (may be virtual) come from?
+enum ManifestFileSource {
+    //! An actual json file on a file system
+    FROM_JSON_MANIFEST = 0,
+    //! The installable runtime broker on Android
+    FROM_INSTALLABLE_BROKER,
+    //! The system runtime broker on Android
+    FROM_SYSTEM_BROKER,
+};
+
 struct JsonVersion {
     uint32_t major;
     uint32_t minor;

--- a/src/loader/manifest_file.hpp
+++ b/src/loader/manifest_file.hpp
@@ -109,6 +109,8 @@ class ApiLayerManifestFile : public ManifestFile {
                          const std::string &description, const JsonVersion &api_version, const uint32_t &implementation_version,
                          const std::string &library_path);
 
+    static void CreateIfValid(ManifestFileType type, const std::string &filename, const Json::Value &root_node,
+                              LibraryLocator locate_library, std::vector<std::unique_ptr<ApiLayerManifestFile>> &manifest_files);
     static void CreateIfValid(ManifestFileType type, const std::string &filename, std::istream &json_stream,
                               LibraryLocator locate_library, std::vector<std::unique_ptr<ApiLayerManifestFile>> &manifest_files);
     static void CreateIfValid(ManifestFileType type, const std::string &filename,

--- a/src/loader/runtime_interface.cpp
+++ b/src/loader/runtime_interface.cpp
@@ -58,6 +58,25 @@ XrResult GetPlatformRuntimeVirtualManifest(Json::Value& out_manifest, ManifestFi
     out_manifest = virtualManifest;
     return XR_SUCCESS;
 }
+
+XrResult GetPlatformApiLayerVirtualManifests(bool is_implicit, bool system_broker, std::vector<Json::Value>& out_manifest) {
+    using wrap::android::content::Context;
+    auto& initData = LoaderInitData::instance();
+    if (!initData.initialized()) {
+        return XR_ERROR_INITIALIZATION_FAILED;
+    }
+    auto context = Context(reinterpret_cast<jobject>(initData.getData().applicationContext));
+    if (context.isNull()) {
+        return XR_ERROR_INITIALIZATION_FAILED;
+    }
+    std::vector<Json::Value> virtualManifests;
+    if (0 != openxr_android::getApiLayerVirtualManifests(is_implicit ? "implicit" : "explicit", context, virtualManifests,
+                                                         system_broker)) {
+        return XR_ERROR_INITIALIZATION_FAILED;
+    }
+    out_manifest = virtualManifests;
+    return XR_SUCCESS;
+}
 #endif  // defined(XR_USE_PLATFORM_ANDROID) && defined(XR_KHR_LOADER_INIT_SUPPORT)
 
 XrResult RuntimeInterface::TryLoadingSingleRuntime(const std::string& openxr_command,

--- a/src/loader/runtime_interface.cpp
+++ b/src/loader/runtime_interface.cpp
@@ -35,7 +35,7 @@
 #endif  // XR_USE_PLATFORM_ANDROID
 
 #if defined(XR_KHR_LOADER_INIT_SUPPORT) && defined(XR_USE_PLATFORM_ANDROID)
-XrResult GetPlatformRuntimeVirtualManifest(Json::Value& out_manifest) {
+XrResult GetPlatformRuntimeVirtualManifest(Json::Value& out_manifest, ManifestFileSource& out_runtime_source) {
     using wrap::android::content::Context;
     auto& initData = LoaderInitData::instance();
     if (!initData.initialized()) {
@@ -49,6 +49,11 @@ XrResult GetPlatformRuntimeVirtualManifest(Json::Value& out_manifest) {
     Json::Value virtualManifest;
     if (0 != openxr_android::getActiveRuntimeVirtualManifest(context, virtualManifest, systemBroker)) {
         return XR_ERROR_INITIALIZATION_FAILED;
+    }
+    if (systemBroker) {
+        out_runtime_source = ManifestFileSource::FROM_SYSTEM_BROKER;
+    } else {
+        out_runtime_source = ManifestFileSource::FROM_INSTALLABLE_BROKER;
     }
     out_manifest = virtualManifest;
     return XR_SUCCESS;

--- a/src/loader/runtime_interface.cpp
+++ b/src/loader/runtime_interface.cpp
@@ -45,8 +45,9 @@ XrResult GetPlatformRuntimeVirtualManifest(Json::Value& out_manifest) {
     if (context.isNull()) {
         return XR_ERROR_INITIALIZATION_FAILED;
     }
+    bool systemBroker = false;
     Json::Value virtualManifest;
-    if (0 != openxr_android::getActiveRuntimeVirtualManifest(context, virtualManifest)) {
+    if (0 != openxr_android::getActiveRuntimeVirtualManifest(context, virtualManifest, systemBroker)) {
         return XR_ERROR_INITIALIZATION_FAILED;
     }
     out_manifest = virtualManifest;


### PR DESCRIPTION
Loader currently did not support API layer disconvery yet. This patch supports this feature.

Loader will try to get all implicit/explicit API layers from broker supported by chosen active runtime and populate virtual API layer manifests from returned cursor. 
Here is authority and path used to find correct cursor: 
- Loader ---> broker

    - authority:org.khronos.openxr.runtime_broker
    - path:/openxr/major_ver/abi/[abi]/api_layer/[implicit:explicit]

Corresponding patch of broker part can be found here: https://gitlab.freedesktop.org/monado/utilities/openxr-android-broker/-/merge_requests/18