### PR TITLE
Add workflow to include pre-built loader on macOS

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,0 +1,57 @@
+# Copyright 2021-2024, Collabora, Ltd.
+# SPDX-License-Identifier: CC0-1.0
+
+name: macOS builds
+on:
+  workflow_call:
+    inputs:
+      organizeAndRelease:
+        description: "Should we organize and release our artifacts?"
+        type: boolean
+        default: false
+  workflow_dispatch:
+
+jobs:
+  build-macos:
+    runs-on: macos-latest
+
+    steps:
+      # Step 1: Checkout the repository
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      # Step 2: Set up Homebrew and install dependencies
+      - name: Install Dependencies
+        run: |
+          brew update
+          brew install cmake ninja
+          # Add any additional dependencies here
+          
+      # Step 3: Configure the build with CMake
+      - name: Configure Build
+        run: |
+          mkdir build
+          cd build
+          cmake -G Ninja \
+                -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+                -DCMAKE_INSTALL_PREFIX=../install \
+                ..
+
+      # Step 4: Build the project
+      - name: Build OpenXR Loader
+        run: |
+          cd build
+          cmake --build . --target install
+
+      # Step 5: Package the build artifacts
+      - name: Package Artifacts
+        run: |
+          cd install
+          tar -czvf OpenXR-Loader-macos-${GITHUB_REF#refs/tags/}.tar.gz *
+
+      # Step 6: Upload the build artifacts
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: OpenXR-Loader-macos-${GITHUB_REF#refs/tags/}
+          path: install/OpenXR-Loader-macos-${GITHUB_REF#refs/tags/}.tar.gz

--- a/.github/workflows/macos-build-preset.yml
+++ b/.github/workflows/macos-build-preset.yml
@@ -4,11 +4,6 @@
 name: macOS builds
 on:
   workflow_call:
-    # inputs:
-    #   organizeAndRelease:
-    #     description: "Should we organize and release our artifacts?"
-    #     type: boolean
-    #     default: false
   workflow_dispatch:
 
 jobs:
@@ -16,42 +11,42 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      # Step 1: Checkout the repository
       - name: Checkout Repository
         uses: actions/checkout@v4
 
-      # Step 2: Set up Homebrew and install dependencies
       - name: Install Dependencies
         run: |
           brew update
           brew install cmake ninja
           # Add any additional dependencies here
           
-      # Step 3: Configure the build with CMake
       - name: Configure Build
         run: |
           mkdir build
           cd build
           cmake -G Ninja \
                 -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+                -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" \
                 -DCMAKE_INSTALL_PREFIX=../install \
                 ..
 
-      # Step 4: Build the project
       - name: Build OpenXR Loader
         run: |
           cd build
           cmake --build . --target install
 
-      # Step 5: Package the build artifacts
+      - name: Add a note about the Quarantine flag
+        run: |
+          cd install
+          echo "After unzipping the package, run 'xattr -d com.apple.quarantine lib/libopenxr_loader.dylib' to allow using the pre-built loader on macOS computers" > README.md
+
       - name: Package Artifacts
         run: |
           cd install
-          tar -czvf OpenXR-Loader-macos-package.tar.gz *
+          tar -czvf openxr_loader_macos.tar.gz *
 
-      # Step 6: Upload the build artifacts
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: OpenXR-Loader-macos-package
-          path: install/OpenXR-Loader-macos-package.tar.gz
+          name: openxr_loader_macos
+          path: install/openxr_loader_macos.tar.gz

--- a/.github/workflows/macos-build-preset.yml
+++ b/.github/workflows/macos-build-preset.yml
@@ -4,11 +4,11 @@
 name: macOS builds
 on:
   workflow_call:
-    inputs:
-      organizeAndRelease:
-        description: "Should we organize and release our artifacts?"
-        type: boolean
-        default: false
+    # inputs:
+    #   organizeAndRelease:
+    #     description: "Should we organize and release our artifacts?"
+    #     type: boolean
+    #     default: false
   workflow_dispatch:
 
 jobs:
@@ -18,7 +18,7 @@ jobs:
     steps:
       # Step 1: Checkout the repository
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Step 2: Set up Homebrew and install dependencies
       - name: Install Dependencies
@@ -47,11 +47,11 @@ jobs:
       - name: Package Artifacts
         run: |
           cd install
-          tar -czvf OpenXR-Loader-macos-${GITHUB_REF#refs/tags/}.tar.gz *
+          tar -czvf OpenXR-Loader-macos-package.tar.gz *
 
       # Step 6: Upload the build artifacts
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: OpenXR-Loader-macos-${GITHUB_REF#refs/tags/}
-          path: install/OpenXR-Loader-macos-${GITHUB_REF#refs/tags/}.tar.gz
+          name: OpenXR-Loader-macos-package
+          path: install/OpenXR-Loader-macos-package.tar.gz

--- a/.github/workflows/macos-build-preset.yml
+++ b/.github/workflows/macos-build-preset.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-macos:
+  macos-build:
     runs-on: macos-latest
 
     steps:
@@ -17,7 +17,7 @@ jobs:
       - name: Install Dependencies
         run: |
           brew update
-          brew install cmake ninja
+          brew install --formula cmake ninja
           # Add any additional dependencies here
           
       - name: Configure Build
@@ -35,6 +35,11 @@ jobs:
           cd build
           cmake --build . --target install
 
+      # Note: The com.apple.quarantine attribute is a macOS extended attribute that 
+      # marks files as downloaded from the internet. When this flag is set, macOS’s 
+      # Gatekeeper enforces security checks, prompting users to confirm whether they 
+      # want to open the file. For developers who download the pre-built OpenXR Loader
+      # using a web browser, they need to manually remove the quarantine attribute.
       - name: Add a note about the Quarantine flag
         run: |
           cd install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,6 @@ jobs:
       organizeAndRelease: true
 
   macos-build:
-    uses: ./.github/workflows/build-macos.yml
-    with:
-      organizeAndRelease: true
+    uses: ./.github/workflows/macos-build-preset.yml
+    # with:
+    #   organizeAndRelease: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,3 +18,8 @@ jobs:
     uses: ./.github/workflows/windows-matrix.yml
     with:
       organizeAndRelease: true
+
+  macos-build:
+    uses: ./.github/workflows/build-macos.yml
+    with:
+      organizeAndRelease: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,4 @@ jobs:
       organizeAndRelease: true
 
   macos-build:
-    uses: ./.github/workflows/macos-build-preset.yml
-    # with:
-    #   organizeAndRelease: true
+    uses: ./.github/workflows/macos-build-preset.yml    


### PR DESCRIPTION
Here is an example run which triggered manually:
https://github.com/xwovr/OpenXR-SDK-Source/actions/runs/12325232718

Test steps:
1. Download the artifact `openxr_loader_macos.zip` from the above run
2. Unzip the artifact to `openxr_loader_macos` folder. And then `cd openxr_loader_macos`
3. Following the instruction in `README.md`, run `xattr -d com.apple.quarantine lib/libopenxr_loader.dylib`
4. Create new Unity project, import `com.unity.xr.openxr`, `com.unity.xr.interaction.toolkit` and `com.meta.xr.simulator` packages
5. Replace the `libopenxr_loader.dylib` in the project's "Packages/OpenXR Plugin/RuntimeLoaders/osx" folder with the one downloaded
6. Meta XR Simulator can be activated and launched successfully using the new OpenXR loader