### PR TITLE
Add missing header references in test Cmake

### DIFF
--- a/src/tests/c_compile_test/CMakeLists.txt
+++ b/src/tests/c_compile_test/CMakeLists.txt
@@ -42,7 +42,7 @@ if(XR_USE_GRAPHICS_API_VULKAN)
     )
 endif()
 
-target_link_libraries(openxr_c_compile_test OpenXR::openxr_loader)
+target_link_libraries(openxr_c_compile_test OpenXR::openxr_loader OpenXR::headers)
 if(MSVC)
     target_compile_options(
         openxr_c_compile_test PRIVATE /Zc:wchar_t /Zc:forScope /W4

--- a/src/tests/hello_xr/CMakeLists.txt
+++ b/src/tests/hello_xr/CMakeLists.txt
@@ -94,7 +94,10 @@ set_target_properties(hello_xr PROPERTIES FOLDER ${SAMPLES_FOLDER})
 source_group("Headers" FILES ${LOCAL_HEADERS})
 source_group("Shaders" FILES ${VULKAN_SHADERS})
 
-target_link_libraries(hello_xr PRIVATE OpenXR::openxr_loader)
+target_link_libraries(hello_xr
+    PRIVATE OpenXR::openxr_loader
+    PUBLIC OpenXR::headers
+)
 
 compile_glsl(run_hello_xr_glsl_compiles ${VULKAN_SHADERS})
 

--- a/src/tests/list_json/CMakeLists.txt
+++ b/src/tests/list_json/CMakeLists.txt
@@ -34,7 +34,10 @@ endif()
 set_target_properties(
     openxr_runtime_list_json PROPERTIES FOLDER ${TESTS_FOLDER}
 )
-target_link_libraries(openxr_runtime_list_json PRIVATE OpenXR::openxr_loader)
+target_link_libraries(openxr_runtime_list_json
+    PRIVATE OpenXR::openxr_loader
+    PUBLIC  OpenXR::headers
+)
 target_include_directories(
     openxr_runtime_list_json PRIVATE "${PROJECT_SOURCE_DIR}/src"
                                      "${PROJECT_SOURCE_DIR}/src/common"


### PR DESCRIPTION
The test builds currently rely on the build loader dependency on the openxr headers for those headers to be pulled. This merge request makes the dependency explicit for tests, so that when the building the loader is off, the headers are still pulled.