### PR TITLE
Add <uses-sdk> tag to android manifests for loader AAR.

### DIFF
--- a/changes/sdk/mr.3029.gl.md
+++ b/changes/sdk/mr.3029.gl.md
@@ -1,0 +1,4 @@
+---
+- pr.434.gh.OpenXR-SDK-Source
+---
+Loader: Add `<uses-sdk>` elements to loader AAR manifest, to prevent the manifest merger from assuming a version < 4 and adding unneeded permissions accordingly.

--- a/src/loader/AndroidManifest.xml
+++ b/src/loader/AndroidManifest.xml
@@ -5,6 +5,9 @@
   SPDX-License-Identifier: Apache-2.0 OR MIT
   -->
 
+  <!-- If this is not included as a minimum, the manifest merger assumes we target an ancient SDK and adds permissions. -->
+  <uses-sdk android:minSdkVersion="24" android:targetSdkVersion="24" />
+
   <uses-permission android:name="org.khronos.openxr.permission.OPENXR" />
   <uses-permission android:name="org.khronos.openxr.permission.OPENXR_SYSTEM" />
 

--- a/src/loader/AndroidManifest.xml.in
+++ b/src/loader/AndroidManifest.xml.in
@@ -7,6 +7,9 @@
   SPDX-License-Identifier: Apache-2.0 OR MIT
   -->
 
+  <!-- If this is not included as a minimum, the manifest merger assumes we target an ancient SDK and adds permissions. -->
+  <uses-sdk android:minSdkVersion="${ANDROID_PLATFORM}" android:targetSdkVersion="${ANDROID_PLATFORM}" />
+
   <uses-permission android:name="org.khronos.openxr.permission.OPENXR" />
   <uses-permission android:name="org.khronos.openxr.permission.OPENXR_SYSTEM" />
 


### PR DESCRIPTION
Without it, the manifest merger assumes something silly (<4) and adds permissions we don't want, which can cause some store rejections.
