### PR TITLE
Option to disable compiling of hello_xr test

### DIFF
--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -15,8 +15,11 @@
 # limitations under the License.
 
 add_subdirectory(c_compile_test)
-add_subdirectory(hello_xr)
 add_subdirectory(list_json)
+
+if(NOT SKIP_HELLO_XR)
+    add_subdirectory(hello_xr)
+endif()
 
 if(NOT ANDROID)
     add_subdirectory(list)


### PR DESCRIPTION
`hello_xr` test doesn't compile on Android out of the box. It requires defining "OS_LINUX" and including `glad` library.

Having `hello_xr` as a mandragory dependency complicates using this repository as a submodule and it is blocking for integrating OpenXR in Dolphin emulator.