### PR TITLE
API dump: print XrPath values

### DIFF
--- a/src/api_layers/api_dump.cpp
+++ b/src/api_layers/api_dump.cpp
@@ -233,7 +233,7 @@ XrInstance FindInstanceFromDispatchTable(XrGeneratedDispatchTable *dispatch_tabl
 }
 
 // Function to record all the API dump information
-bool ApiDumpLayerRecordContent(std::vector<std::tuple<std::string, std::string, std::string>> contents) {
+bool ApiDumpLayerRecordContent(std::vector<Argument> contents) {
     bool success = false;
     if (g_record_info.initialized) {
         std::unique_lock<std::mutex> mlock(g_record_mutex);
@@ -248,17 +248,12 @@ bool ApiDumpLayerRecordContent(std::vector<std::tuple<std::string, std::string, 
 #define ALOGI(...) printf(__VA_ARGS__)
 #endif
                 for (const auto &content : contents) {
-                    std::string content_type;
-                    std::string content_name;
-                    std::string content_value;
-                    std::tie(content_type, content_name, content_value) = content;
-
                     const char *indent = (count++ != 0) ? "    " : "";
 
-                    if (!content_value.empty()) {
-                        ALOGI("%s%s %s = %s", indent, content_type.c_str(), content_name.c_str(), content_value.c_str());
+                    if (!content.value.empty()) {
+                        ALOGI("%s%s %s = %s", indent, content.type.c_str(), content.name.c_str(), content.value.c_str());
                     } else {
-                        ALOGI("%s%s %s", indent, content_type.c_str(), content_name.c_str());
+                        ALOGI("%s%s %s", indent, content.type.c_str(), content.name.c_str());
                     }
                 }
                 success = true;
@@ -269,17 +264,13 @@ bool ApiDumpLayerRecordContent(std::vector<std::tuple<std::string, std::string, 
                 std::ofstream text_file;
                 text_file.open(g_record_info.file_name, std::ios::out | std::ios::app);
                 for (const auto &content : contents) {
-                    std::string content_type;
-                    std::string content_name;
-                    std::string content_value;
-                    std::tie(content_type, content_name, content_value) = content;
                     if (count++ != 0) {
                         text_file << "    ";
                     }
-                    if (!content_value.empty()) {
-                        text_file << content_type << " " << content_name << " = " << content_value << "\n";
+                    if (!content.value.empty()) {
+                        text_file << content.type << " " << content.name << " = " << content.value << "\n";
                     } else {
-                        text_file << content_type << " " << content_name << "\n";
+                        text_file << content.type << " " << content.name << "\n";
                     }
                 }
                 text_file.close();
@@ -293,51 +284,45 @@ bool ApiDumpLayerRecordContent(std::vector<std::tuple<std::string, std::string, 
                 std::vector<std::string> prefixes;
                 uint32_t last_deref_count = 0;
                 for (uint32_t content_index = 0; content_index < contents.size(); ++content_index) {
-                    std::string content_type;
-                    std::string content_name;
-                    std::string content_value;
-                    std::tie(content_type, content_name, content_value) = contents[content_index];
+                    const auto &content = contents[content_index];
                     if (content_index == 0) {
                         text_file << "   <summary>\n"
-                                  << "      <div class='headertype'>" << content_type << "</div>\n"
-                                  << "      <div class='headervar'>" << content_name << "</div>\n"
+                                  << "      <div class='headertype'>" << content.type << "</div>\n"
+                                  << "      <div class='headervar'>" << content.name << "</div>\n"
                                   << "   </summary>\n";
                     } else {
                         uint32_t cur_deref_count = 0;
                         uint32_t next_deref_count = 0;
 
                         // Count number of structure and pointer dereferences for the current line
-                        cur_deref_count = static_cast<uint32_t>(std::count(content_name.begin(), content_name.end(), '.'));
+                        cur_deref_count = static_cast<uint32_t>(std::count(content.name.begin(), content.name.end(), '.'));
                         std::string::size_type start = 0;
-                        while ((start = content_name.find("->", start)) != std::string::npos) {
+                        while ((start = content.name.find("->", start)) != std::string::npos) {
                             ++cur_deref_count;
                             start += 2;
                         }
                         // Now look for array dereferences
                         start = 0;
-                        while ((start = content_name.find('[', start)) != std::string::npos) {
+                        while ((start = content.name.find('[', start)) != std::string::npos) {
                             ++cur_deref_count;
                             start++;
                         }
 
                         // If there's something after this, see if it's a sub-component of this.
                         if (content_index < contents.size() - 1) {
-                            std::string next_content_type;
-                            std::string next_content_name;
-                            std::string next_content_value;
-                            std::tie(next_content_type, next_content_name, next_content_value) = contents[content_index + 1];
+                            const auto &next_content = contents[content_index + 1];
 
                             // Count number of structure and pointer dereferences for the next line
                             next_deref_count =
-                                static_cast<uint32_t>(std::count(next_content_name.begin(), next_content_name.end(), '.'));
+                                static_cast<uint32_t>(std::count(next_content.name.begin(), next_content.name.end(), '.'));
                             start = 0;
-                            while ((start = next_content_name.find("->", start)) != std::string::npos) {
+                            while ((start = next_content.name.find("->", start)) != std::string::npos) {
                                 ++next_deref_count;
                                 start += 2;
                             }
                             // Now look for array dereferences
                             start = 0;
-                            while ((start = next_content_name.find('[', start)) != std::string::npos) {
+                            while ((start = next_content.name.find('[', start)) != std::string::npos) {
                                 ++next_deref_count;
                                 start++;
                             }
@@ -355,17 +340,17 @@ bool ApiDumpLayerRecordContent(std::vector<std::tuple<std::string, std::string, 
 
                         // Look through any prefixes we've saved (going backwards through the list)
                         // and find the one that matches our beginning.
-                        std::string short_name = content_name;
+                        std::string short_name = content.name;
                         if (cur_deref_count > 0) {
                             for (auto it = prefixes.rbegin(); it != prefixes.rend(); ++it) {
-                                if (content_name.find(*it) == 0) {
+                                if (content.name.find(*it) == 0) {
                                     std::string::size_type additional_offset = it->size() + 1;
-                                    if (content_name[additional_offset - 1] == '-') {
+                                    if (content.name[additional_offset - 1] == '-') {
                                         additional_offset++;
-                                    } else if (content_name[additional_offset - 1] == '[') {
+                                    } else if (content.name[additional_offset - 1] == '[') {
                                         additional_offset--;
                                     }
-                                    short_name = content_name.substr(additional_offset);
+                                    short_name = content.name.substr(additional_offset);
                                     break;
                                 }
                             }
@@ -379,25 +364,25 @@ bool ApiDumpLayerRecordContent(std::vector<std::tuple<std::string, std::string, 
                             text_file << "   <details class='data'>\n"
                                       << "      <summary>\n";
                             writing_summary = true;
-                            prefixes.push_back(content_name);
+                            prefixes.push_back(content.name);
                         } else {
                             text_file << "      <div class='data'>\n";
                         }
 
                         // Write out the content
-                        text_file << "         <div class='type'>" << content_type << "</div>\n"
+                        text_file << "         <div class='type'>" << content.type << "</div>\n"
                                   << "         <div class='var'>" << short_name << "</div>\n";
                         bool value_needs_printing = true;
-                        if (content_type.find("char") != std::string::npos) {
-                            uint64_t star_count = std::count(content_type.begin(), content_type.end(), '*');
-                            uint64_t bracket_count = std::count(content_type.begin(), content_type.end(), '[');
+                        if (content.type.find("char") != std::string::npos) {
+                            uint64_t star_count = std::count(content.type.begin(), content.type.end(), '*');
+                            uint64_t bracket_count = std::count(content.type.begin(), content.type.end(), '[');
                             if (star_count + bracket_count < 2) {
-                                text_file << "         <div class='val'>\"" << content_value << "\"</div>";
+                                text_file << "         <div class='val'>\"" << content.value << "\"</div>";
                                 value_needs_printing = false;
                             }
                         }
-                        if (!content_value.empty() && value_needs_printing) {
-                            text_file << "         <div class='val'>" << content_value << "</div>";
+                        if (!content.value.empty() && value_needs_printing) {
+                            text_file << "         <div class='val'>" << content.value << "</div>";
                         }
                         text_file << "\n";
 
@@ -442,11 +427,12 @@ XRAPI_ATTR XrResult XRAPI_CALL ApiDumpLayerXrGetInstanceProcAddr(XrInstance inst
                                                                  PFN_xrVoidFunction *function) {
     try {
         // Generate output for this command
-        std::vector<std::tuple<std::string, std::string, std::string>> contents;
-        contents.emplace_back("XrResult", "xrGetInstanceProcAddr", "");
-        contents.emplace_back("XrInstance", "instance", HandleToHexString(instance));
-        contents.emplace_back("const char*", "name", name);
-        contents.emplace_back("PFN_xrVoidFunction*", "function", PointerToHexString(reinterpret_cast<const void *>(function)));
+        std::vector<Argument> contents;
+        contents.emplace_back(Argument{"XrResult", "xrGetInstanceProcAddr", ""});
+        contents.emplace_back(Argument{"XrInstance", "instance", HandleToHexString(instance)});
+        contents.emplace_back(Argument{"const char*", "name", name});
+        contents.emplace_back(
+            Argument{"PFN_xrVoidFunction*", "function", PointerToHexString(reinterpret_cast<const void *>(function))});
         ApiDumpLayerRecordContent(contents);
 
         *function = ApiDumpLayerInnerGetInstanceProcAddr(name);
@@ -575,12 +561,12 @@ XRAPI_ATTR XrResult XRAPI_CALL ApiDumpLayerXrCreateApiLayerInstance(const XrInst
         }
 
         // Generate output for this command as if it were the standard xrCreateInstance
-        std::vector<std::tuple<std::string, std::string, std::string>> contents;
-        contents.emplace_back("XrResult", "xrCreateInstance", "");
-        contents.emplace_back("const XrInstanceCreateInfo*", "info", PointerToHexString(info));
+        std::vector<Argument> contents;
+        contents.emplace_back(Argument{"XrResult", "xrCreateInstance", ""});
+        contents.emplace_back(Argument{"const XrInstanceCreateInfo*", "info", PointerToHexString(info)});
         if (nullptr != info) {
             std::string info_prefix = "info->";
-            contents.emplace_back("XrStructureType", "info->type", std::to_string(info->type));
+            contents.emplace_back(Argument{"XrStructureType", "info->type", std::to_string(info->type)});
             std::string next_prefix = info_prefix;
             next_prefix += "next";
             // Decode the next chain if it exists
@@ -589,7 +575,7 @@ XRAPI_ATTR XrResult XRAPI_CALL ApiDumpLayerXrCreateApiLayerInstance(const XrInst
             }
             std::string flags_prefix = info_prefix;
             flags_prefix += "createFlags";
-            contents.emplace_back("XrInstanceCreateFlags", flags_prefix, std::to_string(info->createFlags));
+            contents.emplace_back(Argument{"XrInstanceCreateFlags", flags_prefix, std::to_string(info->createFlags)});
             std::string applicationinfo_prefix = info_prefix;
             applicationinfo_prefix += "applicationInfo";
             if (!ApiDumpOutputXrStruct(nullptr, &info->applicationInfo, applicationinfo_prefix, "XrApplicationInfo", true,
@@ -600,33 +586,35 @@ XRAPI_ATTR XrResult XRAPI_CALL ApiDumpLayerXrCreateApiLayerInstance(const XrInst
             enabledapilayercount_prefix += "enabledApiLayerCount";
             std::ostringstream oss_enabledApiLayerCount;
             oss_enabledApiLayerCount << "0x" << std::hex << (info->enabledApiLayerCount);
-            contents.emplace_back("uint32_t", enabledapilayercount_prefix, oss_enabledApiLayerCount.str());
+            contents.emplace_back(Argument{"uint32_t", enabledapilayercount_prefix, oss_enabledApiLayerCount.str()});
             std::string enabledapilayernames_prefix = info_prefix;
             enabledapilayernames_prefix += "enabledApiLayerNames";
             std::ostringstream oss_enabledApiLayerNames_array;
             oss_enabledApiLayerNames_array << "0x" << std::hex << (info->enabledApiLayerNames);
-            contents.emplace_back("const char* const*", enabledapilayernames_prefix, oss_enabledApiLayerNames_array.str());
+            contents.emplace_back(
+                Argument{"const char* const*", enabledapilayernames_prefix, oss_enabledApiLayerNames_array.str()});
             for (uint32_t i = 0; i < info->enabledApiLayerCount; ++i) {
                 std::string prefix = enabledapilayernames_prefix + "[" + std::to_string(i) + "]";
-                contents.emplace_back("const char* const*", prefix, info->enabledApiLayerNames[i]);
+                contents.emplace_back(Argument{"const char* const*", prefix, info->enabledApiLayerNames[i]});
             }
             std::string enabledextensioncount_prefix = info_prefix;
             enabledextensioncount_prefix += "enabledExtensionCount";
             std::ostringstream oss_enabledExtensionCount;
             oss_enabledExtensionCount << "0x" << std::hex << (info->enabledExtensionCount);
-            contents.emplace_back("uint32_t", enabledextensioncount_prefix, oss_enabledExtensionCount.str());
+            contents.emplace_back(Argument{"uint32_t", enabledextensioncount_prefix, oss_enabledExtensionCount.str()});
             std::string enabledextensionnames_prefix = info_prefix;
             enabledextensionnames_prefix += "enabledExtensionNames";
             std::ostringstream oss_enabledExtensionNames_array;
             oss_enabledExtensionNames_array << "0x" << std::hex << (info->enabledExtensionNames);
-            contents.emplace_back("const char* const*", enabledextensionnames_prefix, oss_enabledExtensionNames_array.str());
+            contents.emplace_back(
+                Argument{"const char* const*", enabledextensionnames_prefix, oss_enabledExtensionNames_array.str()});
             for (uint32_t ii = 0; ii < info->enabledExtensionCount; ++ii) {
                 std::string prefix = enabledextensionnames_prefix + "[" + std::to_string(ii) + "]";
-                contents.emplace_back("const char* const*", prefix, info->enabledExtensionNames[ii]);
+                contents.emplace_back(Argument{"const char* const*", prefix, info->enabledExtensionNames[ii]});
             }
         }
 
-        contents.emplace_back("XrInstance*", "instance", PointerToHexString(instance));
+        contents.emplace_back(Argument{"XrInstance*", "instance", PointerToHexString(instance)});
         ApiDumpLayerRecordContent(contents);
 
         // Copy the contents of the layer info struct, but then move the next info up by
@@ -662,9 +650,9 @@ XRAPI_ATTR XrResult XRAPI_CALL ApiDumpLayerXrCreateApiLayerInstance(const XrInst
 
 XRAPI_ATTR XrResult XRAPI_CALL ApiDumpLayerXrDestroyInstance(XrInstance instance) {
     // Generate output for this command
-    std::vector<std::tuple<std::string, std::string, std::string>> contents;
-    contents.emplace_back("XrResult", "xrDestroyInstance", "");
-    contents.emplace_back("XrInstance", "instance", HandleToHexString(instance));
+    std::vector<Argument> contents;
+    contents.emplace_back(Argument{"XrResult", "xrDestroyInstance", ""});
+    contents.emplace_back(Argument{"XrInstance", "instance", HandleToHexString(instance)});
     ApiDumpLayerRecordContent(contents);
 
     XrGeneratedDispatchTable *next_dispatch = nullptr;

--- a/src/api_layers/api_dump.cpp
+++ b/src/api_layers/api_dump.cpp
@@ -169,7 +169,7 @@ bool ApiDumpLayerWriteHtmlHeader() {
                      "            display: inline;\n"
                      "            margin: 0 9px;\n"
                      "        }\n"
-                     "        .var, .type, .val {\n"
+                     "        .var, .type, .val, .decoded{\n"
                      "            display: inline;\n"
                      "            margin: 0 6px;\n"
                      "        }\n"
@@ -251,7 +251,12 @@ bool ApiDumpLayerRecordContent(std::vector<Argument> contents) {
                     const char *indent = (count++ != 0) ? "    " : "";
 
                     if (!content.value.empty()) {
-                        ALOGI("%s%s %s = %s", indent, content.type.c_str(), content.name.c_str(), content.value.c_str());
+                        if (!content.decoded.empty()) {
+                            ALOGI("%s%s %s = %s (%s)", indent, content.type.c_str(), content.name.c_str(), content.value.c_str(),
+                                  content.decoded.c_str());
+                        } else {
+                            ALOGI("%s%s %s = %s", indent, content.type.c_str(), content.name.c_str(), content.value.c_str());
+                        }
                     } else {
                         ALOGI("%s%s %s", indent, content.type.c_str(), content.name.c_str());
                     }
@@ -267,11 +272,14 @@ bool ApiDumpLayerRecordContent(std::vector<Argument> contents) {
                     if (count++ != 0) {
                         text_file << "    ";
                     }
+                    text_file << content.type << " " << content.name;
                     if (!content.value.empty()) {
-                        text_file << content.type << " " << content.name << " = " << content.value << "\n";
-                    } else {
-                        text_file << content.type << " " << content.name << "\n";
+                        text_file << " = " << content.value;
+                        if (!content.decoded.empty()) {
+                            text_file << " (" << content.decoded << ")";
+                        }
                     }
+                    text_file << "\n";
                 }
                 text_file.close();
                 success = true;
@@ -385,6 +393,9 @@ bool ApiDumpLayerRecordContent(std::vector<Argument> contents) {
                             text_file << "         <div class='val'>" << content.value << "</div>";
                         }
                         text_file << "\n";
+                        if (!content.decoded.empty()) {
+                            text_file << "         <div class='decoded'>" << content.decoded << "</div>\n";
+                        }
 
                         // Wrap up any summary we may have started.  Otherwise, just wrap up the
                         // <div> marker wrapping this entry.

--- a/src/scripts/api_dump_generator.py
+++ b/src/scripts/api_dump_generator.py
@@ -77,10 +77,14 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
             preamble += '#include <openxr/openxr_platform.h>\n\n'
             preamble += '#include <mutex>\n'
             preamble += '#include <string>\n'
-            preamble += '#include <tuple>\n'
             preamble += '#include <unordered_map>\n'
             preamble += '#include <vector>\n\n'
             preamble += 'struct XrGeneratedDispatchTable;\n\n'
+            preamble += 'struct Argument {\n'
+            preamble += '    std::string type;\n'
+            preamble += '    std::string name;\n'
+            preamble += '    std::string value;\n'
+            preamble += '};\n\n'
         elif self.genOpts.filename == 'xr_generated_api_dump.cpp':
             preamble += '#include "xr_generated_api_dump.hpp"\n'
             preamble += '#include "xr_generated_dispatch_table.h"\n'
@@ -138,7 +142,7 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
         generated_prototypes += '// Api Dump Inner inner xrGetInstanceProcAddr helper\n'
         generated_prototypes += 'PFN_xrVoidFunction ApiDumpLayerInnerGetInstanceProcAddr(const char* name);\n\n'
         generated_prototypes += '// Api Dump Log Command\n'
-        generated_prototypes += 'bool ApiDumpLayerRecordContent(std::vector<std::tuple<std::string, std::string, std::string>> contents);\n\n'
+        generated_prototypes += 'bool ApiDumpLayerRecordContent(std::vector<Argument> contents);\n\n'
         generated_prototypes += '// Api Dump Manual Functions\n'
         generated_prototypes += 'XrInstance FindInstanceFromDispatchTable(XrGeneratedDispatchTable* dispatch_table);\n'
         generated_prototypes += 'XRAPI_ATTR XrResult XRAPI_CALL ApiDumpLayerXrCreateInstance(const XrInstanceCreateInfo *info,\n'
@@ -146,14 +150,14 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
         generated_prototypes += 'XRAPI_ATTR XrResult XRAPI_CALL ApiDumpLayerXrDestroyInstance(XrInstance instance);\n'
         generated_prototypes += '\n//Dump utility functions\n'
         generated_prototypes += 'bool ApiDumpDecodeNextChain(XrGeneratedDispatchTable* gen_dispatch_table, const void* value, std::string prefix,\n'
-        generated_prototypes += '                            std::vector<std::tuple<std::string, std::string, std::string>> &contents);\n'
+        generated_prototypes += '                            std::vector<Argument> &contents);\n'
         generated_prototypes += '\n// Union/Structure Output Helper function prototypes\n'
         for xr_union in self.api_unions:
             if xr_union.protect_value:
                 generated_prototypes += f'#if {xr_union.protect_string}\n'
             generated_prototypes += f'bool ApiDumpOutputXrUnion(XrGeneratedDispatchTable* gen_dispatch_table, const {xr_union.name}* value,\n'
             generated_prototypes += '                          std::string prefix, std::string type_string, bool is_pointer,\n'
-            generated_prototypes += '                          std::vector<std::tuple<std::string, std::string, std::string>> &contents);\n'
+            generated_prototypes += '                          std::vector<Argument> &contents);\n'
             if xr_union.protect_value:
                 generated_prototypes += f'#endif // {xr_union.protect_string}\n'
         for xr_struct in self.api_structures:
@@ -164,7 +168,7 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
                 generated_prototypes += f'#if {xr_struct.protect_string}\n'
             generated_prototypes += f'bool ApiDumpOutputXrStruct(XrGeneratedDispatchTable* gen_dispatch_table, const {xr_struct.name}* value,\n'
             generated_prototypes += '                           std::string prefix, std::string type_string, bool is_pointer,\n'
-            generated_prototypes += '                           std::vector<std::tuple<std::string, std::string, std::string>> &contents);\n'
+            generated_prototypes += '                           std::vector<Argument> &contents);\n'
             if xr_struct.protect_value:
                 generated_prototypes += f'#endif // {xr_struct.protect_string}\n'
         return generated_prototypes
@@ -387,8 +391,8 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
             write_string += self.writeIndent(indent)
             write_string += f'oss_{short_pname} << std::nouppercase;\n'
             write_string += self.writeIndent(indent)
-            write_string += f'contents.emplace_back("{full_type}", {description}'
-            write_string += f', oss_{short_pname}.str());\n'
+            write_string += f'contents.emplace_back(Argument{{"{full_type}", {description}'
+            write_string += f', oss_{short_pname}.str()}});\n'
             indent = indent - 1
             write_string += self.writeIndent(indent)
             write_string += '}\n'
@@ -409,8 +413,8 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
             write_string += self.writeIndent(indent)
             write_string += f'oss_{short_pname} << std::nouppercase;\n'
             write_string += self.writeIndent(indent)
-            write_string += f'contents.emplace_back("{full_type}", {description}'
-            write_string += f', oss_{short_pname}.str());\n'
+            write_string += f'contents.emplace_back(Argument{{"{full_type}", {description}'
+            write_string += f', oss_{short_pname}.str()}});\n'
             indent = indent - 1
             write_string += self.writeIndent(indent)
             write_string += '}\n'
@@ -425,8 +429,8 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
                 write_string += '*' * pointer_count
             write_string += f'{full_name}).QuadPart );\n'
             write_string += self.writeIndent(indent)
-            write_string += f'contents.emplace_back("{full_type}", {description}'
-            write_string += f', oss_{short_pname}.str());\n'
+            write_string += f'contents.emplace_back(Argument{{"{full_type}", {description}'
+            write_string += f', oss_{short_pname}.str()}});\n'
         elif base_type == 'timespec':
             # Unbeknownst to XR, this is actually a struct.
             write_string += self.writeIndent(indent)
@@ -446,8 +450,8 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
             write_string += f'{full_name}).tv_nsec << "s";\n'
 
             write_string += self.writeIndent(indent)
-            write_string += f'contents.emplace_back("{full_type}", {description}'
-            write_string += f', oss_{short_pname}.str());\n'
+            write_string += f'contents.emplace_back(Argument{{"{full_type}", {description}'
+            write_string += f', oss_{short_pname}.str()}});\n'
         else:
             need_brace = False
             if full_type == 'XrPath':
@@ -455,7 +459,7 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
                 write_string += f'if ({full_name} == XR_NULL_PATH) {{\n'
                 indent = indent + 1
                 write_string += self.writeIndent(indent)
-                write_string += f'contents.emplace_back("{full_type}", {description}, "XR_NULL_PATH");\n'
+                write_string += f'contents.emplace_back(Argument{{"{full_type}", {description}, "XR_NULL_PATH"}});\n'
                 write_string += self.writeIndent(indent - 1)
                 write_string += '} else if (nullptr != gen_dispatch_table) {\n'
                 write_string += self.writeIndent(indent)
@@ -471,7 +475,7 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
                 write_string += self.writeIndent(indent)
                 write_string += f'                                 {full_name}, out_size, &out_size, {short_pname}_string.data());\n'
                 write_string += self.writeIndent(indent)
-                write_string += f'contents.emplace_back("{full_type}", {description}, {short_pname}_string);\n'
+                write_string += f'contents.emplace_back(Argument{{"{full_type}", {description}, {short_pname}_string}});\n'
                 write_string += self.writeIndent(indent - 1)
                 write_string += '} else {\n'
                 need_brace = True
@@ -486,7 +490,7 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
                 write_string += self.writeIndent(indent)
                 write_string += f'                                   {full_name}, {short_pname}_string);\n'
                 write_string += self.writeIndent(indent)
-                write_string += f'contents.emplace_back("{full_type}", {description}, {short_pname}_string);\n'
+                write_string += f'contents.emplace_back(Argument{{"{full_type}", {description}, {short_pname}_string}});\n'
                 write_string += self.writeIndent(indent - 1)
                 write_string += '} else {\n'
                 need_brace = True
@@ -501,7 +505,7 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
                 write_string += self.writeIndent(indent)
                 write_string += f'                                          {full_name}, {short_pname}_string);\n'
                 write_string += self.writeIndent(indent)
-                write_string += f'contents.emplace_back("{full_type}", {description}, {short_pname}_string);\n'
+                write_string += f'contents.emplace_back(Argument{{"{full_type}", {description}, {short_pname}_string}});\n'
                 write_string += self.writeIndent(indent - 1)
                 write_string += '} else {\n'
                 need_brace = True
@@ -536,12 +540,12 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
                     write_string += '*' * pointer_count
                 write_string += f'{full_name});\n'
                 write_string += self.writeIndent(indent)
-                write_string += f'contents.emplace_back("{full_type}", {description}'
-                write_string += f', oss_{short_pname}.str());\n'
+                write_string += f'contents.emplace_back(Argument{{"{full_type}", {description}'
+                write_string += f', oss_{short_pname}.str()}});\n'
 
             else:
                 write_string += self.writeIndent(indent)
-                write_string += f'contents.emplace_back("{full_type}", {description}, '
+                write_string += f'contents.emplace_back(Argument{{"{full_type}", {description}, '
                 if not is_char:
                     write_string += 'std::to_string('
                 if can_dereference:
@@ -556,7 +560,7 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
                 # Close std::to_string
                 if not is_char:
                     write_string += ')'
-                write_string += ');\n'
+                write_string += '});\n'
 
             if need_brace:
                 indent = indent - 1
@@ -901,13 +905,13 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
                 struct_union_check += f'#if {xr_union.protect_string}\n'
             struct_union_check += f'bool ApiDumpOutputXrUnion(XrGeneratedDispatchTable* gen_dispatch_table, const {xr_union.name}* value,\n'
             struct_union_check += '                          std::string prefix, std::string type_string, bool is_pointer,\n'
-            struct_union_check += '                          std::vector<std::tuple<std::string, std::string, std::string>> &contents) {\n'
+            struct_union_check += '                          std::vector<Argument> &contents) {\n'
             struct_union_check += self.writeIndent(1)
             struct_union_check += '(void)gen_dispatch_table;  // silence warning\n'
             struct_union_check += self.writeIndent(1)
             struct_union_check += 'try {\n'
             struct_union_check += self.writeIndent(2)
-            struct_union_check += 'contents.emplace_back(type_string, prefix, PointerToHexString(value));\n'
+            struct_union_check += 'contents.emplace_back(Argument{type_string, prefix, PointerToHexString(value)});\n'
             struct_union_check += self.writeIndent(2)
             struct_union_check += 'if (is_pointer) {\n'
             struct_union_check += self.writeIndent(3)
@@ -938,7 +942,7 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
                 struct_union_check += f'#if {xr_struct.protect_string}\n'
             struct_union_check += f'bool ApiDumpOutputXrStruct(XrGeneratedDispatchTable* gen_dispatch_table, const {xr_struct.name}* value,\n'
             struct_union_check += '                           std::string prefix, std::string type_string, bool is_pointer,\n'
-            struct_union_check += '                           std::vector<std::tuple<std::string, std::string, std::string>> &contents) {\n'
+            struct_union_check += '                           std::vector<Argument> &contents) {\n'
             indent = 1
             struct_union_check += self.writeIndent(indent)
             struct_union_check += '(void)gen_dispatch_table;  // silence warning\n'
@@ -970,7 +974,7 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
                 struct_union_check += self.writeIndent(indent)
                 struct_union_check += '// Fallback path - Just output generic information about the base struct\n'
             struct_union_check += self.writeIndent(indent)
-            struct_union_check += 'contents.emplace_back(type_string, prefix, PointerToHexString(value));\n'
+            struct_union_check += 'contents.emplace_back(Argument{type_string, prefix, PointerToHexString(value)});\n'
             struct_union_check += self.writeIndent(indent)
             struct_union_check += 'if (is_pointer) {\n'
             struct_union_check += self.writeIndent(indent + 1)
@@ -997,11 +1001,11 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
                 struct_union_check += f'#endif // {xr_struct.protect_string}\n'
             struct_union_check += '\n'
         struct_union_check += 'bool ApiDumpDecodeNextChain(XrGeneratedDispatchTable* gen_dispatch_table, const void* value, std::string prefix,\n'
-        struct_union_check += '                            std::vector<std::tuple<std::string, std::string, std::string>> &contents) {\n'
+        struct_union_check += '                            std::vector<Argument> &contents) {\n'
         struct_union_check += self.writeIndent(1)
         struct_union_check += '(void)gen_dispatch_table;  // silence warning\n'
         struct_union_check += '    try {\n'
-        struct_union_check += '        contents.emplace_back("const void *", prefix, PointerToHexString(value));\n'
+        struct_union_check += '        contents.emplace_back(Argument{"const void *", prefix, PointerToHexString(value)});\n'
         struct_union_check += '        if (nullptr == value) {\n'
         struct_union_check += '            return true;\n'
         struct_union_check += '        }\n'
@@ -1143,7 +1147,7 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
 
                 generated_commands += '    try {\n'
                 generated_commands += '        // Generate output for this command\n'
-                generated_commands += '        std::vector<std::tuple<std::string, std::string, std::string>> contents;\n'
+                generated_commands += '        std::vector<Argument> contents;\n'
 
                 # Next, we have to call down to the next implementation of this command in the call chain.
                 # Before we can do that, we have to figure out what the dispatch table is
@@ -1166,10 +1170,10 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
 
                 # Print out a tuple for the header
                 if has_return:
-                    generated_commands += '        contents.emplace_back("%s", "%s", "");\n' % (
+                    generated_commands += '        contents.emplace_back(Argument{"%s", "%s", ""});\n' % (
                         cur_cmd.return_type.text, cur_cmd.name)
                 else:
-                    generated_commands += f'        contents.emplace_back("void", "{cur_cmd.name}", "");\n'
+                    generated_commands += f'        contents.emplace_back(Argument{{"void", "{cur_cmd.name}", ""}});\n'
                 # Print out information for each parameter
                 for param in cur_cmd.params:
                     can_expand = False

--- a/src/scripts/api_dump_generator.py
+++ b/src/scripts/api_dump_generator.py
@@ -449,7 +449,33 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
             write_string += f'contents.emplace_back("{full_type}", {description}'
             write_string += f', oss_{short_pname}.str());\n'
         else:
-            if base_type == 'XrResult':
+            need_brace = False
+            if full_type == 'XrPath':
+                write_string += self.writeIndent(indent)
+                write_string += f'if ({full_name} == XR_NULL_PATH) {{\n'
+                indent = indent + 1
+                write_string += self.writeIndent(indent)
+                write_string += f'contents.emplace_back("{full_type}", {description}, "XR_NULL_PATH");\n'
+                write_string += self.writeIndent(indent - 1)
+                write_string += '} else if (nullptr != gen_dispatch_table) {\n'
+                write_string += self.writeIndent(indent)
+                write_string += 'uint32_t out_size = 0;\n'
+                write_string += self.writeIndent(indent)
+                write_string += 'gen_dispatch_table->PathToString(FindInstanceFromDispatchTable(gen_dispatch_table),\n'
+                write_string += self.writeIndent(indent)
+                write_string += f'                                 {full_name}, 0, &out_size, nullptr);\n'
+                write_string += self.writeIndent(indent)
+                write_string += f'std::string {short_pname}_string(out_size > 0 ? out_size - 1 : 0, \'\\0\');\n'
+                write_string += self.writeIndent(indent)
+                write_string += 'gen_dispatch_table->PathToString(FindInstanceFromDispatchTable(gen_dispatch_table),\n'
+                write_string += self.writeIndent(indent)
+                write_string += f'                                 {full_name}, out_size, &out_size, {short_pname}_string.data());\n'
+                write_string += self.writeIndent(indent)
+                write_string += f'contents.emplace_back("{full_type}", {description}, {short_pname}_string);\n'
+                write_string += self.writeIndent(indent - 1)
+                write_string += '} else {\n'
+                need_brace = True
+            elif base_type == 'XrResult':
                 write_string += self.writeIndent(indent)
                 write_string += 'if (nullptr != gen_dispatch_table) {\n'
                 indent = indent + 1
@@ -463,7 +489,7 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
                 write_string += f'contents.emplace_back("{full_type}", {description}, {short_pname}_string);\n'
                 write_string += self.writeIndent(indent - 1)
                 write_string += '} else {\n'
-                write_string += self.writeIndent(indent)
+                need_brace = True
             elif base_type == 'XrStructureType':
                 write_string += self.writeIndent(indent)
                 write_string += 'if (nullptr != gen_dispatch_table) {\n'
@@ -478,7 +504,7 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
                 write_string += f'contents.emplace_back("{full_type}", {description}, {short_pname}_string);\n'
                 write_string += self.writeIndent(indent - 1)
                 write_string += '} else {\n'
-                write_string += self.writeIndent(indent)
+                need_brace = True
 
             # If we're outputting using a string stream, determine the type of information
             # we're generating and format it appropriately.
@@ -532,7 +558,7 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
                     write_string += ')'
                 write_string += ');\n'
 
-            if base_type in ('XrResult', 'XrStructureType'):
+            if need_brace:
                 indent = indent - 1
                 write_string += self.writeIndent(indent)
                 write_string += '}\n'

--- a/src/scripts/api_dump_generator.py
+++ b/src/scripts/api_dump_generator.py
@@ -84,6 +84,7 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
             preamble += '    std::string type;\n'
             preamble += '    std::string name;\n'
             preamble += '    std::string value;\n'
+            preamble += '    std::string decoded; // human readable alternative to value\n'
             preamble += '};\n\n'
         elif self.genOpts.filename == 'xr_generated_api_dump.cpp':
             preamble += '#include "xr_generated_api_dump.hpp"\n'
@@ -475,7 +476,7 @@ class ApiDumpOutputGenerator(AutomaticSourceOutputGenerator):
                 write_string += self.writeIndent(indent)
                 write_string += f'                                 {full_name}, out_size, &out_size, {short_pname}_string.data());\n'
                 write_string += self.writeIndent(indent)
-                write_string += f'contents.emplace_back(Argument{{"{full_type}", {description}, {short_pname}_string}});\n'
+                write_string += f'contents.emplace_back(Argument{{"{full_type}", {description}, std::to_string({full_name}), {short_pname}_string}});\n'
                 write_string += self.writeIndent(indent - 1)
                 write_string += '} else {\n'
                 need_brace = True


### PR DESCRIPTION
The API dump shows numeric values of an XrPath, which are not convenient to track what is being called.

This change calls `xrPathToString` on each value and prints the result.
It appears that `PathToString` always returns XR_SUCCESS through the dispatch table, so I can't handle invalid paths correctly.

Sample new output:
```
XrResult xrSuggestInteractionProfileBindings
    XrInstance instance = 0x55d95352be10
    const XrInteractionProfileSuggestedBinding* suggestedBindings = 0x00007ffcda491fe0
    XrStructureType suggestedBindings->type = XR_TYPE_INTERACTION_PROFILE_SUGGESTED_BINDING
    const void * suggestedBindings->next = 0x0000000000000000
    XrPath suggestedBindings->interactionProfile = /interaction_profiles/bytedance/pico_neo3_controller
    uint32_t suggestedBindings->countSuggestedBindings = 0x44
    const XrActionSuggestedBinding* suggestedBindings->suggestedBindings = 0x55d9537aed50
    const XrActionSuggestedBinding* suggestedBindings->suggestedBindings[0] = 0x000055d9537aed50
    XrAction suggestedBindings->suggestedBindings[0].action = 0x55d95371a030
    XrPath suggestedBindings->suggestedBindings[0].binding = /user/hand/left/input/aim/pose
    const XrActionSuggestedBinding* suggestedBindings->suggestedBindings[1] = 0x000055d9537aed60
    XrAction suggestedBindings->suggestedBindings[1].action = 0x55d95371bd10
    XrPath suggestedBindings->suggestedBindings[1].binding = /user/hand/left/input/trigger/value
[...]
```