### PR TITLE
Hotfix for 1.0.28: Fix build of API layers on Windows on ARM: need bigobj

### DIFF
--- a/src/api_layers/CMakeLists.txt
+++ b/src/api_layers/CMakeLists.txt
@@ -37,6 +37,13 @@ else()
     set(LAYER_MANIFEST_PREFIX)
 endif()
 
+# Windows needs bigobj support since we have generated code.
+if(MSVC)
+    add_compile_options("/bigobj")
+elseif(WIN32 AND CMAKE_CXX_COMPILER_ID MATCHES "^Clang|GNU$")
+    add_compile_options("-Wa,-mbig-obj")
+endif()
+
 # Basics for api_dump API Layer
 
 gen_xr_layer_json(


### PR DESCRIPTION
1.0.28 release build failed because apparently we exceed the section limit but only on windows on arm. This just changes the build flags to fix that.
