### PR TITLE
ci: Enable full vulkan cache for all macOS architecture

### DIFF
--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -18,6 +18,7 @@ jobs:
     strategy:
         matrix:
           device: [
+            macos-13, # Tests Mac x86_64
             macos-14, # Tests Mac arm64
           ]
     runs-on: ${{ matrix.device }}
@@ -26,12 +27,12 @@ jobs:
       - uses: actions/checkout@v4
       - name: "Get modern CMake and Ninja"
         uses: "lukka/get-cmake@v3.31.6"
-      # - name: Prepare Vulkan SDK
-      #   uses: humbletim/setup-vulkan-sdk@v1.2.0
-      #   with:
-      #     vulkan-query-version: 1.3.290.0
-      #     vulkan-components: Vulkan-Headers, Vulkan-Loader
-      #     vulkan-use-cache: true
+      - name: Prepare Vulkan SDK
+        uses: humbletim/setup-vulkan-sdk@v1.2.1
+        with:
+          vulkan-query-version: 1.3.290.0
+          vulkan-components: Vulkan-Headers, Vulkan-Loader
+          vulkan-use-cache: true
       - name: Build
         run: |
           mkdir -p build/macos


### PR DESCRIPTION
See https://github.com/humbletim/setup-vulkan-sdk/releases/tag/v1.2.1.