### PR TITLE
Fix CMake Warning FindPythonInterp and FindPythonLibs modules are removed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@
 cmake_minimum_required(VERSION 3.16)
 project(OPENXR)
 
-find_package(PythonInterp 3)
+find_package(Python3 COMPONENTS Interpreter)
 include(CTest)
 
 # Enable IDE GUI folders.  "Helper targets" that don't have interesting source code should set their FOLDER property to this
@@ -44,7 +44,7 @@ option(
     OFF
 )
 
-if(BUILD_FORCE_GENERATION AND NOT PYTHON_EXECUTABLE)
+if(BUILD_FORCE_GENERATION AND NOT Python3_EXECUTABLE)
     message(FATAL_ERROR "BUILD_FORCE_GENERATION requires Python")
 endif()
 

--- a/changes/sdk/pr.486.gh.OpenXR-SDK-Source.md
+++ b/changes/sdk/pr.486.gh.OpenXR-SDK-Source.md
@@ -1,0 +1,1 @@
+Improvement: Migrate CMake build system away from using `find_package(PythonInterpreter)`, deprecated since CMake 3.12. Use `find_package(Python3 COMPONENTS Interpreter)` instead.

--- a/include/openxr/CMakeLists.txt
+++ b/include/openxr/CMakeLists.txt
@@ -79,7 +79,7 @@ else()
             OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${output}"
             COMMAND
                 "${CMAKE_COMMAND}" -E env "PYTHONPATH=${CODEGEN_PYTHON_PATH}"
-                "${PYTHON_EXECUTABLE}"
+                "${Python3_EXECUTABLE}"
                 "${PROJECT_SOURCE_DIR}/specification/scripts/genxr.py" -registry
                 "${PROJECT_SOURCE_DIR}/specification/registry/xr.xml" -o
                 "${CMAKE_CURRENT_BINARY_DIR}" ${output}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -429,7 +429,7 @@ macro(run_xr_xml_generate dependency output)
         )
         list(APPEND GENERATED_OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/${output}")
     else()
-        if(NOT PYTHON_EXECUTABLE)
+        if(NOT Python3_EXECUTABLE)
             message(
                 FATAL_ERROR
                     "Python 3 not found, but pre-generated ${CMAKE_CURRENT_SOURCE_DIR}/${output} not found"
@@ -439,7 +439,7 @@ macro(run_xr_xml_generate dependency output)
             OUTPUT "${output}"
             COMMAND
                 "${CMAKE_COMMAND}" -E env "PYTHONPATH=${CODEGEN_PYTHON_PATH}"
-                "${PYTHON_EXECUTABLE}"
+                "${Python3_EXECUTABLE}"
                 "${PROJECT_SOURCE_DIR}/src/scripts/src_genxr.py" -registry
                 "${PROJECT_SOURCE_DIR}/specification/registry/xr.xml"
                 "${output}"
@@ -453,7 +453,7 @@ macro(run_xr_xml_generate dependency output)
                 ${ARGN}
             VERBATIM
             COMMENT
-                "Generating ${output} using ${PYTHON_EXECUTABLE} on ${dependency}"
+                "Generating ${output} using ${Python3_EXECUTABLE} on ${dependency}"
         )
         set_source_files_properties(${output} PROPERTIES GENERATED TRUE)
         list(APPEND GENERATED_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${output}")
@@ -475,7 +475,7 @@ macro(
         OUTPUT "${filename}"
         COMMAND
             "${CMAKE_COMMAND}" -E env "PYTHONPATH=${CODEGEN_PYTHON_PATH}"
-            "${PYTHON_EXECUTABLE}"
+            "${Python3_EXECUTABLE}"
             "${PROJECT_SOURCE_DIR}/src/scripts/generate_api_layer_manifest.py"
             -f "${filename}" -n ${layername} -l ${libfile} -a ${MAJOR}.${MINOR}
             -v ${version} ${genbad} -d ${desc}

--- a/src/tests/loader_test/test_runtimes/CMakeLists.txt
+++ b/src/tests/loader_test/test_runtimes/CMakeLists.txt
@@ -49,7 +49,7 @@ macro(gen_xr_runtime_json filename libfile)
     add_custom_command(
         OUTPUT ${filename}
         COMMAND
-            "${PYTHON_EXECUTABLE}"
+            "${Python3_EXECUTABLE}"
             "${PROJECT_SOURCE_DIR}/src/scripts/generate_runtime_manifest.py" -f
             ${filename} -l ${libfile} ${ARGN}
         DEPENDS "${PROJECT_SOURCE_DIR}/src/scripts/generate_runtime_manifest.py"


### PR DESCRIPTION
When running cmake configure on this project I get:
> CMP0148 is not set: The FindPythonInterp and FindPythonLibs modules
are removed.  Run "cmake --help-policy CMP0148" for policy details.  Use
the cmake_policy command to set the policy and suppress this warning.

This is caused by usage of deprecated functionality `find_package(PythonInterp 3)` in the root `CMakeLists.txt`.

Relevant CMake documentation: https://cmake.org/cmake/help/latest/policy/CMP0148.html
> The FindPythonInterp and FindPythonLibs modules are removed.
These modules have been deprecated since CMake 3.12. CMake 3.27 and above prefer to not provide the modules.
 
Here's the new way of finding Python: https://cmake.org/cmake/help/latest/module/FindPython3.html#module:FindPython3