### PR TITLE
Fix ABI identifier of loongarch64 in specification/loader/runtime.adoc.

### DIFF
--- a/changes/sdk/pr.523.gh.OpenXR-SDK-Source.md
+++ b/changes/sdk/pr.523.gh.OpenXR-SDK-Source.md
@@ -1,0 +1,4 @@
+---
+- pr.523.gh.OpenXR-SDK-Source
+---
+Fix the ABI identifier of LoongArch64 in specification/loader/runtime.adoc.

--- a/specification/loader/runtime.adoc
+++ b/specification/loader/runtime.adoc
@@ -379,7 +379,7 @@ architectures and ABIs is used.
   | `sparc64`
   | 64-bit SPARC architecture
 
-|`loong64`
+|`loongarch64`
   |
   | `loong64`
   | 64-bit LoongArch architecture, little endian (LP64D ABI)

--- a/src/common/platform_utils.hpp
+++ b/src/common/platform_utils.hpp
@@ -72,7 +72,7 @@
 #elif defined(__sparc__) && defined(__arch64__)
 #define XR_ARCH_ABI "sparc64"
 #elif defined(__loongarch64)
-#define XR_ARCH_ABI "loong64"
+#define XR_ARCH_ABI "loongarch64"
 #else
 #error "No architecture string known!"
 #endif


### PR DESCRIPTION
Fix the ABI identifier of `loongarch64` in `specification/loader/runtime.adoc`. Similar to `x86_64` and `aarch64`,  the ABI identifier of `loongarch64` should match the output of `$(uname -m)`:

```sh
OpenXR-SDK-Source:/# uname -m
loongarch64
```