### PR TITLE
Use the `QUITE` mode when looking for `Sanitizers`

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,7 +30,7 @@ list(
 
 include(StdFilesystemFlags)
 
-find_package(Sanitizers)
+find_package(Sanitizers QUIET)
 
 ### Dependencies
 


### PR DESCRIPTION
Prevent CMake warnings.