### PR TITLE
Fix archive-sdk when running on wsl

### DIFF
--- a/maintainer-scripts/archive-sdk.sh
+++ b/maintainer-scripts/archive-sdk.sh
@@ -70,6 +70,7 @@ makeSubset "$TARNAME" $(getSDKFilenames)
 
 # Read the list of headers we should generate, and generate them.
 while read -r header; do
+    header=$(echo "$header" | sed 's/[[:space:]]*$//')
     generate_spec include/openxr "$header" "$TARNAME"
 done < include/generated_header_list.txt
 


### PR DESCRIPTION
When trying to run `maintainer-scripts/archive-sdk.sh` on wsl, it failed to build the headers with `No generator options for unknown target: openxr.h`. This seemed to be because there was an extra character at the end of the filename, so failed to find the key in `genOpts`.

This removes the whitespace at the end of the strings before passing it to `genxr.py` to get it working.