### PR TITLE
Export CMake configuration

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -620,3 +620,16 @@ endif()
 if(BUILD_CONFORMANCE_TESTS)
     add_subdirectory(conformance)
 endif()
+
+include(CMakePackageConfigHelpers)
+
+configure_package_config_file(
+	cmake/OpenXR-config.cmake.in
+	${CMAKE_CURRENT_BINARY_DIR}/OpenXR-config.cmake
+	INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/OpenXR
+)
+
+install(FILES
+	${CMAKE_CURRENT_BINARY_DIR}/OpenXR-config.cmake
+	DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/OpenXR
+)

--- a/src/cmake/OpenXR-config.cmake.in
+++ b/src/cmake/OpenXR-config.cmake.in
@@ -1,0 +1,3 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/OpenXRTargets.cmake")


### PR DESCRIPTION
This allows for dependents to find openxr-loader with `find_package(OpenXR)`