### PR TITLE
build: Do not install manpages on Android, always use gnuinstalldirs unless we do our own thing, fixing install.

### DIFF
--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -18,8 +18,8 @@ jobs:
     strategy:
         matrix:
           device: [
-            macos-13, # Tests Mac x86_64
-            macos-14, # Tests Mac arm64
+            macos-15-intel, # Tests Mac x86_64
+            macos-latest, # Tests Mac arm64
           ]
     runs-on: ${{ matrix.device }}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,7 +128,7 @@ elseif(ANDROID AND INSTALL_TO_ARCHITECTURE_PREFIXES)
         )
     endif()
 
-elseif(NOT ANDROID)
+else()
     include(GNUInstallDirs)
 endif()
 

--- a/changes/sdk/pr.573.gh.OpenXR-SDK-Source.md
+++ b/changes/sdk/pr.573.gh.OpenXR-SDK-Source.md
@@ -1,0 +1,4 @@
+---
+- issue.568.gh.OpenXR-SDK-Source
+---
+Fix: Do not attempt to install manpages on Android, fixing CMake install.

--- a/changes/sdk/pr.573.gh.OpenXR-SDK-Source.md
+++ b/changes/sdk/pr.573.gh.OpenXR-SDK-Source.md
@@ -1,4 +1,5 @@
 ---
 - issue.568.gh.OpenXR-SDK-Source
+- issue.2645.gl
 ---
-Fix: Do not attempt to install manpages on Android, fixing CMake install.
+Fix: Do not attempt to install manpages on Android, and ensure all directory prefixes are populated, fixing CMake install.

--- a/src/tests/list/CMakeLists.txt
+++ b/src/tests/list/CMakeLists.txt
@@ -50,7 +50,7 @@ install(
     TARGETS openxr_runtime_list RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
                                         COMPONENT openxr_runtime_list
 )
-if(NOT WIN32)
+if(NOT WIN32 AND NOT ANDROID)
     install(
         FILES openxr_runtime_list.1
         DESTINATION ${CMAKE_INSTALL_MANDIR}/man1/

--- a/src/tests/list_json/CMakeLists.txt
+++ b/src/tests/list_json/CMakeLists.txt
@@ -75,7 +75,7 @@ if(NOT ANDROID)
                 COMPONENT openxr_runtime_list_json
     )
 endif()
-if(NOT WIN32)
+if(NOT WIN32 AND NOT ANDROID)
     install(
         FILES openxr_runtime_list_json.1
         DESTINATION ${CMAKE_INSTALL_MANDIR}/man1/


### PR DESCRIPTION
Fixes #568