### PR TITLE
Destroy Pipeline and all ShaderModule

### DIFF
--- a/changes/sdk/pr.538.gh.OpenXR-SDK-Source.md
+++ b/changes/sdk/pr.538.gh.OpenXR-SDK-Source.md
@@ -1,0 +1,1 @@
+> hello_xr: Fix Vulkan resource destruction bugs of ShaderProgram and Pipeline.

--- a/src/tests/hello_xr/graphicsplugin_vulkan.cpp
+++ b/src/tests/hello_xr/graphicsplugin_vulkan.cpp
@@ -352,7 +352,7 @@ struct ShaderProgram {
         if (m_vkDevice != nullptr) {
             for (auto& si : shaderInfo) {
                 if (si.module != VK_NULL_HANDLE) {
-                    vkDestroyShaderModule(m_vkDevice, shaderInfo[0].module, nullptr);
+                    vkDestroyShaderModule(m_vkDevice, si.module, nullptr);
                 }
                 si.module = VK_NULL_HANDLE;
             }
@@ -880,6 +880,8 @@ struct Pipeline {
         pipe = VK_NULL_HANDLE;
         m_vkDevice = nullptr;
     }
+
+    ~Pipeline() { Release(); }
 
    private:
     VkDevice m_vkDevice{VK_NULL_HANDLE};


### PR DESCRIPTION
- `vkDestroyShaderModule` : bug in the loop. Was always destory the 0th item
- `vkDestroyPipeline` : Pipeline::Release never call. Use destructor, like in the other structs

In order to avoid thoses warnings

```
VK_OBJECT_TYPE_SHADER_MODULE; | MessageID = 0x4872eaa0 | vkDestroyDevice(): OBJ ERROR : For VkDevice 0x21a28d16d50[], Vk
ShaderModule 0xcfef35000000000a[] has not been destroyed.

validation layer: Validation Error: [ VUID-vkDestroyDevice-device-05137 ] Object 0: handle = 0xd10d270000000018, type =
VK_OBJECT_TYPE_PIPELINE; | MessageID = 0x4872eaa0 | vkDestroyDevice(): OBJ ERROR : For VkDevice 0x232cccfd950[], VkPipel
ine 0xd10d270000000018[] has not been destroyed.
```