### PR TITLE
Include <iterator> directly in api_layer_interface.cpp

### DIFF
--- a/changes/sdk/pr.554.gh.OpenXR-SDK-Source.md
+++ b/changes/sdk/pr.554.gh.OpenXR-SDK-Source.md
@@ -1,0 +1,1 @@
+Fix: Add missing include directive in loader code.

--- a/src/loader/api_layer_interface.cpp
+++ b/src/loader/api_layer_interface.cpp
@@ -19,6 +19,7 @@
 #include <openxr/openxr_loader_negotiation.h>
 
 #include <cstring>
+#include <iterator>
 #include <memory>
 #include <sstream>
 #include <string>


### PR DESCRIPTION
The newest version of LLVM's libc++ no longer includes <iterator> transitively, so we need to include it directly in order to have access to `std::back_inserter`.