### PR TITLE
OpenXR 1.1.54 hello_xr sample fixes

### DIFF
--- a/src/tests/hello_xr/graphicsplugin_d3d11.cpp
+++ b/src/tests/hello_xr/graphicsplugin_d3d11.cpp
@@ -352,9 +352,6 @@ struct D3D11GraphicsPlugin : public IGraphicsPlugin {
     ComPtr<ID3D11Buffer> m_viewProjectionCBuffer;
     ComPtr<ID3D11Buffer> m_cubeVertexBuffer;
     ComPtr<ID3D11Buffer> m_cubeIndexBuffer;
-
-    // Map color buffer to associated depth buffer. This map is populated on demand.
-    std::map<ID3D11Texture2D*, ComPtr<ID3D11DepthStencilView>> m_colorToDepthMap;
     std::array<float, 4> m_clearColor;
 };
 }  // namespace

--- a/src/tests/hello_xr/graphicsplugin_d3d12.cpp
+++ b/src/tests/hello_xr/graphicsplugin_d3d12.cpp
@@ -363,7 +363,7 @@ struct D3D12GraphicsPlugin : public IGraphicsPlugin {
 
        private:
         ComPtr<ID3D12Resource> m_texture{};
-        XrSwapchainImageD3D12KHR m_xrImage{XR_TYPE_SWAPCHAIN_IMAGE_D3D11_KHR};
+        XrSwapchainImageD3D12KHR m_xrImage{XR_TYPE_SWAPCHAIN_IMAGE_D3D12_KHR};
     };
 
     class D3D12SwapchainImageData : public SwapchainImageDataBase<XrSwapchainImageD3D12KHR> {

--- a/src/tests/hello_xr/graphicsplugin_d3d12.cpp
+++ b/src/tests/hello_xr/graphicsplugin_d3d12.cpp
@@ -94,11 +94,6 @@ class SwapchainImageContext {
         return bases;
     }
 
-    uint32_t ImageIndex(const XrSwapchainImageBaseHeader* swapchainImageHeader) {
-        auto p = reinterpret_cast<const XrSwapchainImageD3D12KHR*>(swapchainImageHeader);
-        return (uint32_t)(p - &m_swapchainImages[0]);
-    }
-
     ID3D12Resource* GetDepthStencilTexture(ID3D12Resource* colorTexture) {
         if (!m_depthStencilTexture) {
             // This back-buffer has no corresponding depth-stencil texture, so create one with matching dimensions.

--- a/src/tests/hello_xr/graphicsplugin_opengl.cpp
+++ b/src/tests/hello_xr/graphicsplugin_opengl.cpp
@@ -116,12 +116,6 @@ struct OpenGLGraphicsPlugin : public IGraphicsPlugin {
             glDeleteBuffers(1, &m_cubeIndexBuffer);
         }
 
-        for (auto& colorToDepth : m_colorToDepthMap) {
-            if (colorToDepth.second != 0) {
-                glDeleteTextures(1, &colorToDepth.second);
-            }
-        }
-
         ksGpuWindow_Destroy(&window);
     }
 
@@ -412,35 +406,6 @@ struct OpenGLGraphicsPlugin : public IGraphicsPlugin {
         return ret;
     }
 
-    uint32_t GetDepthTexture(uint32_t colorTexture) {
-        // If a depth-stencil view has already been created for this back-buffer, use it.
-        auto depthBufferIt = m_colorToDepthMap.find(colorTexture);
-        if (depthBufferIt != m_colorToDepthMap.end()) {
-            return depthBufferIt->second;
-        }
-
-        // This back-buffer has no corresponding depth-stencil texture, so create one with matching dimensions.
-
-        GLint width;
-        GLint height;
-        glBindTexture(GL_TEXTURE_2D, colorTexture);
-        glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_WIDTH, &width);
-        glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_HEIGHT, &height);
-
-        uint32_t depthTexture;
-        glGenTextures(1, &depthTexture);
-        glBindTexture(GL_TEXTURE_2D, depthTexture);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT32, width, height, 0, GL_DEPTH_COMPONENT, GL_FLOAT, nullptr);
-
-        m_colorToDepthMap.insert(std::make_pair(colorTexture, depthTexture));
-
-        return depthTexture;
-    }
-
     void RenderView(const XrCompositionLayerProjectionView& layerView, const XrSwapchainImageBaseHeader* swapchainImage,
                     int64_t swapchainFormat, const std::vector<Cube>& cubes) override {
         CHECK(layerView.subImage.imageArrayIndex == 0);  // Texture arrays not supported.
@@ -535,9 +500,6 @@ struct OpenGLGraphicsPlugin : public IGraphicsPlugin {
     GLuint m_vao{0};
     GLuint m_cubeVertexBuffer{0};
     GLuint m_cubeIndexBuffer{0};
-
-    // Map color buffer to associated depth buffer. This map is populated on demand.
-    std::map<uint32_t, uint32_t> m_colorToDepthMap;
     std::array<float, 4> m_clearColor;
 };
 }  // namespace

--- a/src/tests/hello_xr/graphicsplugin_opengles.cpp
+++ b/src/tests/hello_xr/graphicsplugin_opengles.cpp
@@ -82,12 +82,6 @@ struct OpenGLESGraphicsPlugin : public IGraphicsPlugin {
             glDeleteBuffers(1, &m_cubeIndexBuffer);
         }
 
-        for (auto& colorToDepth : m_colorToDepthMap) {
-            if (colorToDepth.second != 0) {
-                glDeleteTextures(1, &colorToDepth.second);
-            }
-        }
-
         ksGpuWindow_Destroy(&window);
     }
 
@@ -341,35 +335,6 @@ struct OpenGLESGraphicsPlugin : public IGraphicsPlugin {
         return ret;
     }
 
-    uint32_t GetDepthTexture(uint32_t colorTexture) {
-        // If a depth-stencil view has already been created for this back-buffer, use it.
-        auto depthBufferIt = m_colorToDepthMap.find(colorTexture);
-        if (depthBufferIt != m_colorToDepthMap.end()) {
-            return depthBufferIt->second;
-        }
-
-        // This back-buffer has no corresponding depth-stencil texture, so create one with matching dimensions.
-
-        GLint width;
-        GLint height;
-        glBindTexture(GL_TEXTURE_2D, colorTexture);
-        glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_WIDTH, &width);
-        glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_HEIGHT, &height);
-
-        uint32_t depthTexture;
-        glGenTextures(1, &depthTexture);
-        glBindTexture(GL_TEXTURE_2D, depthTexture);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT24, width, height, 0, GL_DEPTH_COMPONENT, GL_UNSIGNED_INT, nullptr);
-
-        m_colorToDepthMap.insert(std::make_pair(colorTexture, depthTexture));
-
-        return depthTexture;
-    }
-
     void RenderView(const XrCompositionLayerProjectionView& layerView, const XrSwapchainImageBaseHeader* swapchainImage,
                     int64_t swapchainFormat, const std::vector<Cube>& cubes) override {
         CHECK(layerView.subImage.imageArrayIndex == 0);  // Texture arrays not supported.
@@ -455,9 +420,6 @@ struct OpenGLESGraphicsPlugin : public IGraphicsPlugin {
     GLuint m_cubeVertexBuffer{0};
     GLuint m_cubeIndexBuffer{0};
     GLint m_contextApiMajorVersion{0};
-
-    // Map color buffer to associated depth buffer. This map is populated on demand.
-    std::map<uint32_t, uint32_t> m_colorToDepthMap;
     std::array<float, 4> m_clearColor;
 };
 }  // namespace

--- a/src/tests/hello_xr/graphicsplugin_opengles.cpp
+++ b/src/tests/hello_xr/graphicsplugin_opengles.cpp
@@ -375,9 +375,14 @@ struct OpenGLESGraphicsPlugin : public IGraphicsPlugin {
         CHECK(layerView.subImage.imageArrayIndex == 0);  // Texture arrays not supported.
         UNUSED_PARM(swapchainFormat);                    // Not used in this function for now.
 
+        OpenGLESSwapchainImageData* swapchainData;
+        uint32_t imageIndex;
+        std::tie(swapchainData, imageIndex) = m_swapchainImageDataMap.GetDataAndIndexFromBasePointer(swapchainImage);
+
         glBindFramebuffer(GL_FRAMEBUFFER, m_swapchainFramebuffer);
 
         const uint32_t colorTexture = reinterpret_cast<const XrSwapchainImageOpenGLESKHR*>(swapchainImage)->image;
+        const uint32_t depthTexture = swapchainData->GetDepthImageForColorIndex(imageIndex).image;
 
         glViewport(static_cast<GLint>(layerView.subImage.imageRect.offset.x),
                    static_cast<GLint>(layerView.subImage.imageRect.offset.y),
@@ -388,8 +393,6 @@ struct OpenGLESGraphicsPlugin : public IGraphicsPlugin {
         glCullFace(GL_BACK);
         glEnable(GL_CULL_FACE);
         glEnable(GL_DEPTH_TEST);
-
-        const uint32_t depthTexture = GetDepthTexture(colorTexture);
 
         glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, colorTexture, 0);
         glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, depthTexture, 0);


### PR DESCRIPTION
A few fixes for the hello_xr sample that has been updated with OpenXR 1.1.54.