### PR TITLE
Fix implicit API layers being loaded as explicit on Android

### DIFF
--- a/changes/sdk/pr.475.gh.OpenXR-SDK-Source.md
+++ b/changes/sdk/pr.475.gh.OpenXR-SDK-Source.md
@@ -1,0 +1,1 @@
+Fix: Do not load all Android app-supplied layers as explicit, but rather as their actual type.

--- a/src/loader/manifest_file.cpp
+++ b/src/loader/manifest_file.cpp
@@ -773,8 +773,7 @@ void ApiLayerManifestFile::AddManifestFilesAndroid(const std::string &openxr_com
         }
         std::istringstream json_stream(std::string{buf, length});
 
-        CreateIfValid(ManifestFileType::MANIFEST_TYPE_EXPLICIT_API_LAYER, filename, json_stream,
-                      &ApiLayerManifestFile::LocateLibraryInAssets, manifest_files);
+        CreateIfValid(type, filename, json_stream, &ApiLayerManifestFile::LocateLibraryInAssets, manifest_files);
     }
 }
 #endif  // defined(XR_USE_PLATFORM_ANDROID) && defined(XR_KHR_LOADER_INIT_SUPPORT)


### PR DESCRIPTION
This replaces the hardcoded API layer type with an actual type parameter that's supplied to the function, otherwise implicit API layers are treated as explicit.