### PR TITLE
[Android] libopenxr_loader.so Support 16 KB page size

### DIFF
--- a/src/loader/CMakeLists.txt
+++ b/src/loader/CMakeLists.txt
@@ -151,6 +151,9 @@ if(ANDROID)
     target_link_libraries(
         openxr_loader PRIVATE ${ANDROID_LOG_LIBRARY} ${ANDROID_LIBRARY}
     )
+     target_link_options(openxr_loader PRIVATE
+         "-Wl,-z,max-page-size=16384"
+     )
 
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(FALLBACK_CONFIG_DIRS


### PR DESCRIPTION
[Android] libopenxr_loader.so Support 16 KB page size
	modified:   src/loader/CMakeLists.txt

Beginning with Android 15, AOSP supports devices that are configured to use a page size of 16 KB (16 KB devices).
https://android-developers.googleblog.com/2025/05/prepare-play-apps-for-devices-with-16kb-page-size.html


issue: https://github.com/KhronosGroup/OpenXR-SDK-Source/issues/546

