### PR TITLE
Include <algorithm> directly in api_layer_interface.cpp.

### DIFF
--- a/src/loader/api_layer_interface.cpp
+++ b/src/loader/api_layer_interface.cpp
@@ -18,6 +18,7 @@
 #include <openxr/openxr.h>
 #include <openxr/openxr_loader_negotiation.h>
 
+#include <algorithm>
 #include <cstring>
 #include <iterator>
 #include <memory>


### PR DESCRIPTION
api_layer_interface fails to compile when using libcxx as a module.