### PR TITLE
ci: Turn off 32-bit arm uwp build on azure

### DIFF
--- a/.azure-pipelines/shared/shared.py
+++ b/.azure-pipelines/shared/shared.py
@@ -6,7 +6,7 @@ import sys
 
 VS_VERSION = 'Visual Studio 17 2022'
 
-PLATFORMS = ('Win32', 'x64', 'ARM', 'ARM64')
+PLATFORMS = ('Win32', 'x64', 'ARM64')
 
 TRUE_FALSE = (True, False)
 


### PR DESCRIPTION
Has been broken for quite a while, from about the same time GitHub Actions broke that build.