### PR TITLE
OpenXR loader: fix for implicit/explicit api layer loading logic.

### DIFF
--- a/src/loader/api_layer_interface.cpp
+++ b/src/loader/api_layer_interface.cpp
@@ -237,21 +237,23 @@ XrResult ApiLayerInterface::LoadApiLayers(const std::string& openxr_command, uin
         for (const auto& layer_name : enabled_explicit_api_layer_names) {
             bool found_this_layer = false;
 
-            for (auto it = explicit_layer_manifest_files.begin(); it != explicit_layer_manifest_files.end();) {
-                bool erased_layer_manifest_file = false;
+            if (layers_already_found.count(layer_name) > 0) {
+                found_this_layer = true;
+            } else {
+                for (auto it = explicit_layer_manifest_files.begin(); it != explicit_layer_manifest_files.end();) {
+                    bool erased_layer_manifest_file = false;
 
-                if (layers_already_found.count(layer_name) > 0) {
-                    found_this_layer = true;
-                } else if (layer_name == (*it)->LayerName()) {
-                    found_this_layer = true;
-                    layers_already_found.insert(layer_name);
-                    enabled_layer_manifest_files_in_init_order.push_back(std::move(*it));
-                    it = explicit_layer_manifest_files.erase(it);
-                    erased_layer_manifest_file = true;
-                }
+                    if (layer_name == (*it)->LayerName()) {
+                        found_this_layer = true;
+                        layers_already_found.insert(layer_name);
+                        enabled_layer_manifest_files_in_init_order.push_back(std::move(*it));
+                        it = explicit_layer_manifest_files.erase(it);
+                        erased_layer_manifest_file = true;
+                    }
 
-                if (!erased_layer_manifest_file) {
-                    it++;
+                    if (!erased_layer_manifest_file) {
+                        it++;
+                    }
                 }
             }
 


### PR DESCRIPTION
There is a case where one runtime's layers are all implicit, but app still mentions those layers in create instance. Loader will throw 'XR_ERROR_API_LAYER_NOT_PRESENT' because it will try to find implicit layers from explicit layer manifest files vector (empty! :(  ).

So it should be ok to move this check out of API layer search in explicit layer manifest returned by runtime.



