### PR TITLE
ci: Add GitHub Action for macOS building

### DIFF
--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -1,0 +1,41 @@
+# Copyright (c) 2024, The Khronos Group Inc.
+# SPDX-License-Identifier: CC0-1.0
+
+name: macOS
+
+on:
+  push:
+    branches: [ main ]
+
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  macOS-build:
+    strategy:
+        matrix:
+          device: [
+            macos-14, # Tests Mac arm64
+          ]
+    runs-on: ${{ matrix.device }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: "Get modern CMake and Ninja"
+        uses: "lukka/get-cmake@v3.30.2"
+      - name: Prepare Vulkan SDK
+        uses: humbletim/setup-vulkan-sdk@v1.2.0
+        with:
+          vulkan-query-version: 1.3.290.0
+          vulkan-components: Vulkan-Headers, Vulkan-Loader
+          vulkan-use-cache: true
+      - name: Build
+        run: |
+          mkdir -p build/macos
+          cd build/macos
+          cmake -G "Xcode" ../..
+          xcodebuild -list -project OPENXR.xcodeproj/
+          xcodebuild -scheme ALL_BUILD build

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -155,7 +155,16 @@ cd build/macos
 cmake -G "Xcode" ../..
 ```
 
-Finally, open the build/macos/OPENXR.xcodeproj in Xcode to build the samples.
+Finally, open the `build/macos/OPENXR.xcodeproj` in Xcode to build the samples.
+
+If you want to build on the command line, you can run the following command to
+check available targets and built `ALL_BUILD` target as example:
+
+```shell
+# In build/macos directory
+xcodebuild -list -project OPENXR.xcodeproj/
+xcodebuild -scheme ALL_BUILD build
+```
 
 ### Android
 

--- a/changes/sdk/pr.501.gh.OpenXR-SDK-Source.md
+++ b/changes/sdk/pr.501.gh.OpenXR-SDK-Source.md
@@ -1,0 +1,2 @@
+- ci: Add GitHub Action for macOS building
+- doc: Add command to build OpenXR targets on macOS


### PR DESCRIPTION
1. macos-14 for arm64 macOS.

Looks like humbletim/setup-vulkan-sdk's cache mechanism doesn't work for multiple jobs with the same OS but different architectures, like macOS 13 is x86_64 and macOS 14 is arm64. So this CL only adds macos-14 as runner OS and we can enable the macos-13 when we fixed the upstream cache supporting.