### PR TITLE
[hello_xr] Use preferred depth swapchain format rather than (somewhat unsupported) D32.

### DIFF
--- a/src/tests/hello_xr/graphicsplugin.h
+++ b/src/tests/hello_xr/graphicsplugin.h
@@ -55,7 +55,7 @@ struct IGraphicsPlugin {
 
     // Render to a swapchain image for a projection view.
     virtual void RenderView(const XrCompositionLayerProjectionView& layerView, const XrSwapchainImageBaseHeader* swapchainImage,
-                            int64_t swapchainFormat, const std::vector<Cube>& cubes) = 0;
+                            int64_t colorSwapchainFormat, int64_t depthSwapchainFormat, const std::vector<Cube>& cubes) = 0;
 
     // Get recommended number of sub-data element samples in view (recommendedSwapchainSampleCount)
     // if supported by the graphics plugin. A supported value otherwise.

--- a/src/tests/hello_xr/graphicsplugin_d3d11.cpp
+++ b/src/tests/hello_xr/graphicsplugin_d3d11.cpp
@@ -273,7 +273,8 @@ struct D3D11GraphicsPlugin : public IGraphicsPlugin {
     }
 
     void RenderView(const XrCompositionLayerProjectionView& layerView, const XrSwapchainImageBaseHeader* swapchainImage,
-                    int64_t /* swapchainFormat */, const std::vector<Cube>& cubes) override {
+                    int64_t /* colorSwapchainFormat */, int64_t /* depthSwapchainFormat */,
+                    const std::vector<Cube>& cubes) override {
         CHECK(layerView.subImage.imageArrayIndex == 0);  // Texture arrays not supported.
 
         D3D11SwapchainImageData* swapchainData;

--- a/src/tests/hello_xr/graphicsplugin_d3d12.cpp
+++ b/src/tests/hello_xr/graphicsplugin_d3d12.cpp
@@ -458,8 +458,9 @@ struct D3D12GraphicsPlugin : public IGraphicsPlugin {
         return ret;
     }
 
-    ID3D12PipelineState* GetOrCreatePipelineState(DXGI_FORMAT swapchainFormat) {
-        auto iter = m_pipelineStates.find(swapchainFormat);
+    ID3D12PipelineState* GetOrCreatePipelineState(DXGI_FORMAT colorSwapchainFormat, DXGI_FORMAT depthSwapchainFormat) {
+        auto swapchainFormats = std::make_pair(colorSwapchainFormat, depthSwapchainFormat);
+        auto iter = m_pipelineStates.find(swapchainFormats);
         if (iter != m_pipelineStates.end()) {
             return iter->second.Get();
         }
@@ -525,8 +526,8 @@ struct D3D12GraphicsPlugin : public IGraphicsPlugin {
         pipelineStateDesc.IBStripCutValue = D3D12_INDEX_BUFFER_STRIP_CUT_VALUE_0xFFFF;
         pipelineStateDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
         pipelineStateDesc.NumRenderTargets = 1;
-        pipelineStateDesc.RTVFormats[0] = swapchainFormat;
-        pipelineStateDesc.DSVFormat = DXGI_FORMAT_D32_FLOAT;
+        pipelineStateDesc.RTVFormats[0] = colorSwapchainFormat;
+        pipelineStateDesc.DSVFormat = depthSwapchainFormat;
         pipelineStateDesc.SampleDesc = {1, 0};
         pipelineStateDesc.NodeMask = 0;
         pipelineStateDesc.CachedPSO = {nullptr, 0};
@@ -537,13 +538,13 @@ struct D3D12GraphicsPlugin : public IGraphicsPlugin {
                                                           reinterpret_cast<void**>(pipelineState.ReleaseAndGetAddressOf())));
         ID3D12PipelineState* pipelineStateRaw = pipelineState.Get();
 
-        m_pipelineStates.emplace(swapchainFormat, std::move(pipelineState));
+        m_pipelineStates.emplace(swapchainFormats, std::move(pipelineState));
 
         return pipelineStateRaw;
     }
 
     void RenderView(const XrCompositionLayerProjectionView& layerView, const XrSwapchainImageBaseHeader* swapchainImage,
-                    int64_t swapchainFormat, const std::vector<Cube>& cubes) override {
+                    int64_t colorSwapchainFormat, int64_t depthSwapchainFormat, const std::vector<Cube>& cubes) override {
         CHECK(layerView.subImage.imageArrayIndex == 0);  // Texture arrays not supported.
 
         D3D12SwapchainImageData* swapchainData;
@@ -561,7 +562,8 @@ struct D3D12GraphicsPlugin : public IGraphicsPlugin {
             0, D3D12_COMMAND_LIST_TYPE_DIRECT, swapchainData->GetCommandAllocator(), nullptr, __uuidof(ID3D12GraphicsCommandList),
             reinterpret_cast<void**>(cmdList.ReleaseAndGetAddressOf())));
 
-        ID3D12PipelineState* pipelineState = GetOrCreatePipelineState((DXGI_FORMAT)swapchainFormat);
+        ID3D12PipelineState* pipelineState =
+            GetOrCreatePipelineState((DXGI_FORMAT)colorSwapchainFormat, (DXGI_FORMAT)depthSwapchainFormat);
         cmdList->SetPipelineState(pipelineState);
         cmdList->SetGraphicsRootSignature(m_rootSignature.Get());
 
@@ -584,7 +586,7 @@ struct D3D12GraphicsPlugin : public IGraphicsPlugin {
         // Create RenderTargetView with original swapchain format (swapchain is typeless).
         D3D12_CPU_DESCRIPTOR_HANDLE renderTargetView = m_rtvHeap->GetCPUDescriptorHandleForHeapStart();
         D3D12_RENDER_TARGET_VIEW_DESC renderTargetViewDesc{};
-        renderTargetViewDesc.Format = (DXGI_FORMAT)swapchainFormat;
+        renderTargetViewDesc.Format = (DXGI_FORMAT)colorSwapchainFormat;
         if (colorTextureDesc.DepthOrArraySize > 1) {
             if (colorTextureDesc.SampleDesc.Count > 1) {
                 renderTargetViewDesc.ViewDimension = D3D12_RTV_DIMENSION_TEXTURE2DMSARRAY;
@@ -606,7 +608,7 @@ struct D3D12GraphicsPlugin : public IGraphicsPlugin {
         const D3D12_RESOURCE_DESC depthStencilTextureDesc = depthStencilTexture->GetDesc();
         D3D12_CPU_DESCRIPTOR_HANDLE depthStencilView = m_dsvHeap->GetCPUDescriptorHandleForHeapStart();
         D3D12_DEPTH_STENCIL_VIEW_DESC depthStencilViewDesc{};
-        depthStencilViewDesc.Format = DXGI_FORMAT_D32_FLOAT;
+        depthStencilViewDesc.Format = (DXGI_FORMAT)depthSwapchainFormat;
         if (depthStencilTextureDesc.DepthOrArraySize > 1) {
             if (depthStencilTextureDesc.SampleDesc.Count > 1) {
                 depthStencilViewDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2DMSARRAY;
@@ -730,7 +732,7 @@ struct D3D12GraphicsPlugin : public IGraphicsPlugin {
     SwapchainImageDataMap<D3D12SwapchainImageData> m_swapchainImageDataMap;
     XrGraphicsBindingD3D12KHR m_graphicsBinding{XR_TYPE_GRAPHICS_BINDING_D3D12_KHR};
     ComPtr<ID3D12RootSignature> m_rootSignature;
-    std::map<DXGI_FORMAT, ComPtr<ID3D12PipelineState>> m_pipelineStates;
+    std::map<std::pair<DXGI_FORMAT, DXGI_FORMAT>, ComPtr<ID3D12PipelineState>> m_pipelineStates;
     ComPtr<ID3D12Resource> m_cubeVertexBuffer;
     ComPtr<ID3D12Resource> m_cubeIndexBuffer;
     ComPtr<ID3D12DescriptorHeap> m_rtvHeap;

--- a/src/tests/hello_xr/graphicsplugin_metal.cpp
+++ b/src/tests/hello_xr/graphicsplugin_metal.cpp
@@ -308,19 +308,20 @@ struct MetalGraphicsPlugin : public IGraphicsPlugin {
     }
 
     void RenderView(const XrCompositionLayerProjectionView& layerView, const XrSwapchainImageBaseHeader* swapchainImage,
-                    int64_t swapchainFormat, const std::vector<Cube>& cubes) override {
+                    int64_t colorSwapchainFormat, int64_t depthSwapchainFormat, const std::vector<Cube>& cubes) override {
         auto pAutoReleasePool = NS::TransferPtr(NS::AutoreleasePool::alloc()->init());
 
         SwapchainContext& swapchainContext =
             m_swapchainImageDataMap.GetDataAndIndexFromBasePointer(swapchainImage).first->swapchainContext;
 
-        auto mtlSwapchainFormat = (MTL::PixelFormat)swapchainFormat;
-        if (mtlSwapchainFormat != m_colorAttachmentFormat) {
+        auto mtlColorSwapchainFormat = (MTL::PixelFormat)colorSwapchainFormat;
+        auto mtlDepthSwapchainFormat = (MTL::PixelFormat)depthSwapchainFormat;
+        if ((mtlColorSwapchainFormat != m_colorAttachmentFormat) || (mtlDepthSwapchainFormat != m_depthAttachmentFormat)) {
             auto pDesc = NS::TransferPtr(MTL::RenderPipelineDescriptor::alloc()->init());
             pDesc->setVertexFunction(m_vertexFunction.get());
             pDesc->setFragmentFunction(m_fragmentFunction.get());
-            pDesc->colorAttachments()->object(0)->setPixelFormat(mtlSwapchainFormat);
-            pDesc->setDepthAttachmentPixelFormat(MTL::PixelFormatDepth32Float);
+            pDesc->colorAttachments()->object(0)->setPixelFormat(mtlColorSwapchainFormat);
+            pDesc->setDepthAttachmentPixelFormat(mtlDepthSwapchainFormat);
 
             NS::Error* pError = nullptr;
             m_pipelineStateObject = NS::TransferPtr(m_device->newRenderPipelineState(pDesc.get(), &pError));
@@ -329,7 +330,7 @@ struct MetalGraphicsPlugin : public IGraphicsPlugin {
                 assert(false);
                 return;
             }
-            m_colorAttachmentFormat = mtlSwapchainFormat;
+            m_colorAttachmentFormat = mtlColorSwapchainFormat;
         }
 
         CHECK(layerView.subImage.imageArrayIndex == 0);  // Texture arrays not supported.
@@ -339,7 +340,7 @@ struct MetalGraphicsPlugin : public IGraphicsPlugin {
         if (!m_depthStencilTexture) {
             auto depthTextureDescriptor = NS::TransferPtr(MTL::TextureDescriptor::alloc()->init());
             depthTextureDescriptor->setTextureType(colorTexture->textureType());
-            depthTextureDescriptor->setPixelFormat(MTL::PixelFormatDepth32Float);
+            depthTextureDescriptor->setPixelFormat(mtlDepthSwapchainFormat);
             depthTextureDescriptor->setWidth(colorTexture->width());
             depthTextureDescriptor->setHeight(colorTexture->height());
             depthTextureDescriptor->setUsage(MTL::TextureUsageRenderTarget);
@@ -423,6 +424,7 @@ struct MetalGraphicsPlugin : public IGraphicsPlugin {
     NS::SharedPtr<MTL::RenderPipelineState> m_pipelineStateObject;
     NS::SharedPtr<MTL::DepthStencilState> m_depthStencilState;
     MTL::PixelFormat m_colorAttachmentFormat{MTL::PixelFormatInvalid};
+    MTL::PixelFormat m_depthAttachmentFormat{MTL::PixelFormatInvalid};
 
     NS::SharedPtr<MTL::Library> m_library;
     NS::SharedPtr<MTL::Function> m_vertexFunction;

--- a/src/tests/hello_xr/graphicsplugin_opengl.cpp
+++ b/src/tests/hello_xr/graphicsplugin_opengl.cpp
@@ -407,9 +407,10 @@ struct OpenGLGraphicsPlugin : public IGraphicsPlugin {
     }
 
     void RenderView(const XrCompositionLayerProjectionView& layerView, const XrSwapchainImageBaseHeader* swapchainImage,
-                    int64_t swapchainFormat, const std::vector<Cube>& cubes) override {
+                    int64_t colorSwapchainFormat, int64_t depthSwapchainFormat, const std::vector<Cube>& cubes) override {
         CHECK(layerView.subImage.imageArrayIndex == 0);  // Texture arrays not supported.
-        UNUSED_PARM(swapchainFormat);                    // Not used in this function for now.
+        UNUSED_PARM(colorSwapchainFormat);               // Not used in this function for now.
+        UNUSED_PARM(depthSwapchainFormat);               // Not used in this function for now.
 
         OpenGLSwapchainImageData* swapchainData;
         uint32_t imageIndex;

--- a/src/tests/hello_xr/graphicsplugin_opengles.cpp
+++ b/src/tests/hello_xr/graphicsplugin_opengles.cpp
@@ -336,9 +336,10 @@ struct OpenGLESGraphicsPlugin : public IGraphicsPlugin {
     }
 
     void RenderView(const XrCompositionLayerProjectionView& layerView, const XrSwapchainImageBaseHeader* swapchainImage,
-                    int64_t swapchainFormat, const std::vector<Cube>& cubes) override {
+                    int64_t colorSwapchainFormat, int64_t depthSwapchainFormat, const std::vector<Cube>& cubes) override {
         CHECK(layerView.subImage.imageArrayIndex == 0);  // Texture arrays not supported.
-        UNUSED_PARM(swapchainFormat);                    // Not used in this function for now.
+        UNUSED_PARM(colorSwapchainFormat);               // Not used in this function for now.
+        UNUSED_PARM(depthSwapchainFormat);               // Not used in this function for now.
 
         OpenGLESSwapchainImageData* swapchainData;
         uint32_t imageIndex;

--- a/src/tests/hello_xr/graphicsplugin_vulkan.cpp
+++ b/src/tests/hello_xr/graphicsplugin_vulkan.cpp
@@ -825,7 +825,7 @@ struct VulkanGraphicsPlugin : public IGraphicsPlugin {
     }
 
     void RenderView(const XrCompositionLayerProjectionView& layerView, const XrSwapchainImageBaseHeader* swapchainImage,
-                    int64_t /*swapchainFormat*/, const std::vector<Cube>& cubes) override {
+                    int64_t /*colorSwapchainFormat*/, int64_t /*depthSwapchainFormat*/, const std::vector<Cube>& cubes) override {
         CHECK(layerView.subImage.imageArrayIndex == 0);  // Texture arrays not supported.
 
         VulkanSwapchainImageData* swapchainData;

--- a/src/tests/hello_xr/openxr_program.cpp
+++ b/src/tests/hello_xr/openxr_program.cpp
@@ -1065,7 +1065,8 @@ struct OpenXrProgram : IOpenXrProgram {
 
             const XrSwapchainImageBaseHeader* const swapchainImage =
                 m_swapchainImages[viewSwapchain.handle]->GetGenericColorImage(swapchainImageIndex);
-            m_graphicsPlugin->RenderView(projectionLayerViews[i], swapchainImage, m_colorSwapchainFormat, cubes);
+            m_graphicsPlugin->RenderView(projectionLayerViews[i], swapchainImage, m_colorSwapchainFormat, m_depthSwapchainFormat,
+                                         cubes);
 
             XrSwapchainImageReleaseInfo releaseInfo{XR_TYPE_SWAPCHAIN_IMAGE_RELEASE_INFO};
             CHECK_XRCMD(xrReleaseSwapchainImage(viewSwapchain.handle, &releaseInfo));


### PR DESCRIPTION
Since release of OpenXR 1.1.54, hello_xr example cannot run on some devices such as Microsoft HoloLens 2 HMD. Reason is that for some graphics plugins, D32 depth format is forcibly used. Microsoft HoloLens 2 HMD doesn't support such a format for depth swapchain (preferred depth format is D16 on this device). This PR proposes to make use of the preferred depth swapchain format instead of D32.